### PR TITLE
Per-host prompt colouring

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -15,3 +15,17 @@ function take() {
   cd $1
 }
 
+function string_hash() {
+	HASHSTR=$1
+	HASHSIZE=$2
+
+	HASHVAL=0
+	for i in {1..${#HASHSTR}}; do;
+		THISCHAR=$HASHSTR[$i]
+		HASHVAL=$(( $HASHVAL + $((#THISCHAR)) ))
+	done
+	HASHSIZE=$(( $HASHSIZE - 1 ))
+	HASHVAL=$(( $HASHVAL % $HASHSIZE ))
+	HASHVAL=$(( $HASHVAL + 1 ))
+	echo $HASHVAL
+}

--- a/themes/jms.zsh-theme
+++ b/themes/jms.zsh-theme
@@ -1,0 +1,42 @@
+# check if 'screen' is in TERM
+SCR_COLOR=%{$fg[white]%}
+
+if [ "$TERM" = "screen" ]; then
+	SCR_COLOR=%{$fg[yellow]%}
+fi
+
+if [ "$TERM" = "screen-bce" ]; then
+	SCR_COLOR=%{$fg[yellow]%}
+fi
+
+if [ "x$WINDOW" != "x" ]; then
+	SCR_WINDOW="%{$fg[yellow]%}#$WINDOW"
+elif [ "x$TMUX" != "x" ]; then
+	SCR_WINDOW="%{$fg[yellow]%}#$(tmux display-message -p '#I')"
+else
+	SCR_WINDOW=""
+fi
+
+if [ "x$(battery_pct_prompt)" = "x" ]; then
+	BATTERY=""
+else
+	BATTERY="$(battery_pct_prompt) "
+fi
+BATTERY=""
+
+HOSTNAME=$(hostname)
+HOSTCOLOUR=$(string_hash $HOSTNAME:l 15)
+
+PROMPT='%{$reset_color%}%n%{$fg[white]%}@%{%F{$HOSTCOLOUR}%}%m$SCR_WINDOW$SCR_COLOR:%{$fg[blue]%}%~%{$reset_color%}$(git_prompt_info) %(0?,,%{$fg[red]%}%?!%{$reset_color%} )%(!.%{$fg[red]%}.%{$fg[green]%})%#%{$reset_color%} '
+
+RPROMPT='$BATTERY%{$fg_bold[black]%}%*%{$reset_color%}'
+# include aws_prompt if the ec2 plugin is loaded
+if [ "x$AWS_PLUGIN" = "x1" ]; then
+	RPROMPT='$(aws_prompt) '$RPROMPT
+fi
+
+ZSH_THEME_GIT_PROMPT_PREFIX=":%{$fg[yellow]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_GIT_PROMPT_DIRTY="%F{161}!%{$reset_color%}"
+


### PR DESCRIPTION
Hashes the hostname to get a value 1-15 and uses that as the colour for
the hostname in the prompt.

Includes example theme (jms) which uses it (also uses other things which aren't included here)

Hope I did this right, my fork has diverged a bit and I was trying to just grab just these changes :)