### PR TITLE
Smoother way of changing default login shell back to bash on uninstall

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -20,9 +20,24 @@ then
 
   source ~/.zshrc;
 else
-  echo "Switching back to bash"
+  echo "Changing default login shell from zsh back to bash ... login required."
   chsh -s /bin/bash
-  source /etc/profile
+  if [ "$?" = "0" ]; then
+    echo "Done.  All new shell windows will be bash!"
+    printf "Replace this zsh window with a bash window right now? (yes/no): "
+    read CHOICE
+    if [ "$CHOICE" = "yes" ]; then
+      echo "OK, please login again below ... if something goes wrong you can \
+always close this window and start a new bash window."
+      exec su - $USER
+    else
+      break
+    fi
+  else
+    echo "Oops, something went wrong with the change to bash ... \
+you can execute chsh -s /bin/bash manually and start a new window"
+    break
+  fi
 fi
 
-echo "Thanks for trying out Oh My Zsh. It's been uninstalled."
+echo -e "\nThanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
The current uninstall script attempts to `chsh -s /bin/bash` to change the default login shell for the user back to `bash`.  But `chsh -s /bin/bash` requires user login, and the script cannot deal with login failure or any disruption to the command.  The main change, in general terms, is to check the exit code of `chsh -s /bin/bash` and to prompt the user more appropriately in case of success or failure of the login.  A minor change is to remove the command `source /etc/profile`.  This is because, as [explained here](https://github.com/robbyrussell/oh-my-zsh/issues/3447), according to the [OS X bash man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/bash.1.html) `/etc/profile` is sourced first after `bash` is invoked as an interactive login shell (or a non-interactive login shell with the `--login` option).  So having done `chsh -s /bin/bash` the user would be expected to open either a new window from their terminal app or close and reopen their terminal app, which will start an interactive login `bash` shell that will source `/etc/profile` first.  Thus this is unnecessary in the uninstall script.

In the case of success `chsh -s /bin/bash` will reset the `UserShell` attribute of the user’s record in the OS X Directory Services database for their local domain node `.` back to `/bin/bash`, but this change is not immediately reflected in the working shell window (in which the uninstall script was executed).  So the change here specifically involves asking the user whether they would like to do this, and dealing with the two different possibilities.

These changes are self-explanatory, but could be improved even further - for example, an assumption is made that the user wants to default back to `/bin/bash` but perhaps they do not, or perhaps they do not care because they have specified a specific shell type and path in their terminal app, or they do not wish to default to `bash` but another one of the accepted shells in `/etc/shells`.  For the moment thought these changes should make the uninstallation process less painful and the script easier to maintain and debug.

Note: the default login shell for a local domain user, from the point of OS X, is determined not by environment variables like `SHELL` or the shell preferences in Terminal.app but the value of the `UserShell` attribute of the user's record in the OS X Directory Services database for the their local domain node `.`.  Moreover executing `chsh -s <shell path>` in the active shell window will in fact change this attribute directly but the change will not be visible immediately unless a new shell window is opened or the session restarted or with a command like `exec su - $USER`.