### PR TITLE
Install script's chsh not working on Fedora

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -32,10 +32,12 @@ sed -i -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
 " ~/.zshrc
 
-if [ "$SHELL" != "$(which zsh)" ]; then
+TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
+if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
-    chsh -s `which zsh`
+    chsh -s $(grep /zsh$ /etc/shells | tail -1)
 fi
+unset TEST_CURRENT_SHELL
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"
 echo "\033[0;32m"'  ____  / /_     ____ ___  __  __   ____  _____/ /_  '"\033[0m"


### PR DESCRIPTION
Running the install script on Fedora 20 (after having yum-installed zsh) throws the following error:

    chsh: "/usr/bin/zsh" is not listed in /etc/shells

This is caused by the following line:

    chsh -s `which zsh`

The explaination is the following:
* Running `which -a zsh` return `/usr/bin/zsh` and `/bin/zsh`, but running `which zsh` returns only the first one: `/usr/bin/zsh`.
* Checking the available shells with `chsh -l | grep /zsh$` only returns `/bin/zsh`
* That's why the `chsh -s` command fails.

Both zsh paths should be present in `/etc/shells`, but it looks like it's a Fedora bug (see [bug 1034060](https://bugzilla.redhat.com/show_bug.cgi?id=1034060)).

One way to make the shell switching more robust is to set zsh from the list of available shells returned by `chsh -l` instead. The proposed patch gets the first available shell matching `/zsh$` and sets it as the current shell.

Fixes #3026, fixes #3779, fixes #3780