### PR TITLE
Add ability to disable theme

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -28,15 +28,18 @@ else
     SCREEN_NO=""
 fi
 
-# Apply theming defaults
-PS1="%n@%m:%~%# "
+if [ "$DISABLE_THEME" != "true" ]
+then
+  # Apply theming defaults
+  PS1="%n@%m:%~%# "
 
-# git theming default: Variables for theming the git info prompt
-ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of the prompt, before the branch name
-ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
-ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
-ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+  # git theming default: Variables for theming the git info prompt
+  ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of the prompt, before the branch name
+  ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
+  ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
+  ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
 
-# Setup the prompt with pretty colors
-setopt prompt_subst
+  # Setup the prompt with pretty colors
+  setopt prompt_subst
+fi
 

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -68,26 +68,29 @@ for config_file ($ZSH_CUSTOM/*.zsh(N)); do
 done
 unset config_file
 
-# Load the theme
-if [ "$ZSH_THEME" = "random" ]
+if [ "$DISABLE_THEME" != "true" ]
 then
-  themes=($ZSH/themes/*zsh-theme)
-  N=${#themes[@]}
-  ((N=(RANDOM%N)+1))
-  RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
-  echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
-else
-  if [ ! "$ZSH_THEME" = ""  ]
+  # Load the theme
+  if [ "$ZSH_THEME" = "random" ]
   then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
+    themes=($ZSH/themes/*zsh-theme)
+    N=${#themes[@]}
+    ((N=(RANDOM%N)+1))
+    RANDOM_THEME=${themes[$N]}
+    source "$RANDOM_THEME"
+    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  else
+    if [ ! "$ZSH_THEME" = ""  ]
     then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]
-    then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+      if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
+      then
+        source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+      elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]
+      then
+        source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+      else
+        source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
In order for the zsh flavor of lokaltog/powerline and oh-my-zsh to play nice, the prompt theming in oh-my-zsh needs to be disabled. This pull request adds a $DISABLE_THEME option, that when set to "true" will bypass loading oh-my-zsh themeing.