### PR TITLE
virtualenvwrapper: Deactivate only if in virtualenv

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -38,7 +38,7 @@ if (( $+commands[$virtualenvwrapper] )); then
                 source $ENV_NAME/bin/activate && export CD_VIRTUAL_ENV="$ENV_NAME"
               fi
             fi
-          elif [ $CD_VIRTUAL_ENV ]; then
+          elif [[ -n $CD_VIRTUAL_ENV && -n $VIRTUAL_ENV ]]; then
             # We've just left the repo, deactivate the environment
             # Note: this only happens if the virtualenv was activated automatically
             deactivate && unset CD_VIRTUAL_ENV


### PR DESCRIPTION
If user manually deactivates the virtualenv when using this mode, zsh
will produce following error:

    deactivate:12: command not found: virtualenv_deactivate

To avoid this, check that the VIRTUAL_ENV flag is set before trying to
automatically deactivate the virtual environment.

Fixes #2185