### PR TITLE
dircycle plugin: clean and fix logic once and for all

### DIFF
--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -1,10 +1,27 @@
-##
-# dircycle plugin: enables cycling through the directory
-# stack using Ctrl+Shift+Left/Right
+# enables cycling through the directory stack using
+# Ctrl+Shift+Left/Right
+#
+# left/right direction follows the order in which directories
+# were visited, like left/right arrows do in a browser
 
-eval "insert-cycledleft () { zle push-line; LBUFFER='pushd -q +1'; zle accept-line }"
+# NO_PUSHD_MINUS syntax:
+#  pushd +N: start counting from left of `dirs' output
+#  pushd -N: start counting from right of `dirs' output
+setopt nopushdminus
+
+insert-cycledleft () {
+	zle push-line
+	LBUFFER='pushd -q +1'
+	zle accept-line
+}
 zle -N insert-cycledleft
-bindkey "\e[1;6D" insert-cycledleft
-eval "insert-cycledright () { zle push-line; LBUFFER='pushd -q +0'; zle accept-line }"
+
+insert-cycledright () {
+	zle push-line
+	LBUFFER='pushd -q -0'
+	zle accept-line
+}
 zle -N insert-cycledright
+
+bindkey "\e[1;6D" insert-cycledleft
 bindkey "\e[1;6C" insert-cycledright

--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -7,15 +7,20 @@
 # NO_PUSHD_MINUS syntax:
 #  pushd +N: start counting from left of `dirs' output
 #  pushd -N: start counting from right of `dirs' output
-setopt nopushdminus
 
 insert-cycledleft () {
+	emulate -L zsh
+	setopt nopushdminus
+
 	builtin pushd -q +1 &>/dev/null || true
 	zle reset-prompt
 }
 zle -N insert-cycledleft
 
 insert-cycledright () {
+	emulate -L zsh
+	setopt nopushdminus
+
 	builtin pushd -q -0 &>/dev/null || true
 	zle reset-prompt
 }

--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -10,16 +10,14 @@
 setopt nopushdminus
 
 insert-cycledleft () {
-	zle push-line
-	LBUFFER='pushd -q +1'
-	zle accept-line
+	builtin pushd -q +1 &>/dev/null || true
+	zle reset-prompt
 }
 zle -N insert-cycledleft
 
 insert-cycledright () {
-	zle push-line
-	LBUFFER='pushd -q -0'
-	zle accept-line
+	builtin pushd -q -0 &>/dev/null || true
+	zle reset-prompt
 }
 zle -N insert-cycledright
 

--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -26,5 +26,12 @@ insert-cycledright () {
 }
 zle -N insert-cycledright
 
-bindkey "\e[1;6D" insert-cycledleft
-bindkey "\e[1;6C" insert-cycledright
+
+# add key bindings for iTerm2
+if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+	bindkey "^[[1;6D" insert-cycledleft
+	bindkey "^[[1;6C" insert-cycledright
+else
+	bindkey "\e[1;6D" insert-cycledleft
+	bindkey "\e[1;6C" insert-cycledright
+fi


### PR DESCRIPTION
## STATUS: ready

#### Description

This pull request fixes the error introduced in #3395, which changes `pushd -q -0` to `pushd -q +0`, which doesn't do anything unless you have the `pushd_minus` option set. But, if that's the case, then `pushd -q +1` doesn't work correctly. 

To that end I standardised that option since it seems to change between different zsh setups. You can read more in the [`PUSHD_MINUS` section of the `zshoptions` manpage](http://zsh.sourceforge.net/Doc/Release/Options.html#index-PUSHDMINUS).

I also removed the evals and cleaned up the plugin a little bit. 

#### RFC (Request For Comments)

##### 1. Fast switch
I added in commit d63120501ed924b801774359fb3e8be902cbd0e5 the hability to switch between directories and redraw the prompt without using a new line to run the `pushd` command. 
Here are a couple of screencasts showcasing the difference:
  - [Current switch (**old** version)](https://asciinema.org/a/15264): 
![dircycle slow-switch](https://cloud.githubusercontent.com/assets/1441704/5599081/3c0a486e-92c1-11e4-9567-0d416d6cc351.gif)

  - [Fast switch (**new** version)](https://asciinema.org/a/15265): 
![dircycle fast-switch](https://cloud.githubusercontent.com/assets/1441704/5599077/285ff340-92c1-11e4-9d95-0dd070556a74.gif)

**Please comment what you think about this new behavior**.

##### 2. Left/right switch direction
Finally the chosen behavior for left/right is (see https://github.com/robbyrussell/oh-my-zsh/pull/3413#issuecomment-67987390): 
  
  - `CTRL`+`SHIFT`+`LEFT `: moves to last visited directory
  - `CTRL`+`SHIFT`+`RIGHT`: moves to next visited directory

the previous behavior seemed a little odd an unintuitive to me:
  
  - `CTRL`+`SHIFT`+`LEFT `: moves to directory on the left as appears in `dirs` output
  - `CTRL`+`SHIFT`+`RIGHT`: moves to directory on the right
  
**Please comment which direction you think is better**.

----
Close #1566
Close #2134
Close #2101
Close #2474