### PR TITLE
do not reset LC_CTYPE to LANG

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -11,5 +11,3 @@ setopt long_list_jobs
 ## pager
 export PAGER="less"
 export LESS="-R"
-
-export LC_CTYPE=$LANG


### PR DESCRIPTION
under osx, where LANG is null, it leads to LC_CTYPE='C', which drop some issues which utf8 files.