### PR TITLE
Enable completion for maven colorizer

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -168,3 +168,4 @@ function listMavenCompletions {
 }
 
 compctl -K listMavenCompletions mvn
+compctl -K listMavenCompletions mvn-color


### PR DESCRIPTION
Maven plugin introduces mvn-color, but completion for it doesn't work(and after aliasing mvn-color to mvn it doesn't work too for mvn).
