### PR TITLE
[Plugin: cake] switch newer-than logic to get the desired behavior

### DIFF
--- a/plugins/cake/cake.plugin.zsh
+++ b/plugins/cake/cake.plugin.zsh
@@ -15,7 +15,7 @@ _cake_does_target_list_need_generating () {
 	fi
 
 	[ ! -f ${_cake_task_cache_file} ] && return 0;
-	[ ${_cake_task_cache_file} -nt Cakefile ] && return 0;
+	[ Cakefile -nt ${_cake_task_cache_file} ] && return 0;
 	return 1;
 }
 


### PR DESCRIPTION
See https://github.com/robbyrussell/oh-my-zsh/pull/1655#issuecomment-67301041 for context.

----
In the old version, the function returned true (0) if the cache file was newer than the Cakefile, which was *always* unless the Cakefile had been updated. Therefore we generated the file every time unless the Cakefile was updated, which was precisely when we needed to regenerate the cache file.

Now it generates the cache file only when the Cakefile has been updated.