### PR TITLE
Added a function, that allows Cygwin users to display their git branch in PROMPT, without taking forever to process.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -7,6 +7,14 @@ function git_prompt_info() {
   fi
 }
 
+git_prompt_info_quick() {
+  ref=$(git symbolic-ref HEAD) 2> /dev/null
+  if [ "${ref}" != "" ]
+  then
+      echo "git:${ref#refs/heads/}"
+  fi
+}
+
 
 # Checks if working tree is dirty
 parse_git_dirty() {

--- a/themes/meo.zsh-theme
+++ b/themes/meo.zsh-theme
@@ -1,2 +1,0 @@
-PROMPT="%{${fg_bold[white]}%}[%F{167}%2C%{${fg_bold[white]}%}] %(0?.%{${fg[blue]}%}.%{${fg[red]}%})$%{${reset_color}%} "
-RPROMPT='%F{167} $(git_prompt_info_quick) %{${fg_bold[white]}%}%T%{${reset_color}%}'

--- a/themes/meo.zsh-theme
+++ b/themes/meo.zsh-theme
@@ -1,0 +1,2 @@
+PROMPT="%{${fg_bold[white]}%}[%F{167}%2C%{${fg_bold[white]}%}] %(0?.%{${fg[blue]}%}.%{${fg[red]}%})$%{${reset_color}%} "
+RPROMPT='%F{167} $(git_prompt_info_quick) %{${fg_bold[white]}%}%T%{${reset_color}%}'


### PR DESCRIPTION
I found the default git_prompt_info far too slow to be usable within Cygwin.

I'm not sure how to do a pull request without my two earlier commits, hope that is okay.