### PR TITLE
Added setting of the window title under Cygwin

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -2,13 +2,14 @@
 #http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
 #Fully support screen, iterm, and probably most modern xterm and rxvt
 #Limited support for Apple Terminal (Terminal can't set window or tab separately)
+#Should work with Cygwin in e.g. mintty, ConEmu or plain cmd.exe
 function title {
   if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
     return
   fi
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ $TERM == cygwin ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   fi


### PR DESCRIPTION
Common method for setting window title using escape sequences works under Cygwin on Windows too (for example in mintty, ConEmu and even in plain cmd.exe). But Cygwin sets TERM environment variable to "cygwin" by default. Therefore I have added "cygwin" to the TERM testing condition. Tested in ConEmu, mintty and cmd.exe.