### PR TITLE
Steeef.theme: Simplifying the git check for untracked files

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -81,7 +81,7 @@ add-zsh-hook chpwd steeef_chpwd
 function steeef_precmd {
     if [[ -n "$PR_GIT_UPDATE" ]] ; then
         # check for untracked files or updated submodules, since vcs_info doesn't
-        if git ls-files --other --exclude-standard --directory 2> /dev/null | grep -q "."; then
+        if git status --short --porcelain 2> /dev/null | awk '{ if ( $1 == "??" ) print $2 }' | grep -q .; then
             PR_GIT_UPDATE=1
             FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
         else


### PR DESCRIPTION
Right now on large projects, ls-files takes a long time to loop through the entire tree. Git status shows all the information that we are looking for in the command prompt and is much quicker.
