### PR TITLE
[web-search] Redirect output of nohup command to /dev/null

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -37,8 +37,7 @@ function web_search() {
   done
 
   url="${url%?}" # remove the last '+'
-  nohup $open_cmd "$url" 
- 	rm nohup.out	
+  nohup $open_cmd "$url"&> /dev/null& 
 }
 
 


### PR DESCRIPTION
This will remove the somewhat unnecessary "appending to nohup.out" message.
