### PR TITLE
Changed hard-coded vim to use EDITOR variable

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -13,7 +13,7 @@ alias lS='ls -1FSsh'
 alias lart='ls -1Fcart'
 alias lrt='ls -1Fcrt'
 
-alias zshrc='vim ~/.zshrc' # Quick access to the ~/.zshrc file
+alias zshrc='${EDITOR:-vim} ~/.zshrc' # Quick access to the ~/.zshrc file, using $EDITOR or vim
 
 alias grep='grep --color'
 alias sgrep='grep -R -n -H -C 5 --exclude-dir={.git,.svn,CVS} '


### PR DESCRIPTION
previously zshrc alias called 'vim...'. Changed it to use ${EDITOR:-vim} so it looks for the EDITOR variable (set by in the default .zshrc file) and defaults to vim. Using single quote so updates to EDITOR environmental variable will be used automatically.