### PR TITLE
Changed determination nvm in system

### DIFF
--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,6 +1,9 @@
 # get the node.js version
 function nvm_prompt_info() {
-  [ -f "$HOME/.nvm/nvm.sh" ] || return
+  if [[ "$(command -v nvm)" != "nvm" || -z $(echo $PATH | grep "$HOME/.nvm") ]];
+    then return
+  fi
+
   local nvm_prompt
   nvm_prompt=$(node -v 2>/dev/null)
   [[ "${nvm_prompt}x" == "x" ]] && return

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,3 +1,4 @@
 # The addition 'nvm install' attempts in ~/.profile
 
 [[ -s ~/.nvm/nvm.sh ]] && . ~/.nvm/nvm.sh
+[[ -r $NVM_DIR/bash_completion ]] && . $NVM_DIR/bash_completion


### PR DESCRIPTION
As noted by @deepsweet in #2236, check if `~/.nvm/nvm.sh` exists is not the best way to determine is there an `nvm` command or not.

I replaced it with `command -v`.