### PR TITLE
removed trailing "; " of default $command from tab function.

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -6,7 +6,7 @@
 # ------------------------------------------------------------------------------
 
 function tab() {
-  local command="cd \\\"$PWD\\\"; clear; "
+  local command="cd \\\"$PWD\\\"; clear"
   (( $# > 0 )) && command="${command}; $*"
 
   the_app=$(


### PR DESCRIPTION
If it is there, iterm puts the command there, but does not execute it.

I made this mod and the function tab() works on iTerm as it should.

Thanks.