### PR TITLE
[Plugin composer] Multiple fixes

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -41,9 +41,12 @@ compdef _composer composer.phar
 alias c='composer'
 alias csu='composer self-update'
 alias cu='composer update'
+alias cr='composer require'
 alias ci='composer install'
 alias ccp='composer create-project'
 alias cdu='composer dump-autoload'
+alias cgu='composer global update'
+alias cgr='composer global require'
 
 # install composer in the current directory
 alias cget='curl -s https://getcomposer.org/installer | php'

--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -20,18 +20,15 @@ _composer () {
   _arguments \
     '1: :->command'\
     '*: :->args'
-  if [ -f composer.json ]; then
-    case $state in
-      command)
-        compadd `_composer_get_command_list`
-        ;;
-      *)
-        compadd `_composer_get_required_list`
-        ;;
-    esac
-  else
-    compadd create-project init search selfupdate show
-  fi
+
+  case $state in
+    command)
+      compadd $(_composer_get_command_list)
+      ;;
+    *)
+      compadd $(_composer_get_required_list)
+      ;;
+  esac
 }
 
 compdef _composer composer

--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -7,11 +7,11 @@
 
 # Composer basic command completion
 _composer_get_command_list () {
-	composer --no-ansi | sed "1,/Available commands/d" | awk '/^\s*[a-z]+/ { print $1 }'
+    $_comp_command1 --no-ansi | sed "1,/Available commands/d" | awk '/^\s*[a-z]+/ { print $1 }'
 }
 
 _composer_get_required_list () {
-    composer show -s --no-ansi | sed '1,/requires/d' | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }'
+    $_comp_command1 show -s --no-ansi | sed '1,/requires/d' | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }'
 }
 
 _composer () {
@@ -35,6 +35,7 @@ _composer () {
 }
 
 compdef _composer composer
+compdef _composer composer.phar
 
 # Aliases
 alias c='composer'

--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -7,7 +7,7 @@
 
 # Composer basic command completion
 _composer_get_command_list () {
-	composer --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	composer --no-ansi | sed "1,/Available commands/d" | awk '/^\s*[a-z]+/ { print $1 }'
 }
 
 _composer_get_required_list () {


### PR DESCRIPTION
### STATUS: ready!
-------
This pull request is a compilation of the following:

- #2000: use `$_comp_command1` instead of `composer` to allow using `composer.phar` command; also complete `composer.phar` commands as well.
- #2049: add `composer global` aliases.
- #3375: little change in awk regular expression to parse composer commands in newer versions.

Also, I removed the requisite of having a `composer.json` file in the working directory to show composer commands. This I did because, as it was before, commands in the else statement weren't all that were available to run. Now, all commands will be shown instead (deprecates #2143).
**If no one agrees with this change I can get rid of it**.

Fix #2000, fix #2049, fix #3375.
Close #2143.
Close #3514, #3555.