### PR TITLE
Added path and shortcut for Cygwin and Sublime Text 3

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -36,6 +36,23 @@ elif  [[ $('uname') == 'Darwin' ]]; then
             break
         fi
     done
+
+elif [[ $('uname') =~ 'CYGWIN' ]]; then
+
+    local _sublime_cygwin_paths > /dev/null 2>&1
+    _sublime_cygwin_paths=(
+        "/cygdrive/c/Program Files/Sublime Text 3/sublime_text.exe"
+        "/cygdrive/c/Program Files/Sublime Text 2/sublime_text.exe"
+    )
+
+    for _sublime_path in $_sublime_darwin_paths; do        
+        if [[ -a $_sublime_path ]]; then
+            alias subl="'$_sublime_path'"
+            alias st=subl
+            break
+        fi
+    done
+
 fi
 
 alias stt='st .'


### PR DESCRIPTION
Added path and shortcut for Cygwin and Sublime Text 3. Tested on Windows 7, Cygwin 64 (2.831), and Sublime Text 3 (Build 3059).
