### PR TITLE
allow . in profile names

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -2,16 +2,14 @@ export AWS_HOME=~/.aws
 
 function agp {
   echo $AWS_DEFAULT_PROFILE
-  
 }
 function asp {
   export AWS_DEFAULT_PROFILE=$1
-    export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
-    
+  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
 }
 function aws_profiles {
-  reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))
+  reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
 }
-
 compctl -K aws_profiles asp
+
 source `which aws_zsh_completer.sh`


### PR DESCRIPTION
Allow "." in profile names. This zsh function was originally created by me and added by a workmate I shared it with. Unfortunately he added it without my later addition to allow dots in profile names which I use broadly.
