### PR TITLE
Add "help" method in "frontend-search" plugin

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -22,9 +22,16 @@ plugins=( <your-plugins-list>... frontend-search)
 
 ## Commands ##
 
-All command searches are accept only in format
+All command searches are accept only in formats
 
 * `frontend <search-content> <search-term>`
+* `<search-content> <search-term>`
+
+For more informations, please run help command (are similars)
+
+* `frontend -h`
+* `frontend --help`
+* `frontend help`
 
 The search content are
 

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -10,6 +10,27 @@ function frontend() {
     open_cmd='xdg-open'
   fi
 
+  # show help for commands list
+  if [[ $1 =~ '(help|--help|-h)' ]];
+  then
+      echo "Usage:"
+      echo "\n\tfrontend <search-content>\n\t<search-content>\n\tfrontend <search-content> <search-term>"
+      echo ""
+      echo "Where <search-content> is one of:"
+      echo "jquery, mdn, compass, html5please, caniuse, aurajs, dartlang, qunit, fontello,"
+      echo "bootsnipp, cssflow, codepen, unheap, bem, smacss, angularjs, reactjs, emberjs"
+      echo "help"
+      echo ""
+      echo "Where <search-term> is a term to search in allowed repositories"
+      echo ""
+      echo "frontend --help       show plugin help"
+      echo "frontend -h           show plugin help"
+      echo ""
+      echo "It is allowed to directly access all search contents."
+      echo ""
+      return 1
+  fi
+
   # no keyword provided, simply show how call methods
   if [[ $# -le 1 ]]; then
     echo "Please provide a search-content and a search-term for app.\nEx:\nfrontend <search-content> <search-term>\n"


### PR DESCRIPTION
Add a help option to show commands. Now the methods for access help is available in 3 ways:

`frontend -h`
`frontend --help`
`frontend help`
  