### PR TITLE
Let autocomplete follow symlinks

### DIFF
--- a/plugins/tmuxinator/_tmuxinator
+++ b/plugins/tmuxinator/_tmuxinator
@@ -27,7 +27,7 @@ case $state in
   args)
     case $line[1] in
       start|open|copy|delete|debug)
-        _configs=(`find ~/.tmuxinator -name \*.yml | cut -d/ -f5 | sed s:.yml::g`)
+        _configs=(`find -L ~/.tmuxinator -name \*.yml | cut -d/ -f5 | sed s:.yml::g`)
         [[ -n "$_configs" ]] && _values 'configs' $_configs
         ret=0
         ;;


### PR DESCRIPTION
Else, tab completion throws errors if ~/.tmuxinator is a symlink
This is actually the PR https://github.com/robbyrussell/oh-my-zsh/pull/2979
which I somehow managed to close via a rebase
