### PR TITLE
Added ssh-like mosh window title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -28,7 +28,7 @@ function omz_termsupport_preexec {
   setopt extended_glob
 
   # cmd name only, or if this is sudo or ssh, the next cmd
-  local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]:gs/%/%%}
+  local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
 
   title '$CMD' '%100>...>$LINE%<<'


### PR DESCRIPTION
Display the hostname when running Mosh (http://mosh.mit.edu/).
Same thing as displaying "hostname" when running "ssh hostname".