### PR TITLE
Allow filtering automatically sourced configs

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -8,6 +8,20 @@ fi
 # add a function path
 fpath=($ZSH/functions $ZSH/completions $fpath)
 
+# Load all of the config files in ~/oh-my-zsh that end in .zsh
+# TIP: Add files you don't want in git to .gitignore
+maybe_source() {
+  local config_base=$(basename $1)
+  local config_file="${config_base%.*}"
+  if [[ ${ignored_configs[(r)$config_file]} != $config_file ]]; then
+      source $1
+  fi
+}
+
+for config_file ($ZSH/lib/*.zsh); do
+  maybe_source $config_file
+done
+
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$ZSH_CUSTOM" ]]; then


### PR DESCRIPTION
By specifying `ignored_configs` in your .zshrc file you can ignore
certain configs completely.

Useful for when a certain configuration causes problems on your system.
