### PR TITLE
Add an alias for 'git fetch'

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -15,6 +15,8 @@ alias gup='git pull --rebase'
 compdef _git gup=git-fetch
 alias gp='git push'
 compdef _git gp=git-push
+alias gfe='git fetch'
+compdef _git gfe=git-fetch
 alias gd='git diff'
 gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff


### PR DESCRIPTION
Since 'gf' is used by git-flow, use 'gfe' instead.