### PR TITLE
Improved ant completion

### DIFF
--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -1,6 +1,6 @@
 _ant_does_target_list_need_generating () {
   [ ! -f .ant_targets ] && return 0;
-  [ .ant_targets -nt build.xml ] && return 0;
+  [ build.xml -nt .ant_targets ] && return 0;
   return 1;
 }
 

--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -9,7 +9,7 @@ _ant () {
     if _ant_does_target_list_need_generating; then
     	ant -p | awk -F " " 'NR > 5 { print lastTarget }{lastTarget = $1}' > .ant_targets
     fi
-    compadd `cat .ant_targets`
+    compadd -- `cat .ant_targets`
   fi
 }
 

--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -7,7 +7,7 @@ _ant_does_target_list_need_generating () {
 _ant () {
   if [ -f build.xml ]; then
     if _ant_does_target_list_need_generating; then
-     sed -n '/<target/s/<target.*name="\([^"]*\).*$/\1/p' build.xml > .ant_targets
+    	ant -p | awk -F " " 'NR > 5 { print lastTarget }{lastTarget = $1}' > .ant_targets
     fi
     compadd `cat .ant_targets`
   fi


### PR DESCRIPTION
Fix regenerating .ant_targets on most tab completions (which made ant support sloooow). 
Also make ant do the work of enumerating targets which fixes edge cases.

Note that this change does make it so that "internal" targets (those with no description) are no longer shown, which could possibly be considered a breaking change. I'd argue this is good though, as `ant -projecthelp` also doesn't output these.

closes #1827