### PR TITLE
Background notifications on long-running commands

### DIFF
--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -13,6 +13,7 @@ Just add bgnotify to your plugins list in your `.zshrc`
 - On OS X you'll need [terminal-notifer](https://github.com/alloy/terminal-notifier)
   * `brew install terminal-notifier` (or `gem install terminal-notifier`)
 - On ubuntu you're already all set!
+- On windows you can use [notifu](http://www.paralint.com/projects/notifu/) or the Cygwin Ports libnotify package
 
 
 ## Configuration
@@ -36,4 +37,3 @@ function bgnotify_formatted {
 plugins=(git bgnotify)  ## add to plugins list
 source $ZSH/oh-my-zsh.sh  ## existing source call
 ~~~
-

--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -16,6 +16,21 @@ Just add bgnotify to your plugins list in your `.zshrc`
 - On windows you can use [notifu](http://www.paralint.com/projects/notifu/) or the Cygwin Ports libnotify package
 
 
+## Screenshots
+
+**Linux**
+
+![screenshot from 2014-11-07 15 58 36](https://cloud.githubusercontent.com/assets/326829/4962187/256b465c-66da-11e4-927d-cc2fc105e31f.png)
+
+**OS X**
+
+![screenshot 2014-11-08 14 15 12](https://cloud.githubusercontent.com/assets/326829/4965780/19fa3eac-6795-11e4-8ed6-0355711123a9.png)
+
+**Windows**
+
+![screenshot from 2014-11-07 15 55 00](https://cloud.githubusercontent.com/assets/326829/4962159/a2625ca0-66d9-11e4-9e91-c5834913190e.png)
+
+
 ## Configuration
 
 One can configure a few things:

--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -1,0 +1,39 @@
+# bgnotify zsh plugin
+
+cross-platform background notifications for long running commands! Supports OSX and Ubuntu linux.
+
+Standalone homepage: [t413/zsh-background-notify](https://github.com/t413/zsh-background-notify)
+
+----------------------------------
+
+## How to use!
+
+Just add bgnotify to your plugins list in your `.zshrc`
+
+- On OS X you'll need [terminal-notifer](https://github.com/alloy/terminal-notifier)
+  * `brew install terminal-notifier` (or `gem install terminal-notifier`)
+- On ubuntu you're already all set!
+
+
+## Configuration
+
+One can configure a few things:
+
+- `bgnotify_threshold` sets the notification threshold time (default 6 seconds)
+- `function bgnotify_formatted` lets you change the notification
+
+Use these by adding a function definition before the your call to source. Example:
+
+~~~ sh
+bgnotify_threshold=4  ## set your own notification threshold
+
+function bgnotify_formatted {
+  ## $1=exit_status, $2=command, $3=elapsed_time
+  [ $1 -eq 0 ] && title="Holy Smokes Batman!" || title="Holy Graf Zeppelin!"
+  bgnotify "$title -- after $3 s" "$2";
+}
+
+plugins=(git bgnotify)  ## add to plugins list
+source $ZSH/oh-my-zsh.sh  ## existing source call
+~~~
+

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -1,0 +1,65 @@
+#!/usr/bin/env zsh
+
+
+## setup ##
+
+[[ -o interactive ]] || return #interactive only!
+zmodload zsh/datetime || { print "can't load zsh/datetime"; return } # faster than date()
+autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
+
+(( ${+bgnotify_threshold} )) || bgnotify_threshold=5 #default 10 seconds
+
+
+## definitions ##
+
+if ! (type notify_formatted | grep -q 'function'); then
+  echo "using default notify_formatted"
+  function bgnotify_formatted {
+    ## exit_status, command, elapsed_time
+    [ $1 -eq 0 ] && title="#win (took $3 s)" || title="#fail (took $3 s)"
+    bgnotify "$title" "$2"
+  }
+fi
+
+currentWindowId () {
+  if hash notify-send 2>/dev/null; then #ubuntu!
+    xprop -root | awk '/NET_ACTIVE_WINDOW/ { print $5; exit }'
+  elif hash osascript 2>/dev/null; then #osx
+    osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null
+  fi
+}
+
+bgnotify () {
+  if hash notify-send 2>/dev/null; then #ubuntu!
+    notify-send $1 $2
+  elif hash terminal-notifier 2>/dev/null; then #osx
+    terminal-notifier -message $2 -title $1
+  elif hash growlnotify 2>/dev/null; then #osx growl
+    growlnotify -m $1 $2
+  fi
+}
+
+
+## Zsh hooks ##
+
+bgnotify_begin() {
+  bgnotify_timestamp=$EPOCHSECONDS
+  bgnotify_lastcmd=$1
+  bgnotify_windowid=$(currentWindowId)
+}
+
+bgnotify_end() {
+  didexit=$?
+  elapsed=$(( $EPOCHSECONDS - $bgnotify_timestamp ))
+  past_threshold=$(( $elapsed >= $bgnotify_threshold ))
+  if (( bgnotify_timestamp > 0 )) && (( past_threshold )); then
+    if [ $(currentWindowId) != "$bgnotify_windowid" ]; then
+      print -n "\a"
+      bgnotify_formatted "$didexit" "$bgnotify_lastcmd" "$elapsed"
+    fi
+  fi
+  bgnotify_timestamp=0 #reset it to 0!
+}
+
+add-zsh-hook preexec bgnotify_begin
+add-zsh-hook precmd bgnotify_end

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -13,7 +13,6 @@ autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 ## definitions ##
 
 if ! (type notify_formatted | grep -q 'function'); then
-  echo "using default notify_formatted"
   function bgnotify_formatted {
     ## exit_status, command, elapsed_time
     [ $1 -eq 0 ] && title="#win (took $3 s)" || title="#fail (took $3 s)"
@@ -50,8 +49,8 @@ bgnotify_begin() {
 
 bgnotify_end() {
   didexit=$?
-  elapsed=$(( $EPOCHSECONDS - $bgnotify_timestamp ))
-  past_threshold=$(( $elapsed >= $bgnotify_threshold ))
+  elapsed=$(( EPOCHSECONDS - bgnotify_timestamp ))
+  past_threshold=$(( elapsed >= bgnotify_threshold ))
   if (( bgnotify_timestamp > 0 )) && (( past_threshold )); then
     if [ $(currentWindowId) != "$bgnotify_windowid" ]; then
       print -n "\a"

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -25,6 +25,8 @@ currentWindowId () {
     xprop -root | awk '/NET_ACTIVE_WINDOW/ { print $5; exit }'
   elif hash osascript 2>/dev/null; then #osx
     osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null
+  else
+    echo $EPOCHSECONDS #fallback for windows
   fi
 }
 

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -12,7 +12,7 @@ autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
 ## definitions ##
 
-if ! (type notify_formatted | grep -q 'function'); then
+if ! (type bgnotify_formatted | grep -q 'function'); then
   function bgnotify_formatted {
     ## exit_status, command, elapsed_time
     [ $1 -eq 0 ] && title="#win (took $3 s)" || title="#fail (took $3 s)"

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -24,7 +24,7 @@ currentWindowId () {
   if hash notify-send 2>/dev/null; then #ubuntu!
     xprop -root | awk '/NET_ACTIVE_WINDOW/ { print $5; exit }'
   elif hash osascript 2>/dev/null; then #osx
-    osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null
+    osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
   else
     echo $EPOCHSECONDS #fallback for windows
   fi

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -35,6 +35,8 @@ bgnotify () {
     terminal-notifier -message $2 -title $1
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m $1 $2
+  elif hash notifu 2>/dev/null; then #cygwyn support!
+    notifu /m "$2" /p "$1"
   fi
 }
 


### PR DESCRIPTION
Get background notifications for long running commands! *Running a build? A deploy? Moving files?* Anything that takes more than 6 seconds (easily configurable) sends you a slick and unobtrusive system notification: 

![screenshot 2014-11-08 14 15 12](https://cloud.githubusercontent.com/assets/326829/4965780/19fa3eac-6795-11e4-8ed6-0355711123a9.png)

It works with osx notification center (using terminal-notifier), ubuntu's native `notify-send`, and cygwin:

**Linux**
![screenshot from 2014-11-07 15 58 36](https://cloud.githubusercontent.com/assets/326829/4962187/256b465c-66da-11e4-927d-cc2fc105e31f.png)

**Windows**
![screenshot from 2014-11-07 15 55 00](https://cloud.githubusercontent.com/assets/326829/4962159/a2625ca0-66d9-11e4-9e91-c5834913190e.png)

It supports having a custom message hook (in case you need it to say 'holy smokes batman' for example).

There are a few hacks to do the same thing-- often making heavy use of AppleScript and being very platform-spesefic. This plugin makes a point to run on all three major platforms. 