### PR TITLE
termsupport: add chpwd hook for setting pwd in Apple Terminal.app

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -1,7 +1,6 @@
 #usage: title short_tab_title looooooooooooooooooooooggggggg_windows_title
 #http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
 #Fully support screen, iterm, and probably most modern xterm and rxvt
-#Limited support for Apple Terminal (Terminal can't set window or tab separately)
 function title {
   if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
     return
@@ -10,7 +9,7 @@ function title {
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
-    print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
+    print -Pn "\e]1;$1:q\a" #set icon (=tab) name
   fi
 }
 
@@ -34,5 +33,18 @@ function omz_termsupport_preexec {
   title '$CMD' '%100>...>$LINE%<<'
 }
 
+#Appears each time pwd is changed
+function omz_termsupport_chpwd {
+  #Notify Terminal.app of current directory using undocumented OSC sequence
+  #found in OS X 10.10's /etc/bashrc
+  if [[ $TERM_PROGRAM == Apple_Terminal ]] && [[ -z $INSIDE_EMACS ]]; then
+    local PWD_URL="file://$HOSTNAME${PWD// /%20}"
+    printf '\e]7;%s\a' "$PWD_URL"
+  fi
+}
+#Fire it once so the pwd is set properly upon shell startup
+omz_termsupport_chpwd
+
 precmd_functions+=(omz_termsupport_precmd)
 preexec_functions+=(omz_termsupport_preexec)
+chpwd_functions+=(omz_termsupport_chpwd)


### PR DESCRIPTION
In termsupport, add a chpwd hook that notifies Apple Terminal.app of current working directory changes using the undocumented '\e]7;%s\a' sequence, instead of the normal window/icon title controls. 

Fixes https://github.com/robbyrussell/oh-my-zsh/issues/2646, letting new tabs always open in the correct directory.

This is done using chpwd_functions instead of the prompt/preexec hooks and is intentionally not controlled by DISABLE_AUTO_TITLE, so the directory is properly updated even when auto-titling is off (e.g. when user is setting window and icon titles themself).