### PR TITLE
Fix itchy theme rvm-prompt invocation by silencing error messages

### DIFF
--- a/themes/itchy.zsh-theme
+++ b/themes/itchy.zsh-theme
@@ -10,7 +10,7 @@ local pwd="%{$fg[yellow]%}%~%{$reset_color%}"
 PROMPT='${user}${host} ${pwd}
 ${smiley}  '
 
-RPROMPT='$(rvm-prompt || rbenv version) %{$fg[white]%}$(git_prompt_info)%{$reset_color%}'
+RPROMPT='$(rvm-prompt 2>/dev/null || rbenv version 2>/dev/null) %{$fg[white]%}$(git_prompt_info)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX=""
 ZSH_THEME_GIT_PROMPT_SUFFIX=""


### PR DESCRIPTION
If rvm-prompt or rbenv isn't found within the system, then the
following error message is displayed:

zsh: command not found: rvm-prompt

Silencing standard error while invoking these commands fixes this
problem.
