### PR TITLE
Fixed ssh-agent plugin when ssh-add is not in /usr/bin/ssh-add

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,13 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/ssh-add $HOME/.ssh/${^identities}
+  if [ $(command -v ssh-add 2>/dev/null) ]; then
+    SSH_ADD=ssh-add
+  else
+    SSH_ADD=/usr/bin/ssh-add
+  fi
+
+  $SSH_ADD $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from


### PR DESCRIPTION
On NixOS, for example, **ssh-add** might reside in **/run/current-system/sw/bin/ssh-add**.  Better that we try to grab it by name and allow for **PATH** resolution before resorting to an absolute path.