### PR TITLE
aws: Also set AWS_PROFILE for boto tool support

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -13,8 +13,9 @@ function agp {
   
 }
 function asp {
+  export AWS_PROFILE=$1
   export AWS_DEFAULT_PROFILE=$1
-    export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
+  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
     
 }
 function aws_profiles {


### PR DESCRIPTION
boto tools like s3cat don't respect AWS_DEFAULT_PROFILE. This
change sets the appropriate environment for both, assuming your
boto profiles are defined somewhere. You can build boto creds 
in ~/.aws/credentials by running something like:

cp ~/.aws/config ~/.aws/credentials
sed -i 's/profile //g' ~/.aws/credentials

On OSX, replace the sed command with:

sed -i '' 's/profile //g' ~/.aws/credentials