### PR TITLE
Updated ant plugin (using ant -p)

### DIFF
--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -7,7 +7,7 @@ _ant_does_target_list_need_generating () {
 _ant () {
   if [ -f build.xml ]; then
     if _ant_does_target_list_need_generating; then
-     sed -n '/<target/s/<target.*name="\([^"]*\).*$/\1/p' build.xml > .ant_targets
+     ant -p | grep \^" " | cut -f2 -d" " > .ant_targets
     fi
     compadd `cat .ant_targets`
   fi


### PR DESCRIPTION
Useful when build.xml references other build.xml files