### PR TITLE
Get the number of unstaged changes (lines) for Git

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -5,6 +5,15 @@ function git_prompt_info() {
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
+# Get the number of lines changed between the index and the working tree
+function git_changes_info() {
+  changes=$(command git diff --numstat 2>/dev/null) || return
+  if [[ -z "$changes" ]]; then
+    return
+  fi
+  changes=$(echo $changes | awk 'NF==3 {plus+=$1; minus+=$2} END {printf("+%d/-%d", plus, minus)}')
+  echo "$ZSH_THEME_GIT_CHANGES_PREFIX${changes}$ZSH_THEME_GIT_CHANGES_SUFFIX"
+}
 
 # Checks if working tree is dirty
 parse_git_dirty() {


### PR DESCRIPTION
This function provides a way to display the number of unstaged changes when the working directory is part of a Git project (e.g. `+12/-3`). If there is no such unstage change, nothing is printed.

One just needs to add `$(git_changes_info)` in a theme, and `ZSH_THEME_GIT_CHANGES_PREFIX/SUFFIX` can be used to modify the display.

This is an idea I got from nojhan's [liquidprompt](https://github.com/nojhan/liquidprompt).
