### PR TITLE
check_for_upgrade.sh not executable with /bin/sh

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env zsh
 
 function _current_epoch() {
   echo $(($(date +%s) / 60 / 60 / 24))

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function _current_epoch() {
   echo $(($(date +%s) / 60 / 60 / 24))

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+
 if [ -d ~/.oh-my-zsh ]
 then
   echo "\033[0;33mYou already have Oh My Zsh installed.\033[0m You'll need to remove ~/.oh-my-zsh if you want to install"

--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Zsh Theme Chooser by fox (fox91 at anche dot no)
 # This program is free software. It comes without any warranty, to


### PR DESCRIPTION
check_for_upgrade.sh is not executable with /bin/sh while using bash syntax, so the execution shell should be set to /bin/bash.