### PR TITLE
Add .ipsw to the extract plugin.

### DIFF
--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -3,6 +3,6 @@
 
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
-  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|lzma|Z|zip|rar|7z|deb)(-.)'" && return 0
+  "*::archive file:_files -g '(#i)*.(tar|tgz|tbz|tbz2|txz|tlz|gz|bz2|xz|lzma|Z|zip|ipsw|rar|7z|deb)(-.)'" && return 0
 
 

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -23,7 +23,7 @@ function extract() {
 
   remove_archive=1
   if [[ "$1" == "-r" ]] || [[ "$1" == "--remove" ]]; then
-    remove_archive=0 
+    remove_archive=0
     shift
   fi
 
@@ -52,7 +52,7 @@ function extract() {
       (*.xz) unxz "$1" ;;
       (*.lzma) unlzma "$1" ;;
       (*.Z) uncompress "$1" ;;
-      (*.zip|*.war|*.jar|*.sublime-package) unzip "$1" -d $extract_dir ;;
+      (*.zip|*.war|*.jar|*.sublime-package|*.ipsw) unzip "$1" -d $extract_dir ;;
       (*.rar) unrar x -ad "$1" ;;
       (*.7z) 7za x "$1" ;;
       (*.deb)
@@ -64,10 +64,10 @@ function extract() {
         cd ..; rm *.tar.gz debian-binary
         cd ..
       ;;
-      (*) 
+      (*)
         echo "extract: '$1' cannot be extracted" 1>&2
-        success=1 
-      ;; 
+        success=1
+      ;;
     esac
 
     (( success = $success > 0 ? $success : $? ))


### PR DESCRIPTION
Prior to this commit, the extract plugin did not know what .ipsw file was.
This commit adds .ipsw files to the extract auto-completion list and extracts it with `unzip`.