### PR TITLE
[plugins/tmux] Allow passing arbitrary options through to tmux

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -58,6 +58,10 @@ if which tmux &> /dev/null
 	# Wrapper function for tmux.
 	function _zsh_tmux_plugin_run()
 	{
+		# Construct options.
+		[[ "$ZSH_TMUX_ITERM2"  == "true" ]] && tmux_options+=("-CC")
+		[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_options+=("-f" "$_ZSH_TMUX_FIXED_CONFIG")
+
 		# We have other arguments, just run them
 		if [[ -n "$@" ]]
 		then
@@ -65,11 +69,11 @@ if which tmux &> /dev/null
 		# Try to connect to an existing session.
 		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
 		then
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+			\tmux $tmux_options attach || \tmux $tmux_options new-session
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		# Just run tmux, fixing the TERM variable if requested.
 		else
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+			\tmux $tmux_options
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		fi
 	}

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -24,6 +24,8 @@ if which tmux &> /dev/null
 	[[ -n "$ZSH_TMUX_FIXTERM" ]] || ZSH_TMUX_FIXTERM=true
 	# Set '-CC' option for iTerm2 tmux integration
 	[[ -n "$ZSH_TMUX_ITERM2" ]] || ZSH_TMUX_ITERM2=false
+	# Extra options to pass through to tmux
+	[[ -n "$ZSH_TMUX_OPTIONS" ]] || ZSH_TMUX_OPTIONS=""
 	# The TERM to use for non-256 color terminals.
 	# Tmux states this should be screen, but you may need to change it on
 	# systems without the proper terminfo
@@ -59,6 +61,7 @@ if which tmux &> /dev/null
 	function _zsh_tmux_plugin_run()
 	{
 		# Construct options.
+		tmux_options=($ZSH_TMUX_OPTIONS)
 		[[ "$ZSH_TMUX_ITERM2"  == "true" ]] && tmux_options+=("-CC")
 		[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_options+=("-f" "$_ZSH_TMUX_FIXED_CONFIG")
 


### PR DESCRIPTION
I use this in combination with e.g. `ZSH_TMUX_OPTIONS='-2'` in my `~/.zshrc`.
