### PR TITLE
Xcode plugin: Fix finding in same directory as .xcasset

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -1,12 +1,12 @@
 #xc function courtesy of http://gist.github.com/subdigital/5420709
 function xc {
-  xcode_proj=`ls | grep "\.xc" | sort -r | head -1`
+  xcode_proj=`ls | grep -G "\.xc[w|o]" | sort -r | head -1`
   if [[ `echo -n $xcode_proj | wc -m` == 0 ]]
   then
     echo "No xcworkspace/xcodeproj file found in the current directory."
   else
-    echo "Found $xcode_proj" 
-    open "$xcode_proj" 
+    echo "Found $xcode_proj"
+    open "$xcode_proj"
   fi
 }
 


### PR DESCRIPTION
You probably should not have xcassets in root, where project is. But in that eventuality, xc will not find project but .xcassets folder. This pull request fixes that.