### PR TITLE
tmux plugin sets window-name to CWD

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -90,6 +90,17 @@ if which tmux &> /dev/null
 			_zsh_tmux_plugin_run
 		fi
 	fi
+
+	# Add window name support
+	function omz_tmux_windowname_precmd {
+		# ZSH_THEME_TERM_TAB_TITLE_IDLE is from lib/termsupport.zsh
+		if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
+			return
+		fi
+ 		print -Pn "\033k$ZSH_THEME_TERM_TAB_TITLE_IDLE\033"
+	}
+	autoload -U add-zsh-hook
+	add-zsh-hook precmd omz_tmux_windowname_precmd
 else
 	print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin."
 fi


### PR DESCRIPTION
Some time ago my tmux window names went from being set to the current working dir to just showing 'zsh' (or whatever command was currently running). I did some investigating, and I think that the escape sequence for setting a tmux window name is different than that for setting an xterm title. I don't know if this changed in a recent version of tmux (I'm on OSX, and installed tmux 1.8 using homebrew).

Mike