### PR TITLE
Let 'ys' theme use hg repo info too

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -14,12 +14,35 @@ function box_name {
 # Directory info.
 local current_dir='${PWD/#$HOME/~}'
 
+# VCS
+YS_VCS_PROMPT_PREFIX1=" %{$fg[white]%}on%{$reset_color%} "
+YS_VCS_PROMPT_PREFIX2=":%{$fg[cyan]%}"
+YS_VCS_PROMPT_SUFFIX="%{$reset_color%}"
+YS_VCS_PROMPT_DIRTY=" %{$fg[red]%}x"
+YS_VCS_PROMPT_CLEAN=" %{$fg[green]%}o"
+
 # Git info.
 local git_info='$(git_prompt_info)'
-ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[white]%}on%{$reset_color%} git:%{$fg[cyan]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[red]%}x"
-ZSH_THEME_GIT_PROMPT_CLEAN=" %{$fg[green]%}o"
+ZSH_THEME_GIT_PROMPT_PREFIX="${YS_VCS_PROMPT_PREFIX1}git${YS_VCS_PROMPT_PREFIX2}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="$YS_VCS_PROMPT_SUFFIX"
+ZSH_THEME_GIT_PROMPT_DIRTY="$YS_VCS_PROMPT_DIRTY"
+ZSH_THEME_GIT_PROMPT_CLEAN="$YS_VCS_PROMPT_CLEAN"
+
+# HG info
+local hg_info='$(ys_hg_prompt_info)'
+ys_hg_prompt_info() {
+	# make sure this is a hg dir
+	if [ -d '.hg' ]; then
+		echo -n "${YS_VCS_PROMPT_PREFIX1}hg${YS_VCS_PROMPT_PREFIX2}"
+		echo -n $(hg branch 2>/dev/null)
+		if [ -n "$(hg status 2>/dev/null)" ]; then
+			echo -n "$YS_VCS_PROMPT_DIRTY"
+		else
+			echo -n "$YS_VCS_PROMPT_CLEAN"
+		fi
+		echo -n "$YS_VCS_PROMPT_SUFFIX"
+	fi
+}
 
 # Prompt format: \n # USER at MACHINE in DIRECTORY on git:BRANCH STATE [TIME] \n $ 
 PROMPT="
@@ -29,6 +52,7 @@ PROMPT="
 %{$fg[green]%}$(box_name) \
 %{$fg[white]%}in \
 %{$terminfo[bold]$fg[yellow]%}${current_dir}%{$reset_color%}\
+${hg_info}\
 ${git_info} \
 %{$fg[white]%}[%*]
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"
@@ -41,6 +65,7 @@ PROMPT="
 %{$fg[green]%}$(box_name) \
 %{$fg[white]%}in \
 %{$terminfo[bold]$fg[yellow]%}${current_dir}%{$reset_color%}\
+${hg_info}\
 ${git_info} \
 %{$fg[white]%}[%*]
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"


### PR DESCRIPTION
This small change basically lets the `ys` theme use hg repo info, in addition to the git info it already supports. We don't use vcs_info because all we want to know is if the repo is clean or dirty.

Original Git implementation:
![screen shot 2014-08-13 at 11 59 08 pm](https://cloud.githubusercontent.com/assets/251281/3906412/b615e472-22f2-11e4-91c1-1bf6ee2df644.png)
![screen shot 2014-08-13 at 11 59 20 pm](https://cloud.githubusercontent.com/assets/251281/3906413/b61726ac-22f2-11e4-8f5c-2ad053e0a231.png)

New HG implementation:
![screen shot 2014-08-13 at 11 58 39 pm](https://cloud.githubusercontent.com/assets/251281/3906415/beffbf86-22f2-11e4-8d2b-7dc12595948e.png)
![screen shot 2014-08-13 at 11 58 49 pm](https://cloud.githubusercontent.com/assets/251281/3906416/bf67ce28-22f2-11e4-9599-dd5ed87fed64.png)


I haven't done much in the shell, so please let me know if there are any issues!