### PR TITLE
Sublime Text plugin: sst alias for sudo run sublime

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -12,6 +12,8 @@ if [[ $('uname') == 'Linux' ]]; then
     for _sublime_path in $_sublime_linux_paths; do
         if [[ -a $_sublime_path ]]; then
             st_run() { $_sublime_path $@ >/dev/null 2>&1 &| }
+            st_run_sudo() {sudo $_sublime_path $@ >/dev/null 2>&1}
+            alias sst=st_run_sudo
             alias st=st_run
             break
         fi


### PR DESCRIPTION
Added alias `sst` (sudo sublime text) for run sublime with root rights