### PR TITLE
termsupport: Move DISABLE_AUTO_TITLE check to hooks

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -1,9 +1,16 @@
-#usage: title short_tab_title looooooooooooooooooooooggggggg_windows_title
-#http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
-#Fully support screen, iterm, and probably most modern xterm and rxvt
-#Limited support for Apple Terminal (Terminal can't set window or tab separately)
+# Set terminal window and tab/icon title
+#
+# usage: title short_tab_title [long_window_title]
+#
+# See: http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
+# Fully supports screen, iterm, and probably most modern xterm and rxvt
+# (In screen, only short_tab_title is used)
+# Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
-  if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
+  if [[ $2 == "" ]]; then
+    2="$1"
+  fi
+  if [[ "$EMACS" == *term* ]]; then
     return
   fi
   if [[ "$TERM" == screen* ]]; then
@@ -17,13 +24,21 @@ function title {
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
-#Appears when you have the prompt
+# Called when you have a prompt
 function omz_termsupport_precmd {
+  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+    return
+  fi
+
   title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 }
 
-#Appears at the beginning of (and during) of command execution
+# Called at the beginning of command execution
 function omz_termsupport_preexec {
+  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+    return
+  fi
+
   emulate -L zsh
   setopt extended_glob
 

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -24,7 +24,7 @@ function title {
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
-# Called when you have a prompt
+# Runs before showing the prompt
 function omz_termsupport_precmd {
   # Notify Terminal.app of current directory using undocumented OSC sequence
   # found in OS X 10.9 and 10.10's /etc/bashrc
@@ -41,7 +41,7 @@ function omz_termsupport_precmd {
 
 }
 
-# Called at the beginning of command execution
+# Runs before executing the command
 function omz_termsupport_preexec {
   if [[ $DISABLE_AUTO_TITLE == true ]]; then
     return


### PR DESCRIPTION
This moves the DISABLE_AUTO_TITLE check from title() itself to the precmd/preexec hook functions that call it. It also allows single-argument use by defaulting the long window title ($2) to the short icon title ($1).

I'd like to do this because it would allow the title() function to be used directly by the user or other callers. In my workflow, I like to set the terminal tab title manually, and had my own settitle() function set up to do that. The OMZ title() function is already out there in the global function namespace, so it makes more sense to do that.

This arrangement of the check in the hooks was discussed in https://github.com/robbyrussell/oh-my-zsh/pull/266 but dismissed as DRY/not needed for performance. But I think it's worth reconsidering: this isn't for performance, but an interface/functionality change that makes title() more useful.

Also reformatted the comments to match comments in other OMZ lib/*.zsh files.