### PR TITLE
Remove unrecognized '%p' escape sequence from $PROMPT

### DIFF
--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -1,5 +1,5 @@
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
-PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+PROMPT='${ret_status}%{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"


### PR DESCRIPTION
@robbyrussell et al.

In recent versions of `zsh` _(`v5.x.x` and up, AFAICT)_, the `%p` escape sequence is no longer supported in `$PROMPT`.

It appears to have been a date/time placeholder in earlier versions of `zsh`:

```
%p  The 'precise' time of day in 12-hour AM/PM format, with seconds.
```

... but it is no longer recognized, and as such is causing some superfluous spacing in the rendered `$PROMPT`, which disappears once `%p` has been removed:

![remove_p_escape_sequence_from_prompt](https://cloud.githubusercontent.com/assets/17322/5897637/fcaab43a-a53d-11e4-87ee-4b014a219313.png)

I've removed `%p` from `themes/robbyrussell.zsh-theme` only for now, but can also remove it from the other themes in this repo if that would facilitate the acceptance of this pull request :smile:

Thanks!

---

**Addendum** - instead of removing `%p` from the theme/prompt, I just realized that I could have replaced it with a `%D{strftime_compatible_format_string}` escape sequence to achieve a similar result:

```
%D{string}  string is formatted using the `strftime` function. See man page strftime(3) for more details. 
```

Something that comes close to the original `%p` behaviour appears to be:

```
PROMPT="%D{%L:%M:%S %p} "
```

_(although confusingly the `%p` in this prompt is different from the one removed in this pull request)_
