### PR TITLE
Respect all git versions

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -24,14 +24,14 @@ if error:
 lines = output.splitlines()
 
 behead_re = re.compile(
-    r"^# Your branch is (ahead of|behind) '(.*)' by (\d+) commit")
-diverge_re = re.compile(r"^# and have (\d+) and (\d+) different")
+    r"^(?:# |)Your branch is (ahead of|behind) '(.*)' by (\d+) commit")
+diverge_re = re.compile(r"^(?:# |)and have (\d+) and (\d+) different")
 
 status = ''
-staged = re.compile(r'^# Changes to be committed:$', re.MULTILINE)
-changed = re.compile(r'^# Changed but not updated:$', re.MULTILINE)
-untracked = re.compile(r'^# Untracked files:$', re.MULTILINE)
-unmerged = re.compile(r'^# Unmerged paths:$', re.MULTILINE)
+staged = re.compile(r'^(?:# |)Changes to be committed:$', re.MULTILINE)
+changed = re.compile(r'^(?:# |)Changed but not updated:$', re.MULTILINE)
+untracked = re.compile(r'^(?:# |)Untracked files:$', re.MULTILINE)
+unmerged = re.compile(r'^(?:# |)Unmerged paths:$', re.MULTILINE)
 
 
 def execute(*command):


### PR DESCRIPTION
Since 1.8.5 git doesn't use `# ` in output. See http://blogs.atlassian.com/2013/12/whats-new-git-1-8-5/