### PR TITLE
Support oh-my-zsh.hide-status in git_prompt_status()

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -71,47 +71,49 @@ function git_prompt_long_sha() {
 
 # Get the status of the working tree
 git_prompt_status() {
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  fi
-  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+  if [[ "$(command git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+    INDEX=$(command git status --porcelain -b 2> /dev/null)
+    if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+    elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    fi
+    if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+    fi
   fi
   echo $STATUS
 }


### PR DESCRIPTION
Git status is awfully slow for large git-svn repos, I've run into it a lot of times on the chromium repo. Just like parse_git_dirty() supports this flag, git_prompt_status() should too.