### PR TITLE
Provide downloaded scripts checksums for security

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,11 +18,25 @@ You can install this via the command-line with either @curl@ or @wget@.
 
 h4. via @curl@:
 
-@curl -L http://install.ohmyz.sh | sh@
+@curl -L http://install.ohmyz.sh > ohmyz.sh@
+@openssl sha256 ohmyz.sh@
+
+Verify that the checksum is correct:
+@SHA256(ohmyz.sh)= ad4290f1234ced4f9f344868422e194764d076255df806d90a6bb5bc96c77fb9@
+
+Then run:
+@sh ohmyz.sh@
 
 h4. via @wget@:
 
-@wget --no-check-certificate http://install.ohmyz.sh -O - | sh@
+@wget --no-check-certificate http://install.ohmyz.sh -O ohmyz.sh@
+@openssl sha256 ohmyz.sh@
+
+Verify that the checksum is correct:
+@SHA256(ohmyz.sh)= ad4290f1234ced4f9f344868422e194764d076255df806d90a6bb5bc96c77fb9@
+
+Then run:
+@sh ohmyz.sh@
 
 h4. *Optionally*, change the install directory:
 


### PR DESCRIPTION
As reported in #3459, the README file suggests an insecure download and
execution via HTTP instead of HTTPS.

However, before this essential migration to HTTPS is completed, this
patch adds checksums that will allow users to verify the authenticity of
their download.

The authenticity of the checksums is assured because it will be viewed
on an HTTPS-served GitHub page on the correct author username
(robbyrussell).

I have verified this checksum by downloading the HTTP script from two
different network topologies:

1. The Google corporate network
2. The Linode network

I also visually verified that the script code is not malicious. I have
also compared it with the HTTPS-served script at this location and found
it to be identical:

https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh

This comes from an HTTPS connection from a valid GitHub domain which
ensures that the owner (robbyrussell) has pushed this file as long as we
trust GitHub and PKI.

This commit is signed with my personal GPG key for authenticity.

The reviewer should also verify the checksum is correct.

Thanks for helping keep users secure.

Fixes #3459