### PR TITLE
Do not force PATH in the installer 

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -21,9 +21,6 @@ fi
 echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[0m"
 cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
 
-echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
-echo "export PATH=$PATH" >> ~/.zshrc
-
 echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
 chsh -s `which zsh`
 


### PR DESCRIPTION
The installer forced PATH - this prevents PATH dynamically set by system, also forces any temporary user PATH that was set during installation to be recorded and used on every shell start.

It should be users conscious choice to manipulate PATH, a lot of users is not aware of this and do not even know if this good or not.

If users need to add something to PATH they should do it by adding it not overwriting system detected PATH:

```
PATH="$PATH:/user/custom/path"
```

or:

```
path+=( "/user/custom/path" )
```
