### PR TITLE
Add support for just complete existant commands.

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -35,6 +35,8 @@ cdpath=(.)
 zstyle ':completion::complete:*' use-cache 1
 zstyle ':completion::complete:*' cache-path $ZSH/cache/
 
+zstyle ':completion:*' rehash true
+
 # Don't complete uninteresting users
 zstyle ':completion:*:*:*:users' ignored-patterns \
         adm amanda apache at avahi avahi-autoipd beaglidx bin cacti canna \


### PR DESCRIPTION
Fixes #3440

Following Marc idea I create a pull request for add rehash support, so only autocomplete works only with present commands. I believe there is no regression.