### PR TITLE
Fix dirhistory when the directory contains spaces

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -3,7 +3,7 @@
 #   that the user has changed to in the past, and ALT-RIGHT undoes ALT-LEFT.
 # 
 
-dirhistory_past=(`pwd`)
+dirhistory_past=($PWD)
 dirhistory_future=()
 export dirhistory_past
 export dirhistory_future
@@ -50,7 +50,7 @@ function push_future() {
 
 # Called by zsh when directory changes
 function chpwd() {
-  push_past "`pwd`"
+  push_past "$PWD"
   # If DIRHISTORY_CD is not set...
   if [[ -z "${DIRHISTORY_CD+x}" ]]; then
     # ... clear future.
@@ -73,7 +73,7 @@ function dirhistory_back() {
   pop_past cw 
   if [[ "" == "$cw" ]]; then
     # Someone overwrote our variable. Recover it.
-    dirhistory_past=(`pwd`)
+    dirhistory_past=($PWD)
     return
   fi
 

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -50,7 +50,7 @@ function push_future() {
 
 # Called by zsh when directory changes
 function chpwd() {
-  push_past `pwd`
+  push_past "`pwd`"
   # If DIRHISTORY_CD is not set...
   if [[ -z "${DIRHISTORY_CD+x}" ]]; then
     # ... clear future.


### PR DESCRIPTION
pwd output is not escaped, so when changing to a directory like "space dir", only "space" gets saved in the history. This fix wraps `pwd` in double quotes to mitigate that.