### PR TITLE
Preserve cursor position when prepending sudo.

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -2,20 +2,29 @@
 # Description
 # -----------
 #
-# sudo will be inserted before the command
+# sudo will be inserted before the command and the cursor position will be
+# preserved. If the prompt is empty, the previously executed command will be
+# fetched from the history and prepended with "sudo ".
 #
 # ------------------------------------------------------------------------------
 # Authors
 # -------
 #
 # * Dongweiming <ciici123@gmail.com>
+# * Michael Fladischer <FladischerMichael@fladi.at>
 #
 # ------------------------------------------------------------------------------
 
+sudo_preserve_cursor=1
+
 sudo-command-line() {
-[[ -z $BUFFER ]] && zle up-history
-[[ $BUFFER != sudo\ * ]] && BUFFER="sudo $BUFFER"
-zle end-of-line 
+    [[ -z $BUFFER ]] && zle up-history
+    if [[ $sudo_preserve_cursor -eq 1 ]]; then
+        [[ $LBUFFER != sudo\ * ]] && LBUFFER="sudo $LBUFFER"
+    else
+        [[ $BUFFER != sudo\ * ]] && BUFFER="sudo $BUFFER"
+        zle end-of-line
+    fi
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]


### PR DESCRIPTION
This changes the default behavior of the sudo plugin to preserve the position of the cursor when the current $BUFFER is prepended with "sudo ". The original behavior can be restored by setting `sudo_preserve_cursor=0`.