### PR TITLE
Fix unquoted var borking with "setopt shwordsplit" & whitespace

### DIFF
--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -108,7 +108,7 @@ function _per-directory-history-change-directory() {
 }
 
 function _per-directory-history-addhistory() {
-  print -Sr -- ${1%%$'\n'}
+  print -Sr -- "${1%%$'\n'}"
   fc -p $_per_directory_history_directory
 }
 


### PR DESCRIPTION
When I needed zsh to do wordsplitting Bourne-style (using "setopt shwordsplit") oh-my-zsh borked on an unquoted var. This fixes it.
