### PR TITLE
The executable command on Mac OSX is 'ack' rather than 'ack-grep'.

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -18,7 +18,12 @@ alias _='sudo'
 alias please='sudo'
 
 ## more intelligent acking for ubuntu users
-alias afind='ack-grep -il'
+if which ack-grep > /dev/null;
+then
+  alias afind='ack-grep -il'
+else
+  alias afind='ack -il'
+fi
 
 # only define LC_CTYPE if undefined
 if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then


### PR DESCRIPTION
I have tested it on my Mac, and Ubuntu 14.04 in the virtual box.