### PR TITLE
Fix echo nothing if $SHORT_HOST doesn't exist.

### DIFF
--- a/themes/candy-kingdom.zsh-theme
+++ b/themes/candy-kingdom.zsh-theme
@@ -13,7 +13,7 @@ patches: <patches|join( → )|pre_applied(%{$fg[yellow]%})|post_applied(%{$reset
 }
 
 function box_name {
-    [ -f ~/.box-name ] && cat ~/.box-name || echo $SHORT_HOST || echo $HOST
+    [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-HOST}
 }
 
 PROMPT='

--- a/themes/fino-time.zsh-theme
+++ b/themes/fino-time.zsh-theme
@@ -21,7 +21,7 @@ function prompt_char {
 }
 
 function box_name {
-    [ -f ~/.box-name ] && cat ~/.box-name || echo $SHORT_HOST || echo $HOST
+    [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-HOST}
 }
 
 

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -17,7 +17,7 @@ function prompt_char {
 }
 
 function box_name {
-    [ -f ~/.box-name ] && cat ~/.box-name || echo $SHORT_HOST || echo $HOST
+    [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-HOST}
 }
 
 local ruby_env=''


### PR DESCRIPTION
`echo` doesn't care about empty argument, so, if $SHORT_HOST doesn't exist, it's just print space or so.