### PR TITLE
Fast installation time by shallow copying git repo

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@ if [ -d "$ZSH" ]; then
 fi
 
 echo "\033[0;34mCloning Oh My Zsh...\033[0m"
-hash git >/dev/null 2>&1 && env git clone https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+hash git >/dev/null 2>&1 && env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
   echo "git not installed"
   exit
 }


### PR DESCRIPTION
Use `--depth=1` to clone just the lastest version rather than every version in git.