### PR TITLE
Add Fedora support for command-not-found plugin

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -7,3 +7,19 @@
 # Arch Linux command-not-found support, you must have package pkgfile installed
 # https://wiki.archlinux.org/index.php/Pkgfile#.22Command_not_found.22_hook
 [[ -e /usr/share/doc/pkgfile/command-not-found.zsh ]] && source /usr/share/doc/pkgfile/command-not-found.zsh
+
+# Fedora command-not-found support
+if [ -f /usr/libexec/pk-command-not-found ]; then
+    command_not_found_handler () {
+        runcnf=1
+        retval=127
+        [ ! -S /var/run/dbus/system_bus_socket ] && runcnf=0
+        [ ! -x /usr/libexec/packagekitd ] && runcnf=0
+        if [ $runcnf -eq 1 ]
+            then
+            /usr/libexec/pk-command-not-found $@
+            retval=$?
+        fi
+        return $retval
+    }
+fi


### PR DESCRIPTION
Fedora support by comment from [this issue](https://bugzilla.redhat.com/show_bug.cgi?id=678934) to close #3482.

/cc @robbyrussell 