### PR TITLE
Add Cygwin support to web_search

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -5,6 +5,8 @@ function web_search() {
   local open_cmd
   if [[ "$OSTYPE" = darwin* ]]; then
     open_cmd='open'
+  elif [[ "$OSTYPE" = cygwin ]]; then
+    open_cmd='cygstart'
   else
     open_cmd='xdg-open'
   fi


### PR DESCRIPTION
This fixes the following error when running `google`, `bing`, etc. commands under Cygwin: `nohup: failed to run command 'xdg-open': No such file or directory`