### PR TITLE
Fix the wrong agnoster.zsh-theme git symbol " " to "⭠"

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -100,7 +100,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_%% }${mode}"
+    echo -n "${ref/refs\/heads\//⭠}${vcs_info_msg_0_%% }${mode}"
   fi
 }
 


### PR DESCRIPTION
Hello,

I am a Taiwanese who speak Chinese.
I recently setup the oh-my-zsh on my Ubuntu notebook and I found this error. (14.04)

![1](https://fbcdn-sphotos-d-a.akamaihd.net/hphotos-ak-xpf1/t1.0-9/10478200_687655454650813_6319359507623310327_n.jpg)

Fixed

![2](https://fbcdn-sphotos-c-a.akamaihd.net/hphotos-ak-xfa1/v/t1.0-9/10409606_687655511317474_1877507897809235685_n.jpg?oh=493a1d573a456c91602548bef3b4cf70&oe=545AB83D&__gda__=1412724235_699ef9b7ce2874721dfc1a98bc164ac5)