### PR TITLE
Mercurial: faster prompt, auto-workon

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -12,6 +12,9 @@ if (( $+commands[$virtualenvwrapper] )); then
             # Check if this is a Git repo
             PROJECT_ROOT=`git rev-parse --show-toplevel 2> /dev/null`
             if (( $? != 0 )); then
+                PROJECT_ROOT=`hg prompt '{root}' 2>/dev/null`
+            fi
+            if (( $? != 0 )); then
                 PROJECT_ROOT="."
             fi
             # Check for virtualenv name override

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -105,38 +105,18 @@ prompt_git() {
 }
 
 prompt_hg() {
-  local rev status
-  if $(hg id >/dev/null 2>&1); then
-    if $(hg prompt >/dev/null 2>&1); then
-      if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
-        # if files are not added
-        prompt_segment red white
-        st='±'
-      elif [[ -n $(hg prompt "{status|modified}") ]]; then
-        # if any modification
-        prompt_segment yellow black
-        st='±'
-      else
-        # if working copy is clean
-        prompt_segment green black
-      fi
-      echo -n $(hg prompt "☿ {rev}@{branch}") $st
-    else
-      st=""
-      rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
-      branch=$(hg id -b 2>/dev/null)
-      if `hg st | grep -Eq "^\?"`; then
-        prompt_segment red black
-        st='±'
-      elif `hg st | grep -Eq "^(M|A)"`; then
-        prompt_segment yellow black
-        st='±'
-      else
-        prompt_segment green black
-      fi
-      echo -n "☿ $rev@$branch" $st
+    local hg_status
+    hg_status="`hg prompt "{status} {tip} {branch}" 2>/dev/null`"
+    if (( $? == 0 )); then 
+        if [[ $hg_status == !* ]]; then
+          prompt_segment yellow black
+        elif [[ $hg_status == \?* ]]; then 
+          prompt_segment red white
+        else
+          prompt_segment green black
+        fi
+        echo -n "☿${hg_status}"
     fi
-  fi
 }
 
 # Dir: current working directory


### PR DESCRIPTION
I've added auto-workon for virtualenvs for mercurial repositories like it works on git.

Fixed speed problem of the agnoster theme when inside mercurial repositories, which was slow to the point of being unusable: it was calling hg many times, now it calls hg only once.