### PR TITLE
Avit theme – improved the _git_time_since_commit function

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -38,34 +38,32 @@ function _ruby_version() {
 # Determine the time since last commit. If branch is clean,
 # use a neutral color, otherwise colors will vary according to time.
 function _git_time_since_commit() {
-  if git rev-parse --git-dir > /dev/null 2>&1; then
-    # Only proceed if there is actually a commit.
-    if [[ $(git log 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
-      # Get the last commit.
-      last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
-      now=$(date +%s)
-      seconds_since_last_commit=$((now-last_commit))
+# Only proceed if there is actually a commit.
+  if git log -1 > /dev/null 2>&1; then
+    # Get the last commit.
+    last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
+    now=$(date +%s)
+    seconds_since_last_commit=$((now-last_commit))
 
-      # Totals
-      minutes=$((seconds_since_last_commit / 60))
-      hours=$((seconds_since_last_commit/3600))
+    # Totals
+    minutes=$((seconds_since_last_commit / 60))
+    hours=$((seconds_since_last_commit/3600))
 
-      # Sub-hours and sub-minutes
-      days=$((seconds_since_last_commit / 86400))
-      sub_hours=$((hours % 24))
-      sub_minutes=$((minutes % 60))
+    # Sub-hours and sub-minutes
+    days=$((seconds_since_last_commit / 86400))
+    sub_hours=$((hours % 24))
+    sub_minutes=$((minutes % 60))
 
-      if [ $hours -gt 24 ]; then
-          commit_age="${days}d"
-      elif [ $minutes -gt 60 ]; then
-          commit_age="${sub_hours}h${sub_minutes}m"
-      else
-          commit_age="${minutes}m"
-      fi
-
-      color=$ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL
-      echo "$color$commit_age%{$reset_color%}"
+    if [ $hours -gt 24 ]; then
+      commit_age="${days}d"
+    elif [ $minutes -gt 60 ]; then
+      commit_age="${sub_hours}h${sub_minutes}m"
+    else
+      commit_age="${minutes}m"
     fi
+
+    color=$ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL
+    echo "$color$commit_age%{$reset_color%}"
   fi
 }
 
@@ -99,4 +97,3 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[grey]%}"
 export LSCOLORS="exfxcxdxbxegedabagacad"
 export LS_COLORS='di=34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
 export GREP_COLOR='1;33'
-


### PR DESCRIPTION
Check for at least one commit using a `git log` limit of one.

Improves the performance inside git repos with a large history.