### PR TITLE
Removing 'local' usage to prevent issue when installed with antigen

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -5,7 +5,7 @@
 # Flag indicating if we've previously jumped to last directory.
 typeset -g ZSH_LAST_WORKING_DIRECTORY
 mkdir -p $ZSH_CACHE_DIR
-local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+cache_file="$ZSH_CACHE_DIR/last-working-dir"
 
 # Updates the last directory once directory is changed.
 function chpwd() {


### PR DESCRIPTION
Error encountered when installed with antigen: "chpwd:2: no such file or directory:".  Solution described in https://github.com/zsh-users/antigen/issues/75