### PR TITLE
Add git_prompt_behind and git_prompt_exists

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -49,18 +49,34 @@ git_remote_status() {
     fi
 }
 
-# Checks if there are commits ahead from remote
-function git_prompt_ahead() {
-  if $(echo "$(command git log @{upstream}..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
-    echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
-  fi
-}
-
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
   if $(echo "$(command git log @{upstream}..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
     COMMITS=$(command git log @{upstream}..HEAD | grep '^commit' | wc -l | tr -d ' ')
     echo "$ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX$COMMITS$ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
+  fi
+}
+
+# Outputs if current branch is ahead of remote
+function git_prompt_ahead() {
+  if [[ -n "$(command git rev-list origin/$(current_branch)..HEAD 2> /dev/null)" ]]; then
+    echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
+  fi
+}
+
+# Outputs if current branch is behind remote
+function git_prompt_behind() {
+  if [[ -n "$(command git rev-list HEAD..origin/$(current_branch) 2> /dev/null)" ]]; then
+    echo "$ZSH_THEME_GIT_PROMPT_BEHIND"
+  fi
+}
+
+# Outputs if current branch exists on remote or not
+function git_prompt_remote() {
+  if [[ -n "$(command git show-ref origin/$(current_branch) 2> /dev/null)" ]]; then
+    echo "$ZSH_THEME_GIT_PROMPT_REMOTE_EXISTS"
+  else
+    echo "$ZSH_THEME_GIT_PROMPT_REMOTE_MISSING"
   fi
 }
 


### PR DESCRIPTION
This adds two new theme functions for git:
* `git_prompt_behind` works in a identical fashion to `git_prompt_ahead`
  and will output a format variable (`ZSH_THEME_GIT_PROMPT_BEHIND`) if
  the branch is behind.
* `git_prompt_remote` will output one format variable if the branch
  exists on remote (`ZSH_THEME_GIT_PROMPT_REMOTE_EXISTS`), and another
  if the branch is unpublished (`ZSH_THEME_GIT_PROMPT_REMOTE_MISSING`).