### PR TITLE
sublime: Make subl a function so it can be called from functions in other modules

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -31,7 +31,7 @@ elif  [[ "$OSTYPE" = darwin* ]]; then
 
     for _sublime_path in $_sublime_darwin_paths; do
         if [[ -a $_sublime_path ]]; then
-            alias subl="'$_sublime_path'"
+            subl () { "$_sublime_path" $* }
             alias st=subl
             break
         fi


### PR DESCRIPTION
Without this change, whether a function can invoke 'subl' depends on the order in which modules are loaded. With this change, the order doesn't matter.

zsh resolves aliases at parse time not run time, which means if you invoke an alias from a function, the alias must be defined before the function.

See http://stackoverflow.com/a/25532276/893113 which refers to an explanation of this limitation.

For code which may be used non-interactively, the recommend workaround is to use functions instead of aliases.