### PR TITLE
Add heroku alias function for setting app or remote name

### DIFF
--- a/plugins/heroku/_heroku
+++ b/plugins/heroku/_heroku
@@ -159,3 +159,23 @@ _arguments \
   '(--remote)--remote[the remote name]' \
   &&  return 0
 
+# Alias overriding default "heroku" command to ease setting app or remote name.
+#
+# heroku @@foo info -> heroku info -a foo
+# heroku @foo info -> heroku info -r foo
+
+heroku() {
+  if [ $# -gt 0 ] && [ ${1:0:2} = "@@" ]
+  then
+    app=${1:2}
+    shift
+    command heroku $@ -a $app
+  elif [ $# -gt 0 ] && [ ${1:0:1} = "@" ]
+  then
+    remote=${1:1}
+    shift
+    command heroku $@ -r $remote
+  else
+    command heroku $@
+  fi
+}


### PR DESCRIPTION
Instead of having to use `-a` or `-r` to set the app or remote name in the `heroku` command, use this alias to specify those names:

``` shell
  heroku @@foo info
  # heroku info -a foo
  heroku @foo info
  # heroku info -r foo
```
