### PR TITLE
Allow FreeBSD to correctly detect number of CPUs on host.

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -19,7 +19,7 @@ bi() {
   if _bundler-installed && _within-bundled-project; then
     local bundler_version=`bundle version | cut -d' ' -f3`
     if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then
-      if [[ "$(uname)" == 'Darwin' ]]
+      if [[ "$(uname)" == 'Darwin' || "$(uname)" == 'FreeBSD' ]]
       then
         local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
       else


### PR DESCRIPTION
Use the same scheme as Darwin - `sysctl hw.ncpu' instead of nproc, which doesn't exist in FreeBSD
