### PR TITLE
Fixed: sudo plugin interfering with vim-mode + cursor position #3141

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -13,9 +13,8 @@
 # ------------------------------------------------------------------------------
 
 sudo-command-line() {
-[[ -z $BUFFER ]] && zle up-history
-[[ $BUFFER != sudo\ * ]] && BUFFER="sudo $BUFFER"
-zle end-of-line 
+    [[ -z $BUFFER ]] && zle up-history
+    [[ $BUFFER != sudo\ * ]] && LBUFFER="sudo $LBUFFER"
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -17,5 +17,5 @@ sudo-command-line() {
     [[ $BUFFER != sudo\ * ]] && LBUFFER="sudo $LBUFFER"
 }
 zle -N sudo-command-line
-# Defined shortcut keys: [Esc] [Esc]
-bindkey "\e\e" sudo-command-line
+# Defined shortcut keys: Ctrl+_
+bindkey "^_" sudo-command-line


### PR DESCRIPTION
This patch alters the sudo-plugin's bindkey for sudo-command-line, which is eating up the `ESC` key used on vim-mode to enter command mode.

The *bug* only affects people using vim-mode; the *fix* changes the bindkey to `C-_`. 

Guess this needs design decision, for keeping compatibility between the two modes.

incorporates #3141
replaces #2522