### PR TITLE
Give agnoster an option to provide prompt on newline

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -178,4 +178,9 @@ build_prompt() {
   prompt_end
 }
 
-PROMPT='%{%f%b%k%}$(build_prompt) '
+if [ "${PROMPT_ON_NEWLINE}" = "true" ] ; then
+  PROMPT='╭─%{%f%b%k%}$(build_prompt)
+╰─ '
+else
+  PROMPT='%{%f%b%k%}$(build_prompt) '
+fi


### PR DESCRIPTION
This change adds a new environment export called PROMPT_ON_NEWLINE.
For example, when configured in ~/.zshrc as export PROMPT_ON_NEWLINE=true,
the prompt will always show on a new line so that you have more room to type.
Use full when working in deep folders.   Should be backwards compatible
with previous default behavior.