### PR TITLE
gpg-agent plugin service check changed

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -15,7 +15,7 @@ function start_agent_withssh {
 }
 
 # check if another agent is running
-if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
+if ! gpg-agent -q > /dev/null 2> /dev/null; then
     # source settings of old agent, if applicable
     if [ -f "${GPG_ENV}" ]; then
         . ${GPG_ENV} > /dev/null


### PR DESCRIPTION
Running on OsX 10.8:

When using gpg-agent plugin, found numerous instances of gpg-agent running on my system, growing linearly with time.  Found existing check for running services is calling a deprecated command.

gpg-agent -q has the same effect.

![image](https://f.cloud.github.com/assets/191587/1030808/d4cfe8e6-0ec5-11e3-8290-c8ccb23313bb.png)
