### PR TITLE
[plugins/tmux] Support automatic session grouping

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -58,6 +58,10 @@ if which tmux &> /dev/null
 	# Wrapper function for tmux.
 	function _zsh_tmux_plugin_run()
 	{
+		# Construct options.
+		[[ "$ZSH_TMUX_ITERM2"  == "true" ]] && tmux_options+=("-CC")
+		[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_options+=("-f" "$_ZSH_TMUX_FIXED_CONFIG")
+
 		# We have other arguments, just run them
 		if [[ -n "$@" ]]
 		then
@@ -65,11 +69,11 @@ if which tmux &> /dev/null
 		# Try to connect to an existing session.
 		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
 		then
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+			\tmux $tmux_options attach || \tmux $tmux_options new-session
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		# Just run tmux, fixing the TERM variable if requested.
 		else
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+			\tmux $tmux_options
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		fi
 	}


### PR DESCRIPTION
The current behavior with `ZSH_TMUX_AUTOCONNECT` enabled is to attach to an existing session. This change adds `ZSH_TMUX_GROUP`, which if enabled will group with an existing session instead.

This allows multiple terminals to share the same set of windows but display different active windows.
