### PR TITLE
Add terminal Google Translate using termit gem.

### DIFF
--- a/plugins/termit/termit.plugin.zsh
+++ b/plugins/termit/termit.plugin.zsh
@@ -1,0 +1,2 @@
+#!/bin/zsh
+alias translate=$ZSH/plugins/termit/termit.rb

--- a/plugins/termit/termit.rb
+++ b/plugins/termit/termit.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+#
+# termit
+# Pawel Urbanek / @pawurb
+#
+# Termit is an easy way to use Google Translate in your terminal.
+#
+# Usage:
+# termit 'source_language' 'target_language' 'text'
+#
+# Example:
+# termit en fr 'hey cowboy where is your horse?'
+# => 'hey cow-boy ou est votre cheval?'
+#
+# Options:
+# -t - speech synthesis
+# -s - synonyms list
+#
+# Check docs at: github.com/pawurb/termit
+
+require 'rubygems'
+
+begin
+  require 'termit'
+rescue LoadError
+  puts "You need to install termit: gem install termit"
+  exit!(1)
+end
+
+begin
+  options = Termit::UserInputParser.new(ARGV).options
+  Termit::Main.new(options).translate
+rescue Interrupt
+  STDERR.puts "\nTermit: exiting due to user request"
+  exit 130
+end
+


### PR DESCRIPTION
Hello. I would like to suggest including a [Termit](https://github.com/pawurb/termit) gem as a plugin. It allows a user to use all the Google Translate goodies (together with speech synthesis) from the terminal. It's only dependency is ruby in version from 1.9.2. Executable is aliased to translate.
