### PR TITLE
Removing trash command from osx plugin

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -137,23 +137,6 @@ function man-preview() {
   man -t "$@" | open -f -a Preview
 }
 
-function trash() {
-  local trash_dir="${HOME}/.Trash"
-  local temp_ifs="$IFS"
-  IFS=$'\n'
-  for item in "$@"; do
-    if [[ -e "$item" ]]; then
-      item_name="$(basename $item)"
-      if [[ -e "${trash_dir}/${item_name}" ]]; then
-        mv -f "$item" "${trash_dir}/${item_name} $(date "+%H-%M-%S")"
-      else
-        mv -f "$item" "${trash_dir}/"
-      fi
-    fi
-  done
-  IFS=$temp_ifs
-}
-
 function vncviewer() {
   open vnc://$@
 }


### PR DESCRIPTION
Current **trash** command implementation from osx plugin has a bunch of issues:

1. It does not have “Put Back” feature (Fixes #3038).
2. It does not rename files correctly whether we already have file with the same name in the Trash (Fixes #3195, #3038).
3. It does not move file to proper trash on multiple drives systems (Closes #3421).
4. It overrides trash command from http://hasseg.org/trash/ implementation and requires additional workaround to work with osx plugin.

@Kriechi has suggested https://github.com/robbyrussell/oh-my-zsh/pull/3038#issuecomment-52826550 to remove trash command from plugin in favor of binary trash and afair you have agreed to remove it, but it still exists.

So here is the magic PR. :blush: