### PR TITLE
Cleaning lib

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -4,19 +4,5 @@ alias please='sudo'
 
 #alias g='grep -in'
 
-# Show history
-if [ "$HIST_STAMPS" = "mm/dd/yyyy" ]
-then
-    alias history='fc -fl 1'
-elif [ "$HIST_STAMPS" = "dd.mm.yyyy" ]
-then
-    alias history='fc -El 1'
-elif [ "$HIST_STAMPS" = "yyyy-mm-dd" ]
-then
-    alias history='fc -il 1'
-else
-    alias history='fc -l 1'
-fi
-
 alias afind='ack-grep -il'
 

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -1,8 +1,0 @@
-# Super user
-alias _='sudo'
-alias please='sudo'
-
-#alias g='grep -in'
-
-alias afind='ack-grep -il'
-

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -1,11 +1,3 @@
-# Push and pop directories on directory stack
-alias pu='pushd'
-alias po='popd'
-
-# Basic directory operations
-alias ...='cd ../..'
-alias -- -='cd -'
-
 # Super user
 alias _='sudo'
 alias please='sudo'
@@ -25,12 +17,6 @@ then
 else
     alias history='fc -l 1'
 fi
-# List direcory contents
-alias lsa='ls -lah'
-alias l='ls -lah'
-alias ll='ls -lh'
-alias la='ls -lAh'
-alias sl=ls # often screw this up
 
 alias afind='ack-grep -il'
 

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -4,12 +4,10 @@ setopt auto_pushd
 setopt pushd_ignore_dups
 setopt pushdminus
 
-alias ..='cd ..'
-alias cd..='cd ..'
-alias cd...='cd ../..'
-alias cd....='cd ../../..'
-alias cd.....='cd ../../../..'
-alias cd/='cd /'
+alias -g ...='../..'
+alias -g ....='../../..'
+alias -g .....='../../../..'
+alias -g ......='../../../../..'
 
 alias 1='cd -'
 alias 2='cd -2'
@@ -21,23 +19,17 @@ alias 7='cd -7'
 alias 8='cd -8'
 alias 9='cd -9'
 
-cd () {
-  if   [[ "x$*" == "x..." ]]; then
-    cd ../..
-  elif [[ "x$*" == "x...." ]]; then
-    cd ../../..
-  elif [[ "x$*" == "x....." ]]; then
-    cd ../../../..
-  elif [[ "x$*" == "x......" ]]; then
-    cd ../../../../..
-  elif [ -d ~/.autoenv ]; then
-    source ~/.autoenv/activate.sh
-    autoenv_cd "$@"
-  else
-    builtin cd "$@"
-  fi
-}
-
 alias md='mkdir -p'
 alias rd=rmdir
 alias d='dirs -v | head -10'
+
+# List direcory contents
+alias lsa='ls -lah'
+alias l='ls -la'
+alias ll='ls -l'
+alias la='ls -lA'
+alias sl=ls # often screw this up
+
+# Push and pop directories on directory stack
+alias pu='pushd'
+alias po='popd'

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -23,7 +23,7 @@ alias md='mkdir -p'
 alias rd=rmdir
 alias d='dirs -v | head -10'
 
-# List direcory contents
+# List directory contents
 alias lsa='ls -lah'
 alias l='ls -la'
 alias ll='ls -l'

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -5,6 +5,14 @@ fi
 HISTSIZE=10000
 SAVEHIST=10000
 
+# Show history
+case $HIST_STAMPS in
+  "mm/dd/yyyy") alias history='fc -fl 1' ;;
+  "dd.mm.yyyy") alias history='fc -El 1' ;;
+  "yyyy-mm-dd") alias history='fc -il 1' ;;
+  *) alias history='fc -l 1' ;;
+esac
+
 setopt append_history
 setopt extended_history
 setopt hist_expire_dups_first

--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -44,6 +44,9 @@ autoload -U edit-command-line
 zle -N edit-command-line
 bindkey '\C-x\C-e' edit-command-line
 
+# file rename magick
+bindkey "^[m" copy-prev-shell-word
+
 # consider emacs keybindings:
 
 #bindkey -e  ## emacs key bindings

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -2,9 +2,6 @@
 autoload -U url-quote-magic
 zle -N self-insert url-quote-magic
 
-## file rename magick
-bindkey "^[m" copy-prev-shell-word
-
 ## jobs
 setopt long_list_jobs
 

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -13,3 +13,10 @@ export PAGER="less"
 export LESS="-R"
 
 export LC_CTYPE=$LANG
+
+## super user alias
+alias _='sudo'
+alias please='sudo'
+
+## more intelligent acking for ubuntu users
+alias afind='ack-grep -il'

--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -1,6 +1,17 @@
+# Activates autoenv or reports its failure
+if ! source $HOME/.autoenv/activate.sh 2>/dev/null; then
+  echo '-------- AUTOENV ---------'
+  echo 'Could not find ~/.autoenv/activate.sh.'
+  echo 'Please check if autoenv is correctly installed.'
+  echo 'In the meantime the autoenv plugin is DISABLED.'
+  echo '--------------------------'
+  return 1
+fi
+
 # The use_env call below is a reusable command to activate/create a new Python
 # virtualenv, requiring only a single declarative line of code in your .env files.
 # It only performs an action if the requested virtualenv is not the current one.
+
 use_env() {
     typeset venv
     venv="$1"

--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -21,12 +21,6 @@ alias sgrep='grep -R -n -H -C 5 --exclude-dir={.git,.svn,CVS} '
 
 alias t='tail -f'
 
-# because typing 'cd' is A LOT of work!!
-alias ..='cd ../'
-alias ...='cd ../../'
-alias ....='cd ../../../'
-alias .....='cd ../../../../'
-
 # Command line head / tail shortcuts
 alias -g H='| head'
 alias -g T='| tail'


### PR DESCRIPTION
- Provides a more useful approach to directory switching, as suggested in #2412
- Deletes `aliases.zsh`, as almost all things defined in their can find a place in other files present
  - The directory aliases (some of the which duplicate functionality) are all in `directories.zsh`
  - The history alias is in `history.zsh`. Also refactored to a nicer case switch
  - Remaining pieces like the please alias for sudo are in `misc.zsh`
  - Deletes the .. aliases from the `common-aliases` plugin, they are in `lib` anyway
- Moves a bindkey statement from `misc.zsh` to `key-bindings.zsh`
- Avoids sourcing of `autoenv` with every call to cd. This plugin related code is also taken out of the lib directory. Its activation file is now sourced only once - if its not present, the user is informed and the plugin disabled. Overriding cd by hand is not needed, autoenv does this by itself.

Closes #2412
Closes #2601 