### PR TITLE
Allow custom cache dir

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -38,7 +38,7 @@ cdpath=(.)
 
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1
-zstyle ':completion::complete:*' cache-path $ZSH/cache/
+zstyle ':completion::complete:*' cache-path $ZSH_CACHE_DIR
 
 # Don't complete uninteresting users
 zstyle ':completion:*:*:*:users' ignored-patterns \

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -14,6 +14,13 @@ if [[ -z "$ZSH_CUSTOM" ]]; then
     ZSH_CUSTOM="$ZSH/custom"
 fi
 
+# Set ZSH_CACHE_DIR to the path where cache files sould be created
+# or else we will use the default cache/
+if [[ -z "$ZSH_CACHE_DIR" ]]; then
+  ZSH_CACHE_DIR="$ZSH/cache/"
+fi
+
+
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
 # TIP: Add files you don't want in git to .gitignore
 for config_file ($ZSH/lib/*.zsh); do

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -4,8 +4,8 @@
 
 # Flag indicating if we've previously jumped to last directory.
 typeset -g ZSH_LAST_WORKING_DIRECTORY
-mkdir -p "$ZSH/cache"
-local cache_file="$ZSH/cache/last-working-dir"
+mkdir -p $ZSH_CACHE_DIR
+local cache_file="$ZSH_CACHE_DIR/last-working-dir"
 
 # Updates the last directory once directory is changed.
 function chpwd() {

--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,7 +1,7 @@
 # reload zshrc
 function src()
 {
-  local cache="$ZSH/cache"
+  local cache=$ZSH_CACHE_DIR
   autoload -U compinit zrecompile
   compinit -d "$cache/zcomp-$HOST"
 


### PR DESCRIPTION
We are running oh-my-zsh on a shared install and the only issue is each
user having a custom cache dir. This will allow us to set the cache dir
to ZSH_CACHE_DIR=~/oh-my-zsh/cache/ .