### PR TITLE
Bundle exec berks and rubocop

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -25,6 +25,7 @@ bundled_commands=(
   rainbows
   rake
   rspec
+  rubocop
   shotgun
   sidekiq
   spec

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -7,6 +7,7 @@ alias bi="bundle_install"
 
 bundled_commands=(
   annotate
+  berks
   cap
   capify
   cucumber


### PR DESCRIPTION
Adds berks and rubocop to the list of commands bundle exec'ed by default. The commit logs explain the rationale, but I'll repeat here for convenience:

 == Add berks to the bundled_commands list ==
knife and kitchen are already included, and almost everyone who uses
those tools also makes use of berks for chef cookbook management.

== Add rubocop to the list of bundled_commands ==
Tailor is already in the list for ruby style and syntax checking, but
rubocop has far surpassed it in popularity and is a better default.
On github, rubocop currently has 10x-20x the contributors, forks, and
stars.
