### PR TITLE
avoided unnecessary git call from `git_prompt_status`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -79,7 +79,7 @@ function git_prompt_long_sha() {
 
 # Get the status of the working tree
 git_prompt_status() {
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
+  INDEX=$(command git status --porcelain -b 2> /dev/null) || return 1
   STATUS=""
   if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"


### PR DESCRIPTION
The primary use of `git_prompt_status` is in prompts, which demands that the function should be as fast as possible. Taking an early exit from this function on non-git directories saves around `60ms` on my machine for every prompt that is rendered.
