### PR TITLE
AWS plugin: alias for easier update of access keys

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -25,7 +25,22 @@ function aws_profiles {
   reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))
 }
 
-compctl -K aws_profiles asp
+function aws_change_access_key {
+  if [[ "x$1" == "x" ]] then
+    echo "usage: $0 <profile.name>"
+    return 1
+  else
+    echo "Insert the credentials when asked."
+    asp $1
+    aws iam create-access-key
+    aws configure --profile $1
+    echo "You can now safely delete the old access key running 'aws iam delete-access-key --access-key-id ID'"
+    echo "Your current keys are:"
+    aws iam list-access-keys
+  fi
+}
+
+compctl -K aws_profiles asp aws_change_access_key
 
 if _homebrew-installed && _awscli-homebrew-installed ; then
   _aws_zsh_completer_path=$(brew --prefix awscli)/libexec/bin/aws_zsh_completer.sh


### PR DESCRIPTION
This change initially included support for MFA authentication, which was later moved to a dedicated otp plugin.

Now it includes an alias for acces key updates and a few code style changes.
