### PR TITLE
Add an option to the tmux plugin to force 256 colors. 

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -8,89 +8,89 @@ alias tl='tmux list-sessions'
 
 # Only run if tmux is actually installed
 if which tmux &> /dev/null
-	then
-	# Configuration variables
-	#
-	# Automatically start tmux
-	[[ -n "$ZSH_TMUX_AUTOSTART" ]] || ZSH_TMUX_AUTOSTART=false
-	# Only autostart once. If set to false, tmux will attempt to
-	# autostart every time your zsh configs are reloaded.
-	[[ -n "$ZSH_TMUX_AUTOSTART_ONCE" ]] || ZSH_TMUX_AUTOSTART_ONCE=true
-	# Automatically connect to a previous session if it exists
-	[[ -n "$ZSH_TMUX_AUTOCONNECT" ]] || ZSH_TMUX_AUTOCONNECT=true
-	# Automatically close the terminal when tmux exits
-	[[ -n "$ZSH_TMUX_AUTOQUIT" ]] || ZSH_TMUX_AUTOQUIT=$ZSH_TMUX_AUTOSTART
-	# Set term to screen or screen-256color based on current terminal support
-	[[ -n "$ZSH_TMUX_FIXTERM" ]] || ZSH_TMUX_FIXTERM=true
-	# Set '-CC' option for iTerm2 tmux integration
-	[[ -n "$ZSH_TMUX_ITERM2" ]] || ZSH_TMUX_ITERM2=false
-	# The TERM to use for non-256 color terminals.
-	# Tmux states this should be screen, but you may need to change it on
-	# systems without the proper terminfo
-	[[ -n "$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITHOUT_256COLOR="screen"
-	# The TERM to use for 256 color terminals.
-	# Tmux states this should be screen-256color, but you may need to change it on
-	# systems without the proper terminfo
-	[[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
+    then
+    # Configuration variables
+    #
+    # Automatically start tmux
+    [[ -n "$ZSH_TMUX_AUTOSTART" ]] || ZSH_TMUX_AUTOSTART=false
+    # Only autostart once. If set to false, tmux will attempt to
+    # autostart every time your zsh configs are reloaded.
+    [[ -n "$ZSH_TMUX_AUTOSTART_ONCE" ]] || ZSH_TMUX_AUTOSTART_ONCE=true
+    # Automatically connect to a previous session if it exists
+    [[ -n "$ZSH_TMUX_AUTOCONNECT" ]] || ZSH_TMUX_AUTOCONNECT=true
+    # Automatically close the terminal when tmux exits
+    [[ -n "$ZSH_TMUX_AUTOQUIT" ]] || ZSH_TMUX_AUTOQUIT=$ZSH_TMUX_AUTOSTART
+    # Set term to screen or screen-256color based on current terminal support
+    [[ -n "$ZSH_TMUX_FIXTERM" ]] || ZSH_TMUX_FIXTERM=true
+    # Set '-CC' option for iTerm2 tmux integration
+    [[ -n "$ZSH_TMUX_ITERM2" ]] || ZSH_TMUX_ITERM2=false
+    # The TERM to use for non-256 color terminals.
+    # Tmux states this should be screen, but you may need to change it on
+    # systems without the proper terminfo
+    [[ -n "$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITHOUT_256COLOR="screen"
+    # The TERM to use for 256 color terminals.
+    # Tmux states this should be screen-256color, but you may need to change it on
+    # systems without the proper terminfo
+    [[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
     [[ -n "$ZSH_TMUX_FORCE_256COLOR" ]] || ZSH_TMUX_FORCE_256COLOR=false
 
 
-	# Get the absolute path to the current directory
-	local zsh_tmux_plugin_path="$(cd "$(dirname "$0")" && pwd)"
+    # Get the absolute path to the current directory
+    local zsh_tmux_plugin_path="$(cd "$(dirname "$0")" && pwd)"
 
-	# Determine if the terminal supports 256 colors
-	if [[ `tput colors` == "256" ]]
-	then
-		export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
-	else
-		export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR
-	fi
+    # Determine if the terminal supports 256 colors
+    if [[ `tput colors` == "256" ]]
+    then
+        export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
+    else
+        export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR
+    fi
 
-	# Set the correct local config file to use.
+    # Set the correct local config file to use.
     if [[ "$ZSH_TMUX_ITERM2" == "false" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]
-	then
-		#use this when they have a ~/.tmux.conf
-		export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
-	else
-		#use this when they don't have a ~/.tmux.conf
-		export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.only.conf"
-	fi
+    then
+        #use this when they have a ~/.tmux.conf
+        export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
+    else
+        #use this when they don't have a ~/.tmux.conf
+        export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.only.conf"
+    fi
 
-	# Wrapper function for tmux.
-	function _zsh_tmux_plugin_run()
-	{
-		# We have other arguments, just run them
-		if [[ -n "$@" ]]
-		then
-			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` $@
-		# Try to connect to an existing session.
-		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
-		then
-			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
-			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
-		# Just run tmux, fixing the TERM variable if requested.
-		else
-			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
-			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
-		fi
-	}
+    # Wrapper function for tmux.
+    function _zsh_tmux_plugin_run()
+    {
+        # We have other arguments, just run them
+        if [[ -n "$@" ]]
+        then
+            \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` $@
+        # Try to connect to an existing session.
+        elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
+        then
+            \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+            [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
+        # Just run tmux, fixing the TERM variable if requested.
+        else
+            \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+            [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
+        fi
+    }
 
-	# Use the completions for tmux for our function
-	compdef _tmux _zsh_tmux_plugin_run
+    # Use the completions for tmux for our function
+    compdef _tmux _zsh_tmux_plugin_run
 
-	# Alias tmux to our wrapper function.
-	alias tmux=_zsh_tmux_plugin_run
+    # Alias tmux to our wrapper function.
+    alias tmux=_zsh_tmux_plugin_run
 
-	# Autostart if not already in tmux and enabled.
-	if [[ ! -n "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" ]]
-	then
-		# Actually don't autostart if we already did and multiple autostarts are disabled.
-		if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]
-		then
-			export ZSH_TMUX_AUTOSTARTED=true
-			_zsh_tmux_plugin_run
-		fi
-	fi
+    # Autostart if not already in tmux and enabled.
+    if [[ ! -n "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" ]]
+    then
+        # Actually don't autostart if we already did and multiple autostarts are disabled.
+        if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]
+        then
+            export ZSH_TMUX_AUTOSTARTED=true
+            _zsh_tmux_plugin_run
+        fi
+    fi
 else
-	print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin."
+    print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin."
 fi

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -32,6 +32,7 @@ if which tmux &> /dev/null
 	# Tmux states this should be screen-256color, but you may need to change it on
 	# systems without the proper terminfo
 	[[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
+    [[ -n "$ZSH_TMUX_FORCE_256COLOR" ]] || ZSH_TMUX_FORCE_256COLOR=false
 
 
 	# Get the absolute path to the current directory
@@ -61,15 +62,15 @@ if which tmux &> /dev/null
 		# We have other arguments, just run them
 		if [[ -n "$@" ]]
 		then
-			\tmux $@
+			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` $@
 		# Try to connect to an existing session.
 		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
 		then
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		# Just run tmux, fixing the TERM variable if requested.
 		else
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+			\tmux `[[ "$ZSH_TMUX_FORCE_256COLOR" == "true" ]] && echo '-2 '` `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		fi
 	}


### PR DESCRIPTION
Tmux has a command line option to force 256 colors wether tmux thinks the terminal supports it or not. For some reason tmux thinks gnome-terminal doesn't support 256 colors, so this option makes life a bit easier. 

This pull request adds an option for the oh-my-zsh tmux plugin, so tmux can be called with the '-2' command line argument, forcing 256 colors. 