### PR TITLE
Add an option about git submodules to ignore

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -17,6 +17,19 @@ function parse_git_dirty() {
     if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
+    case "$GIT_STATUS_IGNORE_SUBMODULES" in
+      "")
+        # if unset: ignore dirty submodules
+        FLAGS+="--ignore-submodules=dirty"
+        ;;
+      "git")
+        # let git decide (this respects per-repo config in .gitmodules)
+        ;;
+      *)
+        # other values are passed to --ignore-submodules
+        FLAGS+="--ignore-submodules=$GIT_STATUS_IGNORE_SUBMODULES"
+        ;;
+    esac
     STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -n1)
   fi
   if [[ -n $STATUS ]]; then


### PR DESCRIPTION
Hi there

I found that when checking whether a git repo is clean, `lib/git.zsh` always ignore dirty submodules,
no matter what was specified in `.gitmodules` file.
So I added an option to enable overriding this behavior.
When this option is not set, it should work as before. See commit message for more details.
