### PR TITLE
Fix Unicode problems by only setting LC_CTYPE if not set

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -9,11 +9,21 @@ setopt long_list_jobs
 export PAGER="less"
 export LESS="-R"
 
-export LC_CTYPE=$LANG
-
 ## super user alias
 alias _='sudo'
 alias please='sudo'
 
 ## more intelligent acking for ubuntu users
 alias afind='ack-grep -il'
+
+## how to interpret text characters
+if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then # only define if undefined
+	export LC_CTYPE=${LANG%%:*}                 # pick the first entry from LANG
+	[[ -z "$LC_CTYPE" ]] && \
+		export LC_CTYPE=`locale -a | grep en_US.utf8 | head -1`
+	[[ -z "$LC_CTYPE" ]] && \
+		export LC_CTYPE=`locale -a | grep en_US | head -1`
+	[[ -z "$LC_CTYPE" ]] && \
+		export LC_CTYPE=C                         # default to internal encoding.
+fi
+

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -16,14 +16,7 @@ alias please='sudo'
 ## more intelligent acking for ubuntu users
 alias afind='ack-grep -il'
 
-## how to interpret text characters
-if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then # only define if undefined
-	export LC_CTYPE=${LANG%%:*}                 # pick the first entry from LANG
-	[[ -z "$LC_CTYPE" ]] && \
-		export LC_CTYPE=`locale -a | grep en_US.utf8 | head -1`
-	[[ -z "$LC_CTYPE" ]] && \
-		export LC_CTYPE=`locale -a | grep en_US | head -1`
-	[[ -z "$LC_CTYPE" ]] && \
-		export LC_CTYPE=C                         # default to internal encoding.
+# only define LC_CTYPE if undefined
+if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then
+	export LC_CTYPE=${LANG%%:*} # pick the first entry from LANG
 fi
-


### PR DESCRIPTION
This temporarily closes #2012 since it provides a complex solution that is possibly not useful. If we still have unicode issues with just this solution, we'll open it again and test it.

In most systems, `LC_CTYPE` will be correctly set while `LANG` will not be set (since it's optional). This generates a lot of messed up prompts and other problems. A cleanup of unicode-related issues will be needed after this gets merged.

/cc @robbyrussell 