### PR TITLE
gitstatus.py incorrectly parse git status for some config

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -24,14 +24,14 @@ if error:
 lines = output.splitlines()
 
 behead_re = re.compile(
-    r"^# Your branch is (ahead of|behind) '(.*)' by (\d+) commit")
-diverge_re = re.compile(r"^# and have (\d+) and (\d+) different")
+    r"^(?:# )?Your branch is (ahead of|behind) '(.*)' by (\d+) commit")
+diverge_re = re.compile(r"^(?:# )?and have (\d+) and (\d+) different")
 
 status = ''
-staged = re.compile(r'^# Changes to be committed:$', re.MULTILINE)
-changed = re.compile(r'^# Changed but not updated:$', re.MULTILINE)
-untracked = re.compile(r'^# Untracked files:$', re.MULTILINE)
-unmerged = re.compile(r'^# Unmerged paths:$', re.MULTILINE)
+staged = re.compile(r'^(?:# )?Changes to be committed:$', re.MULTILINE)
+changed = re.compile(r'^(?:# )?Changes not staged for commit:$', re.MULTILINE)
+untracked = re.compile(r'^(?:# )?Untracked files:$', re.MULTILINE)
+unmerged = re.compile(r'^(?:# )?Unmerged paths:$', re.MULTILINE)
 
 
 def execute(*command):


### PR DESCRIPTION
On my machine (Ubuntu 14.04 with zsh and git 2.0), there is no '#' at the start of each lines of git status.
But the regexp defined in gitstatus.py expect them to know the state of the repo. The regex should also accept output without these.

 to test, you can use dogenpunk theme for exemple.

