### PR TITLE
Update composer.plugin.zsh

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -7,7 +7,7 @@
 
 # Composer basic command completion
 _composer_get_command_list () {
-	composer --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	composer --no-ansi | sed "1,/Available commands/d" | awk '/^ +[a-z]+/ { print $1 }'
 }
 
 _composer_get_required_list () {


### PR DESCRIPTION
In some cases, composer renders a single space before command name.