### PR TITLE
Fix get_command_list for recent composer versions

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -7,7 +7,7 @@
 
 # Composer basic command completion
 _composer_get_command_list () {
-	composer --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	composer --no-ansi | sed "1,/Available commands/d" | awk '/^\s*[a-z]+/ { print $1 }'
 }
 
 _composer_get_required_list () {


### PR DESCRIPTION
Hi,

I encountered a problem with composer command completion after updating composer to its latest version. The command list printed by composer had a different indentation, so I changed the regex to be more tolerant regarding the indentation.