### PR TITLE
add profile auto completion for maven

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -166,6 +166,8 @@ function listMavenCompletions {
         archetype:generate generate-sources 
         cobertura:cobertura
         -Dtest= `if [ -d ./src/test/java ] ; then find ./src/test/java -type f -name '*.java' | grep -v svn | sed 's?.*/\([^/]*\)\..*?-Dtest=\1?' ; fi`
+        # profile id auto completion
+        -P `[ -e pom.xml ] && grep -e "<profile>" -A 1 pom.xml | grep -e "<id>.*</id>" | sed 's/.*<id>//' | sed 's/<\/id>.*//g' |sed 's/^/-P/'`
     ); 
 }
 


### PR DESCRIPTION
The script will filter all profile id from pom.xml in current directory and support profile auto completion for '-P\<tab\>'.