### PR TITLE
Setup `grep` alias lazily through a function

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -7,13 +7,14 @@ _setup_grep_alias() {
         echo | grep $1 "" >/dev/null 2>&1
     }
 
+    local GREP_OPTIONS
     # Color grep results.
-    local GREP_OPTIONS="--color=auto"
+    GREP_OPTIONS=(--color=auto)
 
     if grep-flag-available --exclude-dir=.cvs; then
-        GREP_OPTIONS+=" --exclude-dir=$VCS_FOLDERS"
+        GREP_OPTIONS+=(--exclude-dir=$VCS_FOLDERS)
     elif grep-flag-available --exclude=.cvs; then
-        GREP_OPTIONS+=" --exclude=$VCS_FOLDERS"
+        GREP_OPTIONS+=(--exclude=$VCS_FOLDERS)
     fi
 
     # Re-define alias.

--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -2,15 +2,14 @@
 VCS_FOLDERS="{.bzr,.cvs,.git,.hg,.svn}"
 
 _setup_grep_alias() {
-    # Is grep argument $1 available?
-    grep-flag-available() {
-        echo | grep $1 "" >/dev/null 2>&1
-    }
-
     local GREP_OPTIONS
     # Color grep results.
     GREP_OPTIONS=(--color=auto)
 
+    # Is grep argument $1 available?
+    grep-flag-available() {
+        echo | grep $1 "" >/dev/null 2>&1
+    }
     if grep-flag-available --exclude-dir=.cvs; then
         GREP_OPTIONS+=(--exclude-dir=$VCS_FOLDERS)
     elif grep-flag-available --exclude=.cvs; then

--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -15,14 +15,23 @@ _setup_grep_alias() {
     elif grep-flag-available --exclude=.cvs; then
         GREP_OPTIONS+=(--exclude=$VCS_FOLDERS)
     fi
-
-    # Re-define alias.
-    alias grep="grep $GREP_OPTIONS"
-
     # Clean up.
     unfunction grep-flag-available
 
+    # Remove alias and setup function.
+    unalias grep
+    setopt localoptions norcexpandparam
+    eval "grep() {
+        local options
+        options=(${(@)GREP_OPTIONS})
+        # Add '-r' if grepping a dir.
+        if [[ -d \$@[\$#] ]]; then
+            options+=(-r)
+        fi
+        command grep \$options \"\$@\"
+    }"
+
     # Run it on first invocation.
-    command grep $GREP_OPTIONS "$@"
+    grep $GREP_OPTIONS "$@"
 }
 alias grep=_setup_grep_alias

--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -22,5 +22,8 @@ _setup_grep_alias() {
 
     # Clean up.
     unfunction grep-flag-available
+
+    # Run it on first invocation.
+    command grep $GREP_OPTIONS "$@"
 }
 alias grep=_setup_grep_alias

--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -1,24 +1,25 @@
-# is x grep argument available?
-grep-flag-available() {
-    echo | grep $1 "" >/dev/null 2>&1
-}
-
-# color grep results
-GREP_OPTIONS="--color=auto"
-
-# ignore VCS folders (if the necessary grep flags are available)
+# Ignore VCS folders (if the necessary grep flags are available).
 VCS_FOLDERS="{.bzr,.cvs,.git,.hg,.svn}"
 
-if grep-flag-available --exclude-dir=.cvs; then
-    GREP_OPTIONS+=" --exclude-dir=$VCS_FOLDERS"
-elif grep-flag-available --exclude=.cvs; then
-    GREP_OPTIONS+=" --exclude=$VCS_FOLDERS"
-fi
+_setup_grep_alias() {
+    # Is grep argument $1 available?
+    grep-flag-available() {
+        echo | grep $1 "" >/dev/null 2>&1
+    }
 
-# export grep settings
-alias grep="grep $GREP_OPTIONS"
+    # Color grep results.
+    local GREP_OPTIONS="--color=auto"
 
-# clean up
-unset GREP_OPTIONS
-unset VCS_FOLDERS
-unfunction grep-flag-available
+    if grep-flag-available --exclude-dir=.cvs; then
+        GREP_OPTIONS+=" --exclude-dir=$VCS_FOLDERS"
+    elif grep-flag-available --exclude=.cvs; then
+        GREP_OPTIONS+=" --exclude=$VCS_FOLDERS"
+    fi
+
+    # Re-define alias.
+    alias grep="grep $GREP_OPTIONS"
+
+    # Clean up.
+    unfunction grep-flag-available
+}
+alias grep=_setup_grep_alias


### PR DESCRIPTION
This saves an extra / initial call to `grep` during shell startup.

/cc @mcornella