### PR TITLE
Fix AWS plugin overriding currently set RPROMPT

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -14,9 +14,16 @@ function agp {
 }
 function asp {
   export AWS_DEFAULT_PROFILE=$1
-    export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
-    
 }
+
+# Makes AWS profile info available to shell prompt. Inspired by git_prompt_info()
+function aws_prompt_info {
+	if [[ -n $(echo $AWS_DEFAULT_PROFILE) ]]; 
+	then
+		echo "$ZSH_THEME_AWS_PROFILE_PREFIX$AWS_DEFAULT_PROFILE$ZSH_THEME_AWS_PROFILE_SUFFIX"
+	fi
+}
+
 function aws_profiles {
   reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))
 }


### PR DESCRIPTION
If RPROMPT is set by a theme, this plugin will rudely override it once an AWS profile is loaded.
This PR adds a function, following the git_prompt_info() pattern, that can be used in a theme to display the currently loaded AWS profile wherever suitable.
