### PR TITLE
Update alias of for Atom

### DIFF
--- a/plugins/atom/atom.plugin.zsh
+++ b/plugins/atom/atom.plugin.zsh
@@ -6,9 +6,9 @@ _atom_paths=(
 
 for _atom_path in $_atom_paths; do
     if [[ -a $_atom_path ]]; then
-        alias at="open -a '$_atom_path'"
+        alias a="open -a '$_atom_path'"
         break
     fi
 done
 
-alias att='at .'
+alias att='a .'


### PR DESCRIPTION
### Refactor at alias for Atom

*at* command is already use on MacOS for jobs handling.

I just change at to *a* alias. 
