### PR TITLE
added optirun plugin completion

### DIFF
--- a/plugins/optirun/_optirun
+++ b/plugins/optirun/_optirun
@@ -1,0 +1,19 @@
+#compdef optirun
+
+local curcontext="$curcontext" environ e
+local -a args
+
+zstyle -a ":completion:${curcontext}:" environ environ
+
+for e in "${environ[@]}"
+do local -x "$e"
+done
+
+args=(
+       '-V[show version]'
+       '-h[show help]'
+)
+
+_arguments $args \
+'(-):command: _command_names -e' \
+'*::arguments: _normal'


### PR DESCRIPTION
Added a plugin for optirun, part of Bumblebee that lets people with linux and optimus laptops run applications on the nvidia graphics card. This plugin causes the completion engine to still work even when preceded by 'optirun'. 
