### PR TITLE
Add the environment variable DISABLE_CMD_AUTO_TITLE 

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -24,6 +24,9 @@ function omz_termsupport_precmd {
 
 #Appears at the beginning of (and during) of command execution
 function omz_termsupport_preexec {
+  if [[ "$DISABLE_CMD_AUTO_TITLE" == "true" ]]; then
+    return
+  fi
   emulate -L zsh
   setopt extended_glob
 

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -19,8 +19,11 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to disable colors in ls.
 # DISABLE_LS_COLORS="true"
 
-# Uncomment the following line to disable auto-setting terminal title.
+# Uncomment the following line to disable auto-setting terminal title in any way.
 # DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to disable auto-setting running commands in the terminal title.
+# DISABLE_CMD_AUTO_TITLE="true"
 
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"


### PR DESCRIPTION
This will be handy for those that only want to see pwd in their window and tab titles.