### PR TITLE
Add aliases for DNF package manager.

### DIFF
--- a/plugins/dnf/dnf.plugin.zsh
+++ b/plugins/dnf/dnf.plugin.zsh
@@ -1,0 +1,15 @@
+## Aliases
+
+alias dns="dnf search"                       # search package
+alias dnp="dnf info"                         # show package info
+alias dnl="dnf list"                         # list packages
+alias dngl="dnf group list"                  # list package groups
+alias dnli="dnf list installed"              # print all installed packages
+alias dnmc="dnf makecache"                   # rebuilds the yum package list
+
+alias dnu="sudo dnf upgrade"                 # upgrate packages
+alias dni="sudo dnf install"                 # install package
+alias dngi="sudo dnf group install"          # install package group
+alias dne="sudo dnf erase"                   # remove package
+alias dngr="sudo dnf group remove"           # remove pagage group
+alias dnc="sudo dnf clean all"               # clean cache


### PR DESCRIPTION
DNF is the new YUM replacement as the default package manager in Fedora moving forward.