### PR TITLE
Add submodule helpers to Git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -159,4 +159,10 @@ alias gunignore='git update-index --no-assume-unchanged'
 alias gignored='git ls-files -v | grep "^[[:lower:]]"'
 
 
-
+# Submodules
+alias gf='git fetch'
+compdef _git gf=git-fetch
+alias gsi='git submodule init'
+compdef gsi=git-submodule
+alias gsu='git submodule update'
+compdef gsu=git-submodule


### PR DESCRIPTION
From #1116 but I don't see any PR for it and nothing in the current version of OMZ.