### PR TITLE
Rails plugin: renamed 'ss' alias to 'sstat' (to avoid collision with /bin/ss).

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -59,7 +59,7 @@ alias rn='rake notes'
 alias rr='rake routes'
 
 # legacy stuff
-alias ss='thin --stats "/thin/stats" start'
+alias sstat='thin --stats "/thin/stats" start'
 alias sg='ruby script/generate'
 alias sd='ruby script/destroy'
 alias sp='ruby script/plugin'


### PR DESCRIPTION
I renamed the 'ss' alias in the ruby plugin to avoid collision with /bin/ss