### PR TITLE
Added a possibility to display the remote branch and the number of commits you are ahead or behind

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -39,16 +39,26 @@ git_remote_status() {
         ahead=$(command git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
         behind=$(command git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
 
-        if [ $ahead -eq 0 ] && [ $behind -gt 0 ]
+        if [ $ahead -gt 0 ] && [ $behind -eq 0 ]
         then
-            echo "$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
-        elif [ $ahead -gt 0 ] && [ $behind -eq 0 ]
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
+            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}"
+        elif [ $behind -gt 0 ] && [ $ahead -eq 0 ] 
         then
-            echo "$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
+            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
         elif [ $ahead -gt 0 ] && [ $behind -gt 0 ]
         then
-            echo "$ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
+            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
         fi
+
+        if [ $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]
+        then
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+        fi
+
+        echo $git_remote_status
     fi
 }
 

--- a/themes/strug.zsh-theme
+++ b/themes/strug.zsh-theme
@@ -1,0 +1,25 @@
+# terminal coloring
+export CLICOLOR=1
+export LSCOLORS=dxFxCxDxBxegedabagacad
+
+local git_branch='$(git_prompt_info)%{$reset_color%}$(git_remote_status)'
+
+PROMPT="%{$fg[green]%}╭─%n@%m %{$reset_color%}%{$fg[yellow]%}in %~ %{$reset_color%}${git_branch}
+%{$fg[green]%}╰\$ %{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[yellow]%}on "
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$reset_color%}%{$fg[red]%} ✘ %{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[green]%} ✔ %{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED=true
+ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX="%{$fg[yellow]%}("
+ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX="%{$fg[yellow]%})%{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE=" +"
+ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR=%{$fg[green]%}
+
+ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE=" -"
+ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR=%{$fg[red]%}
+


### PR DESCRIPTION
Added a possibility to display the remote branch and the number of commits you are ahead or behind.

The theme "strug" demonstrates this new funtionality. There are some new variables:

`ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED` : allows you to switch between the current and the new display option.
`ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX` : prefix for the remote status information
`ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX` : suffix for the remote status information
`ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR` : color for displaying the ahead information (currently only used for the detailed mode)
`ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR` : color for displaying the behind information (currently only used for the detailed mode)


Demonstration of the new functionality: 

![git_remote_status_detailed_demo_ahead](https://f.cloud.github.com/assets/128227/42053/9897d29c-55f9-11e2-9a20-7822ebc9e124.png)
![git_remote_status_detailed_demo_ahead_and_behind](https://f.cloud.github.com/assets/128227/42057/a44e1132-55f9-11e2-84cb-ecd0b15c9b4e.png)
![git_remote_status_detailed_demo_behind](https://f.cloud.github.com/assets/128227/42058/a849b700-55f9-11e2-9daf-afa46b7b6277.png)
