### PR TITLE
Updated BZR prompt info and added HG prompt info

### DIFF
--- a/lib/bzr.zsh
+++ b/lib/bzr.zsh
@@ -1,10 +1,19 @@
 ## Bazaar integration
 ## Just works with the GIT integration just add $(bzr_prompt_info) to the PROMPT
 function bzr_prompt_info() {
-	BZR_CB=`bzr nick 2> /dev/null | grep -v "ERROR" | cut -d ":" -f2 | awk -F / '{print "bzr::"$1}'`
-	if [ -n "$BZR_CB" ]; then
-		BZR_DIRTY=""
-		[[ -n `bzr status` ]] && BZR_DIRTY=" %{$fg[red]%} * %{$fg[green]%}"
-		echo "$ZSH_THEME_SCM_PROMPT_PREFIX$BZR_CB$BZR_DIRTY$ZSH_THEME_GIT_PROMPT_SUFFIX"
+	BZR_BRANCH=$(command bzr nick 2> /dev/null | grep -v "ERROR" | cut -d ":" -f2 | awk -F / '{print $1}')
+
+	if [[ -n "$BZR_CB" ]]; then
+		echo "$ZSH_THEME_SCM_PROMPT_PREFIX$BZR_BRANCH$(parse_bzr_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 	fi
+}
+
+function parse_bzr_dirty() {
+    BZR_STATUS=$(command bzr status 2> /dev/null | tail -n1)
+
+    if [[ -n "$BZR_STATUS" ]]; then
+        echo $ZSH_THEME_GIT_PROMPT_DIRTY
+    else
+        echo $ZSH_THEME_GIT_PROMPT_CLEAN
+    fi
 }

--- a/lib/bzr.zsh
+++ b/lib/bzr.zsh
@@ -3,7 +3,7 @@
 function bzr_prompt_info() {
 	BZR_BRANCH=$(command bzr nick 2> /dev/null | grep -v "ERROR" | cut -d ":" -f2 | awk -F / '{print $1}')
 
-	if [[ -n "$BZR_CB" ]]; then
+	if [[ -n "$BZR_BRANCH" ]]; then
 		echo "$ZSH_THEME_SCM_PROMPT_PREFIX$BZR_BRANCH$(parse_bzr_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 	fi
 }

--- a/lib/hg.zsh
+++ b/lib/hg.zsh
@@ -2,7 +2,7 @@
 function hg_prompt_info() {
     HG_BRANCH=$(command hg branch 2> /dev/null | grep -v ^abort)
 
-    if [[ -n "$HG_CB" ]]; then
+    if [[ -n "$HG_BRANCH" ]]; then
         echo "$ZSH_THEME_HG_PROMPT_PREFIX$HG_BRANCH$(parse_hg_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
     fi
 }

--- a/lib/hg.zsh
+++ b/lib/hg.zsh
@@ -1,0 +1,18 @@
+## Mercurial (Hg) integration
+function hg_prompt_info() {
+    HG_BRANCH=$(command hg branch 2> /dev/null | grep -v ^abort)
+
+    if [[ -n "$HG_CB" ]]; then
+        echo "$ZSH_THEME_HG_PROMPT_PREFIX$HG_BRANCH$(parse_hg_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    fi
+}
+
+function parse_hg_dirty() {
+    HG_STATUS=$(command hg status 2> /dev/null | tail -n1)
+
+    if [[ -n "$HG_STATUS" ]]; then
+        echo $ZSH_THEME_GIT_PROMPT_DIRTY
+    else
+        echo $ZSH_THEME_GIT_PROMPT_CLEAN
+    fi
+}


### PR DESCRIPTION
# lib/bzr.zsh
- Followed the pattern given by _lib/git.zsh_ and refactored to have a separate function to determine if the BZR repository is dirty or clean.
- Removed static _"bzr::"_ prefix to allow for custom defining in theme or configuration file(s).
# lib/hg.zsh
- New library function to provide similar functionality as _lib/git.zsh_ and _lib/bzr.zsh_.
# Known Issues
- If the Mercurial (Hg) repository uses special plugins/extensions (i.e. largefiles) which have not been configured on the system then _hg_prompt_info()_ will not display any repository information.
# Example Theme

```
if [[ -z $ZSH_THEME_CLOUD_PREFIX ]]; then
    ZSH_THEME_CLOUD_PREFIX=''
fi

PROMPT='${ZSH_THEME_CLOUD_PREFIX} $FG[208]/* $FG[248]dir:%~ $FG[208]*/%{$reset_color%} '
RPROMPT='$(git_prompt_info)$(hg_prompt_info)$(bzr_prompt_info)'

# This is the standard prompt to be used between all version control systems.
VCS_PROMPT_PREFIX="$FG[208]["

ZSH_THEME_GIT_PROMPT_PREFIX="${VCS_PROMPT_PREFIX}$FG[248]git$FG[208]::$FG[248]"
ZSH_THEME_SCM_PROMPT_PREFIX="${VCS_PROMPT_PREFIX}$FG[248]bzr$FG[208]::$FG[248]"
ZSH_THEME_HG_PROMPT_PREFIX="${VCS_PROMPT_PREFIX}$FG[248]hg$FG[208]::$FG[248]"
ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[208]]%{$reset_color%}"
ZSH_THEME_GIT_PROMPT_DIRTY="$FG[160]*%{$reset_color%}"
ZSH_THEME_GIT_PROMPT_CLEAN=""
```
