### PR TITLE
Disable globbing when executing `zeus rake`

### DIFF
--- a/plugins/zeus/zeus.plugin.zsh
+++ b/plugins/zeus/zeus.plugin.zsh
@@ -25,8 +25,8 @@ alias zsr='zeus server'
 alias zerver='zeus server'
 
 # Rake
-alias zr='zeus rake'
-alias zake='zeus rake'
+alias zr='noglob zeus rake'
+alias zake='noglob zeus rake'
 
 # Generate
 alias zg='zeus generate'


### PR DESCRIPTION
Enables easy use of the Zeus rake aliases with tasks that accept arguments via square brackets.