### PR TITLE
Remove duplicate diff alias in git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -15,7 +15,6 @@ alias gup='git pull --rebase'
 compdef _git gup=git-fetch
 alias gp='git push'
 compdef _git gp=git-push
-alias gd='git diff'
 gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 alias gdt='git difftool'
@@ -174,6 +173,3 @@ alias gignore='git update-index --assume-unchanged'
 alias gunignore='git update-index --no-assume-unchanged'
 # list temporarily ignored files
 alias gignored='git ls-files -v | grep "^[[:lower:]]"'
-
-
-


### PR DESCRIPTION
I just came across a duplicate alias for git diff being defined in the git plugin. See [line 6](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/git/git.plugin.zsh#L6) and [line 18](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/git/git.plugin.zsh#L18). Removing the later one.