### PR TITLE
Fix: __git_complete_remote_or_refspec:35: bad pattern: +*

### DIFF
--- a/plugins/gitfast/git-completion.bash
+++ b/plugins/gitfast/git-completion.bash
@@ -643,8 +643,8 @@ __git_complete_remote_or_refspec ()
 		cur_="${cur_#*:}"
 		lhs=0
 		;;
-	+*)
-		pfx="+"
+	*)
+		pfx=""
 		cur_="${cur_#+}"
 		;;
 	esac


### PR DESCRIPTION
I'm using gitfast plugin instead of git.
Since i upgrade my debian sid to the latest, when i use `git push -u origin somebranch` and press tab, it will output 3 lines:
> __git_complete_remote_or_refspec:35: bad pattern: +*
__git_complete_remote_or_refspec:35: bad pattern: +*
__git_complete_remote_or_refspec:35: bad pattern: +*

So i check the source and make the modification to keep the function works.