### PR TITLE
Adds support to capistrano multistage completion

### DIFF
--- a/plugins/capistrano/_capistrano
+++ b/plugins/capistrano/_capistrano
@@ -1,7 +1,7 @@
-#compdef xcap cap
+#compdef shipit
 #autoload
 
-# Added `xcap` because `cap` is a reserved word. `cap` completion doesn't work.
+# Added `shipit` because `cap` is a reserved word. `cap` completion doesn't work.
 # http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fcap-Module
 
 local curcontext="$curcontext" state line ret=1
@@ -14,7 +14,7 @@ _arguments -C \
 _cap_tasks() {
   if [[ -f config/deploy.rb || -f Capfile ]]; then
     if [[ ! -f .cap_tasks~ ]]; then
-      xcap -v --tasks | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
+      shipit -v --tasks | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
     fi
 
     OLD_IFS=$IFS

--- a/plugins/capistrano/_capistrano
+++ b/plugins/capistrano/_capistrano
@@ -1,10 +1,49 @@
-#compdef cap
+#compdef xcap cap
 #autoload
 
-if [[ -f config/deploy.rb || -f Capfile ]]; then
-  if [[ ! -f .cap_tasks~ || config/deploy.rb -nt .cap_tasks~ ]]; then
-    echo "\nGenerating .cap_tasks~..." > /dev/stderr
-    cap -v --tasks | grep '#' | cut -d " " -f 2 > .cap_tasks~
+# Added `xcap` because `cap` is a reserved word. `cap` completion doesn't work.
+# http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fcap-Module
+
+local curcontext="$curcontext" state line ret=1
+local -a _configs
+
+_arguments -C \
+  '1: :->cmds' \
+  '2:: :->args' && ret=0
+
+_cap_tasks() {
+  if [[ -f config/deploy.rb || -f Capfile ]]; then
+    if [[ ! -f .cap_tasks~ ]]; then
+      xcap -v --tasks | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
+    fi
+
+    OLD_IFS=$IFS
+    IFS=$'\n'
+    _values 'cap commands' $(< .cap_tasks~)
+    IFS=$OLD_IFS
+    # zmodload zsh/mapfile
+    # _values ${(f)mapfile[.cap_tasks~]}
   fi
-  compadd `cat .cap_tasks~`
-fi
+}
+
+_cap_stages() {
+  compadd $(find config/deploy -name \*.rb | cut -d/ -f3 | sed s:.rb::g)
+}
+
+case $state in
+  cmds)
+    # check if it uses multistage
+    if [[ -d config/deploy ]]; then
+      _cap_stages
+    else
+      _cap_tasks
+    fi
+    ret=0
+    ;;
+  args)
+    _cap_tasks
+    ret=0
+    ;;
+esac
+
+return ret

--- a/plugins/capistrano/_capistrano
+++ b/plugins/capistrano/_capistrano
@@ -14,7 +14,7 @@ _arguments -C \
 _cap_tasks() {
   if [[ -f config/deploy.rb || -f Capfile ]]; then
     if [[ ! -f .cap_tasks~ ]]; then
-      shipit -v --tasks | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
+      shipit -v --tasks | sed 's/\(\[\)\(.*\)\(\]\)/\2:/' | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
     fi
 
     OLD_IFS=$IFS

--- a/plugins/capistrano/capistrano.plugin.zsh
+++ b/plugins/capistrano/capistrano.plugin.zsh
@@ -1,7 +1,7 @@
-# Added `xcap` because `cap` is a reserved word. `cap` completion doesn't work.
+# Added `shipit` because `cap` is a reserved word. `cap` completion doesn't work.
 # http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fcap-Module
 
-func xcap() {
+func shipit() {
   if [ -f Gemfile ]
   then
     bundle exec cap $*

--- a/plugins/capistrano/capistrano.plugin.zsh
+++ b/plugins/capistrano/capistrano.plugin.zsh
@@ -1,0 +1,11 @@
+# Added `xcap` because `cap` is a reserved word. `cap` completion doesn't work.
+# http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fcap-Module
+
+func xcap() {
+  if [ -f Gemfile ]
+  then
+    bundle exec cap $*
+  else
+    cap $*
+  fi
+}


### PR DESCRIPTION
Uses `shipit` because [cap is a reserved word](http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#The-zsh_002fcap-Module), so `cap` completion doesn't work.

```bash
$ shipit |
production staging

$ shipit production |
deploy                       -- Deploy a new release
deploy:bundle                -- Bundle
deploy:check                 -- Check required files and directories exist
deploy:check:directories     -- Check shared and release directories exist
deploy:check:linked_dirs     -- Check directories to be linked exist in shared
deploy:check:linked_files    -- Check files to be linked exist in shared
deploy:cleanup               -- Clean up old releases
deploy:cleanup_rollback      -- Remove and archive rolled-back release
deploy:finished              -- Finished
deploy:finishing             -- Finish the deployment, clean up server(s)
deploy:finishing_rollback    -- Finish the rollback, clean up server(s)
deploy:log_revision          -- Log details of the deploy
deploy:published             -- Published
deploy:publishing            -- Publish the release
deploy:restart               -- Restart application
deploy:revert_release        -- Revert to previous release timestamp
deploy:reverted              -- Reverted
deploy:reverting             -- Revert server(s) to previous release
deploy:rollback              -- Rollback to previous release
deploy:started               -- Started
deploy:starting              -- Start a deployment, make sure server(s) ready
deploy:symlink:linked_dirs   -- Symlink linked directories
deploy:symlink:linked_files  -- Symlink linked files
deploy:symlink:release       -- Symlink release to current
deploy:symlink:shared        -- Symlink files and directories from shared to release
deploy:updated               -- Updated
deploy:updating              -- Update server(s) by setting up a new release
```
