### PR TITLE
sudo: maintain cursor position

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -13,9 +13,8 @@
 # ------------------------------------------------------------------------------
 
 sudo-command-line() {
-[[ -z $BUFFER ]] && zle up-history
-[[ $BUFFER != sudo\ * ]] && BUFFER="sudo $BUFFER"
-zle end-of-line 
+    [[ -z $BUFFER ]] && zle up-history
+    [[ $BUFFER != sudo\ * ]] && LBUFFER="sudo $LBUFFER"
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]


### PR DESCRIPTION
I.e. when prefixing the current command-line with 'sudo ' maintain the
current cursor position instead of jumping to the end of the line.

This takes advantage of the fact that LBUFFER always contains all text left of the cursor and also happens to contain all text at the start of the buffer currently being edited.