### PR TITLE
Change trash function to follow osx naming convention

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -145,7 +145,7 @@ function trash() {
     if [[ -e "$item" ]]; then
       item_name="$(basename $item)"
       if [[ -e "${trash_dir}/${item_name}" ]]; then
-        mv -f "$item" "${trash_dir}/${item_name} $(date "+%H-%M-%S")"
+        mv -f "$item" "${trash_dir}/${item_name:r} $(date "+%l.%M.%S %p" | sed 's/^ *//')${item_name#${item_name:r}}"
       else
         mv -f "$item" "${trash_dir}/"
       fi


### PR DESCRIPTION
Changes the `osx` plugin's `trash` function to follow the file naming conventions used when trashing from Finder. 

For example, a file called `filename.ext` trashed at 16:42:04 will become `filename 4.42.04 PM.ext` to avoid naming conflicts if `filename.ext` already exists in the trash. A file `filename` with no extension likewise will become `filename 4.42.04 PM`.