### PR TITLE
Only add `--color` to grep's alias if that option is valid.

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -3,8 +3,12 @@ grep-flag-available() {
     echo | grep $1 "" >/dev/null 2>&1
 }
 
+GREP_OPTIONS=""
+
 # color grep results
-GREP_OPTIONS="--color=auto"
+if grep-flag-available --color=auto; then
+    GREP_OPTIONS+="--color=auto"
+fi
 
 # ignore VCS folders (if the necessary grep flags are available)
 VCS_FOLDERS="{.bzr,.cvs,.git,.hg,.svn}"


### PR DESCRIPTION
The option `--color` is not available on all versions of grep. This change verifies that the option is valid before adding it to the alias used by default.

Fixes #3470.