### PR TITLE
Clean up and add new vundle commands

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -1,27 +1,25 @@
 function vundle-init () {
-  if [ ! -d ~/.vim/bundle/vundle/ ]
+  if [ ! -d ~/.vim/bundle/Vundle.vim/ ]
   then
-    mkdir -p ~/.vim/bundle/vundle/
-  fi
-
-  if [ ! -d ~/.vim/bundle/vundle/.git ] && [ ! -f ~/.vim/bundle/vundle/.git ]
-  then
-    git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+    git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
     echo "\n\tRead about vim configuration for vundle at https://github.com/gmarik/vundle\n"
   fi
 }
 
 function vundle () {
   vundle-init
-  vim -c "execute \"BundleInstall\" | q | q"
+  vim +PluginInstall +qall
+  echo "\n\tVundle plugins installed!\n"
 }
 
 function vundle-update () {
   vundle-init
-  vim -c "execute \"BundleInstall!\" | q | q"
+  vim +PluginUpdate +qall
+  echo "\n\tVundle plugins updated!\n"
 }
 
 function vundle-clean () {
   vundle-init
-  vim -c "execute \"BundleClean!\" | q | q"
+  vim +PluginClean +qall
+  echo "\n\tUnused vundle plugins has been removed!\n"
 }


### PR DESCRIPTION
Vundle [quick start readme](https://github.com/gmarik/Vundle.vim#quick-start) is recommending users use 

    $ git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
instead of 

    $ git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle

So I've changed them accordingly in this pull request.

Vundle is also currently undergoing an [interface change](https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396).

Changed to the new `PluginInstall` command instead of `BundleInstall` so on and so forth. 