### PR TITLE
Modified battery gauge to allow custom chars

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -91,7 +91,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
   }
 
   function battery_pct_prompt() {
-    b=$(battery_pct_remaining) 
+    b=$(battery_pct_remaining)
     if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
       if [ $b -gt 50 ] ; then
         color='green'
@@ -135,6 +135,11 @@ function battery_level_gauge() {
 
   local battery_remaining_percentage=$(battery_pct);
 
+  if [ "$1" ] && [ "$2" ]; then
+    filled_symbol=${BATTERY_GAUGE_FILLED_SYMBOL:-$1};
+    empty_symbol=${BATTERY_GAUGE_EMPTY_SYMBOL:-$2};
+  fi
+
   if [[ $battery_remaining_percentage =~ [0-9]+ ]]; then
     local filled=$(((( $battery_remaining_percentage + $gauge_slots - 1) / $gauge_slots)));
     local empty=$(($gauge_slots - $filled));
@@ -149,12 +154,10 @@ function battery_level_gauge() {
     filled_symbol=${BATTERY_UNKNOWN_SYMBOL:-'.'};
   fi
 
-  local charging=' ' && battery_is_charging && charging=$charging_symbol;
+  local charging=' ' && battery_is_charging && charging=$charging_symbol' ';
 
   printf ${charging_color//\%/\%\%}$charging${color_reset//\%/\%\%}${battery_prefix//\%/\%\%}${gauge_color//\%/\%\%}
   printf ${filled_symbol//\%/\%\%}'%.0s' {1..$filled}
   [[ $filled -lt $gauge_slots ]] && printf ${empty_symbol//\%/\%\%}'%.0s' {1..$empty}
   printf ${color_reset//\%/\%\%}${battery_suffix//\%/\%\%}${color_reset//\%/\%\%}
 }
-
-

--- a/themes/jarvis.zsh-theme
+++ b/themes/jarvis.zsh-theme
@@ -1,0 +1,70 @@
+###########################################
+# Jarvis oh-my-zsh theme                  #
+# Original Author: Jack Spirou            #
+# Email: jack.spirou@me.com               #
+###########################################
+
+#### SOURCES ####
+# shortcut color code
+# https://github.com/ethervoid/dotfiles/blob/master/zsh/jarvis.zsh-theme~
+#
+# original idea code
+# https://github.com/andrew8088/oh-my-zsh/blob/master/themes/doubleend.zsh-theme
+
+# Color shortcuts
+RED=$fg[red]
+YELLOW=$fg[yellow]
+GREEN=$fg[green]
+WHITE=$fg[white]
+BLUE=$fg[blue]
+CYAN=$fg[cyan]
+RED_BOLD=$fg_bold[red]
+YELLOW_BOLD=$fg_bold[yellow]
+GREEN_BOLD=$fg_bold[green]
+WHITE_BOLD=$fg_bold[white]
+BLUE_BOLD=$fg_bold[blue]
+RESET_COLOR=$reset_color
+
+# Format for git_prompt_info()
+ZSH_THEME_GIT_PROMPT_PREFIX=""
+ZSH_THEME_GIT_PROMPT_SUFFIX=""
+
+# Format for parse_git_dirty()
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$RED%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=" %{$GREEN%}"
+
+# Format for git_prompt_status()
+ZSH_THEME_GIT_PROMPT_UNMERGED=" %{$RED%}unmerged"
+ZSH_THEME_GIT_PROMPT_DELETED=" %{$RED%}deleted"
+ZSH_THEME_GIT_PROMPT_RENAMED=" %{$YELLOW%}renamed"
+ZSH_THEME_GIT_PROMPT_MODIFIED=" %{$YELLOW%}modified"
+ZSH_THEME_GIT_PROMPT_ADDED=" %{$GREEN%}added"
+ZSH_THEME_GIT_PROMPT_UNTRACKED=" %{$WHITE%}untracked"
+
+# Format for git_prompt_ahead()
+ZSH_THEME_GIT_PROMPT_AHEAD=" %{$RED%}(!)"
+
+# Format for git_prompt_long_sha() and git_prompt_short_sha()
+ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$WHITE%}[%{$YELLOW%}"
+ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$WHITE%}]"
+
+# Define git info
+function git_prompt_info() {
+  ref=$(git symbolic-ref HEAD 2> /dev/null) || return
+  echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+}
+
+# Define get pwd
+function get_pwd() {
+  print -D $PWD
+}
+
+# Define pre command text.  Note: The format below is intended
+function precmd() {
+print -rP '
+$CYAN%m: $YELLOW$(get_pwd)'
+}
+
+# Define prompt vars
+PROMPT='%{$reset_color%}→ '
+RPROMPT='${return_status}$(git_prompt_info) $(battery_level_gauge ■ □)%{$reset_color%}'


### PR DESCRIPTION
This request adds a couple lines to the battery gauge function allowing theme creators to add their own unicode characters for full and empty.  This is useful if you want squares instead of triangles, like I did for the Jarvis theme.  

It is important to note that this change doesn't affect any other themes.  The default battery gauge character values are still triangles. 

I removed the theme from this pull request after seeing the ask in the project README to do so.