### PR TITLE
[plugin][web-search] fix + changes

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -13,21 +13,18 @@ function web_search() {
   local url="http://$1"
 
   # no keyword provided, simply open the search engine homepage
-  if [[ $# -le 2 ]]; then
-    $open_cmd "$url" &> /dev/null
-    return
+  if [[ ! $# -le 2 ]]; then
+    url="${url}/$2"
+
+    shift 2  # shift out $1 and $2
+
+    while [[ $# -gt 0 ]]; do
+      url="${url}$1+"
+      shift
+    done
+
+    url="${url%?}" # remove the last '+'
   fi
-
-  url="${url}/$2"
-
-  shift 2  # shift out $1 and $2
-
-  while [[ $# -gt 0 ]]; do
-    url="${url}$1+"
-    shift
-  done
-
-  url="${url%?}" # remove the last '+'
 
   $open_cmd "$url" &> /dev/null
 }

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -35,3 +35,4 @@ function web_search() {
 alias bing='web_search www.bing.com search\?q='
 alias google='web_search www.google.com search\?q='
 alias yahoo='web_search www.yahoo.com search\?q='
+alias ddg="web_search www.duckduckgo.com \?q="

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -21,7 +21,7 @@ function web_search() {
 
   # no keyword provided, simply open the search engine homepage
   if [[ $# -le 1 ]]; then
-    $open_cmd "$url"
+    $open_cmd "$url" &> /dev/null
     return
   fi
 
@@ -35,7 +35,7 @@ function web_search() {
 
   url="${url%?}" # remove the last '+'
 
-  $open_cmd "$url"
+  $open_cmd "$url" &> /dev/null
 }
 
 alias bing='web_search bing'

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -10,23 +10,17 @@ function web_search() {
     open_cmd='xdg-open'
   fi
 
-  # check whether the search engine is supported
-  if [[ ! $1 =~ '(google|bing|yahoo)' ]];
-  then
-    echo "Search engine $1 not supported."
-    return 1
-  fi
-
-  local url="http://www.$1.com"
+  local url="http://$1"
 
   # no keyword provided, simply open the search engine homepage
-  if [[ $# -le 1 ]]; then
+  if [[ $# -le 2 ]]; then
     $open_cmd "$url" &> /dev/null
     return
   fi
 
-  url="${url}/search?q="
-  shift   # shift out $1
+  url="${url}/$2"
+
+  shift 2  # shift out $1 and $2
 
   while [[ $# -gt 0 ]]; do
     url="${url}$1+"
@@ -38,6 +32,6 @@ function web_search() {
   $open_cmd "$url" &> /dev/null
 }
 
-alias bing='web_search bing'
-alias google='web_search google'
-alias yahoo='web_search yahoo'
+alias bing='web_search www.bing.com search\?q='
+alias google='web_search www.google.com search\?q='
+alias yahoo='web_search www.yahoo.com search\?q='


### PR DESCRIPTION
Fix:
  - do not display stderr/stdin from web browsers in the zsh console

Changes:
  - make the web_search function more generic so other search engines can be added easily
  - add duckduckgo as a default search engine
  - cosmetic: call the open command from only one place