### PR TITLE
Add alias for git add --verbose

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -44,6 +44,7 @@ alias ga='git add'
 alias gaa='git add --all'
 alias gapa='git add --patch'
 alias gau='git add --update'
+alias gav='git add --verbose'
 alias gap='git apply'
 
 alias gb='git branch'


### PR DESCRIPTION
Add alias `gav='git add -v'`
fixes #6793