### PR TITLE
add `rcd` alias to rails plugin

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -34,6 +34,7 @@ alias -g RET='RAILS_ENV=test'
 
 # Rails aliases
 alias rc='rails console'
+alias rcd='rails console --debugger'
 alias rd='rails destroy'
 alias rdb='rails dbconsole'
 alias rg='rails generate'


### PR DESCRIPTION
use `rcd` as alias for `rails console --debugger`, analog to `rsd` for `rails server --debugger`
