### PR TITLE
Enhance history alias

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -32,7 +32,6 @@ HISTSIZE=10000
 SAVEHIST=10000
 
 ## History command configuration
-setopt append_history         # append history to HISTFILE on session exit
 setopt extended_history       # record timestamp of command in HISTFILE
 setopt hist_expire_dups_first # delete duplicates first when HISTFILE size exceeds HISTSIZE
 setopt hist_ignore_dups       # ignore duplicated commands history list

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -6,7 +6,7 @@ function omz_history {
     echo -n >| "$HISTFILE"
     echo >&2 History file deleted. Reload the session to see its effects.
   else
-    fc $@ -l 1
+    builtin fc "$@" -l 1
   fi
 }
 

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -6,12 +6,24 @@ fi
 HISTSIZE=10000
 SAVEHIST=10000
 
-# Show history
+## History wrapper
+function omz_history {
+  # Delete the history file if `-c' argument provided.
+  # This won't affect the `history' command output until the next login.
+  if [[ "${@[(i)-c]}" -le $# ]]; then
+    echo -n >| "$HISTFILE"
+    echo >&2 History file deleted. Reload the session to see its effects.
+  else
+    fc $@ -l 1
+  fi
+}
+
+# Timestamp format
 case $HIST_STAMPS in
-  "mm/dd/yyyy") alias history='fc -fl 1' ;;
-  "dd.mm.yyyy") alias history='fc -El 1' ;;
-  "yyyy-mm-dd") alias history='fc -il 1' ;;
-  *) alias history='fc -l 1' ;;
+  "mm/dd/yyyy") alias history='omz_history -f' ;;
+  "dd.mm.yyyy") alias history='omz_history -E' ;;
+  "yyyy-mm-dd") alias history='omz_history -i' ;;
+  *) alias history='omz_history' ;;
 esac
 
 setopt append_history

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -5,6 +5,8 @@ function omz_history {
   if [[ "${@[(i)-c]}" -le $# ]]; then
     echo -n >| "$HISTFILE"
     echo >&2 History file deleted. Reload the session to see its effects.
+  elif [[ "${@[(i)-l]}" -le $# ]]; then
+    builtin fc "$@"
   else
     builtin fc "$@" -l 1
   fi

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -2,12 +2,18 @@
 function omz_history {
   # Delete the history file if `-c' argument provided.
   # This won't affect the `history' command output until the next login.
-  if [[ "${@[(i)-c]}" -le $# ]]; then
+  zparseopts -E c=clear l=list
+
+  if [[ -n "$clear" ]]; then
+    # if -c provided, clobber the history file
     echo -n >| "$HISTFILE"
     echo >&2 History file deleted. Reload the session to see its effects.
-  elif [[ "${@[(i)-l]}" -le $# ]]; then
+  elif [[ -n "$list" ]]; then
+    # if -l provided, run as if calling `fc' directly
     builtin fc "$@"
   else
+    # otherwise, call `fc -l 1` to show all available
+    # history (and pass additional parameters)
     builtin fc "$@" -l 1
   fi
 }

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -28,7 +28,7 @@ esac
 
 ## History file configuration
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
-HISTSIZE=10000
+HISTSIZE=50000
 SAVEHIST=10000
 
 ## History command configuration

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -1,8 +1,5 @@
 ## Command history configuration
-if [ -z "$HISTFILE" ]; then
-    HISTFILE=$HOME/.zsh_history
-fi
-
+[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
 HISTSIZE=10000
 SAVEHIST=10000
 

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -1,8 +1,3 @@
-## Command history configuration
-[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
-HISTSIZE=10000
-SAVEHIST=10000
-
 ## History wrapper
 function omz_history {
   # Delete the history file if `-c' argument provided.
@@ -23,11 +18,17 @@ case $HIST_STAMPS in
   *) alias history='omz_history' ;;
 esac
 
-setopt append_history
-setopt extended_history
-setopt hist_expire_dups_first
-setopt hist_ignore_dups # ignore duplication command history list
-setopt hist_ignore_space
-setopt hist_verify
-setopt inc_append_history
-setopt share_history # share command history data
+## History file configuration
+[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
+HISTSIZE=10000
+SAVEHIST=10000
+
+## History command configuration
+setopt append_history         # append history to HISTFILE on session exit
+setopt extended_history       # record timestamp of command in HISTFILE
+setopt hist_expire_dups_first # delete duplicates first when HISTFILE size exceeds HISTSIZE
+setopt hist_ignore_dups       # ignore duplicated commands history list
+setopt hist_ignore_space      # ignore commands that start with space
+setopt hist_verify            # show command with history expansion to user before running it
+setopt inc_append_history     # add commands to HISTFILE in order of execution
+setopt share_history          # share command history data


### PR DESCRIPTION
Allow passing in other `fc` arguments (complain in #789) and provides a simple workaround to the lack of `history -c`-like command (as seen in #739).

I also reorganized the script a little bit and removed the `append_history` ~~and `hist_verify` which seem to not be good defaults.~~ I've put it back in because at this point that's the expected behavior. Use `unsetopt hist_verify` in your zshrc files if you want to disable it.
