### PR TITLE
Added portable sed command for OpenBSD/NetBSD

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -25,12 +25,14 @@ echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[
 cp $ZSH/templates/zshrc.zsh-template ~/.zshrc
 sed -e "/^ZSH=/ c\\
 ZSH=$ZSH
-" ~/.zshrc | tee ~/.zshrc
+" ~/.zshrc > ~/.zshrc.omztemplate
+mv -f ~/.zshrc.omztemplate ~/.zshrc
 
 echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
 sed -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
-" ~/.zshrc | tee ~/.zshrc
+" ~/.zshrc > ~/.zshrc.newpath
+mv -f ~/.zshrc.newpath ~/.zshrc
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -23,14 +23,14 @@ fi
 
 echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[0m"
 cp $ZSH/templates/zshrc.zsh-template ~/.zshrc
-sed -i -e "/^ZSH=/ c\\
+sed -e "/^ZSH=/ c\\
 ZSH=$ZSH
-" ~/.zshrc
+" ~/.zshrc | tee ~/.zshrc
 
 echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
-sed -i -e "/export PATH=/ c\\
+sed -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
-" ~/.zshrc
+" ~/.zshrc | tee ~/.zshrc
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"


### PR DESCRIPTION
Standard sed, which is used on OpenBSD and NetBSD, doesn't have the "-i" option
