### PR TITLE
Do not use -i (insecure) with compinit

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -54,7 +54,7 @@ fi
 
 # Load and run compinit
 autoload -U compinit
-compinit -i -d "${ZSH_COMPDUMP}"
+compinit -d "${ZSH_COMPDUMP}"
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do


### PR DESCRIPTION
This was added in 99d72ca, to work around warnings with `sudo -s`.

`sudo -s` seems to cause a lot of other issues anyway, where files get
owned by root etc.

I think it's better to be safe by default.

From zsh's man page:

       For security reasons compinit also checks if the completion
       system would use files not owned by root or by the cur‐ rent
       user, or files in directories that are world- or group-writable
       or that are not owned by root or by  the  cur‐ rent  user.   If
       such  files or directories are found, compinit will ask if the
       completion system should really be used.  To avoid these tests
       and make all files found be used without  asking,  use  the
       option  -u,  and  to  make compinit  silently  ignore  all
       insecure  files and directories use the option -i.  This security
       check is skipped entirely when the -C option is given.