### PR TITLE
Fix homebrew directory in aws plugin

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -22,7 +22,7 @@ function aws_profiles {
 compctl -K aws_profiles asp
 
 if _homebrew-installed && _awscli-homebrew-installed ; then
-  _aws_zsh_completer_path=$(brew --prefix)/opt/awscli/libexec/bin/aws_zsh_completer.sh
+  _aws_zsh_completer_path=$(brew --prefix awscli)/libexec/bin/aws_zsh_completer.sh
 else
   _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi


### PR DESCRIPTION
Sometimes the output of ``homebrew --prefix`` and ``homebrew --prefix
awscli`` don't match, and the second is the correct call.