### PR TITLE
web-search plugin: unwanted output to nohup.out

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -37,8 +37,7 @@ function web_search() {
   done
 
   url="${url%?}" # remove the last '+'
-  nohup $open_cmd "$url" 
- 	rm nohup.out	
+  nohup $open_cmd "$url" &>/dev/null </dev/null &
 }
 
 


### PR DESCRIPTION
When calling `google something`, a warning appears and it ask to remove nohup.out (interactive rm enabled).
This fix avoid creating nohup.out

    nohup: ignoring input and appending output to ‘nohup.out’
    rm: remove regular empty file ‘nohup.out’?