### PR TITLE
rebind key for editor with edit-command-line

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -48,3 +48,6 @@ bindkey "\e[3~" delete-char
 ## Fix weird sequence that rxvt produces
 #bindkey -s '^[[Z' '\t'
 #
+
+# rebind key for editor with edit-command-line
+bindkey '\C-x\C-e' edit-command-line


### PR DESCRIPTION
because of the script `bindkey -e` at `lib/key-bindings.zsh`, the binding-key `\C-x\C-e` was disabled. So rebind the key `\C-x\C-e` at the last line. Thx for take this suggest!