### PR TITLE
Fixed wd plugin bug on zsh <= 4.3.10

### DIFF
--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -64,9 +64,9 @@ wd_warp()
 
 wd_add()
 {
-    if [[ $2 =~ "^\.+$" || $2 =~ "^\s*$" ]]
+    if [[ $2 -regex-match "^\.+$" || $2 -regex-match "^\s*$" ]]
     then
-        wd_print_msg $RED "Illegal warp point (see README)."
+	wd_print_msg $RED "Warp point name cannot be just dots or spaces"
     elif [[ ${points[$2]} == "" ]] || $1
     then
         wd_remove $2 > /dev/null


### PR DESCRIPTION
See http://www.zsh.org/mla/workers/2014/msg00501.html for details.
At time of writing, some RedHat and CentOS still have 4.3.10 as
the most up-to-date zsh in their package managers, so this should
allow wd to work on those systems properly.

Not sure if you only want to pull in full versions and not just minor 
patches. If that's the case just close this out please :-)