### PR TITLE
Repost #2422: cleaning lib

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -4,19 +4,5 @@ alias please='sudo'
 
 #alias g='grep -in'
 
-# Show history
-if [ "$HIST_STAMPS" = "mm/dd/yyyy" ]
-then
-    alias history='fc -fl 1'
-elif [ "$HIST_STAMPS" = "dd.mm.yyyy" ]
-then
-    alias history='fc -El 1'
-elif [ "$HIST_STAMPS" = "yyyy-mm-dd" ]
-then
-    alias history='fc -il 1'
-else
-    alias history='fc -l 1'
-fi
-
 alias afind='ack-grep -il'
 

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -1,8 +1,0 @@
-# Super user
-alias _='sudo'
-alias please='sudo'
-
-#alias g='grep -in'
-
-alias afind='ack-grep -il'
-

--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -1,11 +1,3 @@
-# Push and pop directories on directory stack
-alias pu='pushd'
-alias po='popd'
-
-# Basic directory operations
-alias ...='cd ../..'
-alias -- -='cd -'
-
 # Super user
 alias _='sudo'
 alias please='sudo'
@@ -25,11 +17,6 @@ then
 else
     alias history='fc -l 1'
 fi
-# List direcory contents
-alias lsa='ls -lah'
-alias l='ls -lah'
-alias ll='ls -lh'
-alias la='ls -lAh'
 
 alias afind='ack-grep -il'
 

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -27,7 +27,6 @@ alias lsa='ls -lah'
 alias l='ls -la'
 alias ll='ls -l'
 alias la='ls -lA'
-alias sl=ls # often screw this up
 
 # Push and pop directories on directory stack
 alias pu='pushd'

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -22,7 +22,7 @@ alias md='mkdir -p'
 alias rd=rmdir
 alias d='dirs -v | head -10'
 
-# List direcory contents
+# List directory contents
 alias lsa='ls -lah'
 alias l='ls -la'
 alias ll='ls -l'

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -3,12 +3,10 @@ setopt auto_pushd
 setopt pushd_ignore_dups
 setopt pushdminus
 
-alias ..='cd ..'
-alias cd..='cd ..'
-alias cd...='cd ../..'
-alias cd....='cd ../../..'
-alias cd.....='cd ../../../..'
-alias cd/='cd /'
+alias -g ...='../..'
+alias -g ....='../../..'
+alias -g .....='../../../..'
+alias -g ......='../../../../..'
 
 alias 1='cd -'
 alias 2='cd -2'
@@ -20,23 +18,17 @@ alias 7='cd -7'
 alias 8='cd -8'
 alias 9='cd -9'
 
-cd () {
-  if   [[ "x$*" == "x..." ]]; then
-    cd ../..
-  elif [[ "x$*" == "x...." ]]; then
-    cd ../../..
-  elif [[ "x$*" == "x....." ]]; then
-    cd ../../../..
-  elif [[ "x$*" == "x......" ]]; then
-    cd ../../../../..
-  elif [ -d ~/.autoenv ]; then
-    source ~/.autoenv/activate.sh
-    autoenv_cd "$@"
-  else
-    builtin cd "$@"
-  fi
-}
-
 alias md='mkdir -p'
 alias rd=rmdir
 alias d='dirs -v | head -10'
+
+# List direcory contents
+alias lsa='ls -lah'
+alias l='ls -la'
+alias ll='ls -l'
+alias la='ls -lA'
+alias sl=ls # often screw this up
+
+# Push and pop directories on directory stack
+alias pu='pushd'
+alias po='popd'

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -6,6 +6,15 @@ fi
 HISTSIZE=10000
 SAVEHIST=10000
 
+# Show history
+case $HIST_STAMPS in
+  "mm/dd/yyyy") alias history='fc -fl 1' ;;
+  "dd.mm.yyyy") alias history='fc -El 1' ;;
+  "yyyy-mm-dd") alias history='fc -il 1' ;;
+  *) alias history='fc -l 1' ;;
+esac
+
+setopt append_history
 setopt extended_history
 setopt hist_expire_dups_first
 setopt hist_ignore_dups # ignore duplication command history list

--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -64,6 +64,9 @@ autoload -U edit-command-line
 zle -N edit-command-line
 bindkey '\C-x\C-e' edit-command-line
 
+# file rename magick
+bindkey "^[m" copy-prev-shell-word
+
 # consider emacs keybindings:
 
 #bindkey -e  ## emacs key bindings

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -2,9 +2,6 @@
 autoload -U url-quote-magic
 zle -N self-insert url-quote-magic
 
-## file rename magick
-bindkey "^[m" copy-prev-shell-word
-
 ## jobs
 setopt long_list_jobs
 

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -13,3 +13,10 @@ export PAGER="less"
 export LESS="-R"
 
 export LC_CTYPE=$LANG
+
+## super user alias
+alias _='sudo'
+alias please='sudo'
+
+## more intelligent acking for ubuntu users
+alias afind='ack-grep -il'

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -1,14 +1,13 @@
 # ls colors
-autoload colors; colors;
+autoload -U colors && colors
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
-#export LS_COLORS
 
 # Enable ls colors
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
   if [[ "$(uname -s)" == "NetBSD" ]]; then
-    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
+    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   elif [[ "$(uname -s)" == "OpenBSD" ]]; then
@@ -23,7 +22,7 @@ fi
 #setopt no_beep
 setopt auto_cd
 setopt multios
-setopt cdablevarS
+setopt cdablevars
 
 if [[ x$WINDOW != x ]]
 then
@@ -43,4 +42,3 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is c
 
 # Setup the prompt with pretty colors
 setopt prompt_subst
-

--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -1,6 +1,17 @@
+# Activates autoenv or reports its failure
+if ! source $HOME/.autoenv/activate.sh 2>/dev/null; then
+  echo '-------- AUTOENV ---------'
+  echo 'Could not find ~/.autoenv/activate.sh.'
+  echo 'Please check if autoenv is correctly installed.'
+  echo 'In the meantime the autoenv plugin is DISABLED.'
+  echo '--------------------------'
+  return 1
+fi
+
 # The use_env call below is a reusable command to activate/create a new Python
 # virtualenv, requiring only a single declarative line of code in your .env files.
 # It only performs an action if the requested virtualenv is not the current one.
+
 use_env() {
     typeset venv
     venv="$1"

--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -20,12 +20,6 @@ alias sgrep='grep -R -n -H -C 5 --exclude-dir={.git,.svn,CVS} '
 
 alias t='tail -f'
 
-# because typing 'cd' is A LOT of work!!
-alias ..='cd ../'
-alias ...='cd ../../'
-alias ....='cd ../../../'
-alias .....='cd ../../../../'
-
 # Command line head / tail shortcuts
 alias -g H='| head'
 alias -g T='| tail'

--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -2,9 +2,6 @@
 # http://github.com/olivierverdier/zsh-git-prompt
 #
 export __GIT_PROMPT_DIR=$ZSH/plugins/git-prompt
-# Initialize colors.
-autoload -U colors
-colors
 
 # Allow for functions in the prompt.
 setopt PROMPT_SUBST

--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -27,7 +27,6 @@ unmark() {
 	rm -i "$MARKPATH/$1"
 }
 
-autoload colors
 marks() {
 	for link in $MARKPATH/*(@); do
 		local markname="$fg[cyan]${link:t}$reset_color"

--- a/themes/adben.zsh-theme
+++ b/themes/adben.zsh-theme
@@ -69,17 +69,17 @@ function precmd {
         #Choose from all databases, regardless of whether they are considered "offensive"
         fortune -a
     }
-    #obtains the tip 
+    #obtains the tip
     ps1_command_tip () {
         wget -qO - http://www.commandlinefu.com/commands/random/plaintext | sed 1d | sed '/^$/d'
-    }  
+    }
     prompt_header () {
         if [[ "true" == "$ENABLE_COMMAND_TIP" ]]; then
             ps1_command_tip
         else
             ps1_fortune
-        fi 
-    }   
+        fi
+    }
     PROMPT_HEAD="${RED_START}${PR_YELLOW}$(prompt_header)${PR_RESET}"
     # set a simple variable to show when in screen
     if [[ -n "${WINDOW}" ]]; then
@@ -99,11 +99,8 @@ prompt_context () {
 set_prompt () {
     # required for the prompt
     setopt prompt_subst
-    autoload colors zsh/terminfo
-    if [[ "$terminfo[colors]" -gt 8 ]]; then
-        colors
-    fi 
-    
+    autoload zsh/terminfo
+
     # ######### PROMPT #########
     PROMPT='${PROMPT_HEAD}
 ${RED_START}$(prompt_context)

--- a/themes/apple.zsh-theme
+++ b/themes/apple.zsh-theme
@@ -7,7 +7,6 @@ get_git_dirty() {
 }
 
 autoload -Uz vcs_info
-autoload -U colors && colors
 zstyle ':vcs_info:*' check-for-changes true
 zstyle ':vcs_info:*' unstagedstr '%F{red}*'   # display this when there are unstaged changes
 zstyle ':vcs_info:*' stagedstr '%F{yellow}+'  # display this when there are staged changes

--- a/themes/gnzh.zsh-theme
+++ b/themes/gnzh.zsh-theme
@@ -2,8 +2,7 @@
 # Based on bira theme
 
 # load some modules
-autoload -U colors zsh/terminfo # Used in the colour alias below
-colors
+autoload -U zsh/terminfo # Used in the colour alias below
 setopt prompt_subst
 
 # make some aliases for the colours: (could use normal escape sequences too)

--- a/themes/half-life.zsh-theme
+++ b/themes/half-life.zsh-theme
@@ -13,8 +13,6 @@ function virtualenv_info {
 PR_GIT_UPDATE=1
 
 setopt prompt_subst
-autoload colors
-colors
 
 autoload -U add-zsh-hook
 autoload -Uz vcs_info

--- a/themes/jonathan.zsh-theme
+++ b/themes/jonathan.zsh-theme
@@ -44,10 +44,7 @@ setprompt () {
     ###
     # See if we can use colors.
 
-    autoload colors zsh/terminfo
-    if [[ "$terminfo[colors]" -ge 8 ]]; then
-	colors
-    fi
+    autoload zsh/terminfo
     for color in RED GREEN YELLOW BLUE MAGENTA CYAN WHITE GREY; do
 	eval PR_$color='%{$terminfo[bold]$fg[${(L)color}]%}'
 	eval PR_LIGHT_$color='%{$fg[${(L)color}]%}'

--- a/themes/kolo.zsh-theme
+++ b/themes/kolo.zsh-theme
@@ -1,5 +1,3 @@
-autoload -U colors && colors
-
 autoload -Uz vcs_info
 
 zstyle ':vcs_info:*' stagedstr '%F{green}●'

--- a/themes/mikeh.zsh-theme
+++ b/themes/mikeh.zsh-theme
@@ -1,6 +1,4 @@
 setopt prompt_subst
-autoload colors
-colors
 
 autoload -U add-zsh-hook
 autoload -Uz vcs_info

--- a/themes/simonoff.zsh-theme
+++ b/themes/simonoff.zsh-theme
@@ -63,10 +63,7 @@ setprompt () {
 ###
 # See if we can use colors.
 
-    autoload colors zsh/terminfo
-    if [[ "$terminfo[colors]" -ge 8 ]]; then
-    colors
-    fi
+    autoload zsh/terminfo
     for color in RED GREEN YELLOW BLUE MAGENTA CYAN WHITE; do
     eval PR_$color='%{$terminfo[bold]$fg[${(L)color}]%}'
     eval PR_LIGHT_$color='%{$fg[${(L)color}]%}'

--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -15,8 +15,6 @@ function virtualenv_info {
 PR_GIT_UPDATE=1
 
 setopt prompt_subst
-autoload colors
-colors
 
 autoload -U add-zsh-hook
 autoload -Uz vcs_info

--- a/themes/zhann.zsh-theme
+++ b/themes/zhann.zsh-theme
@@ -1,5 +1,3 @@
-autoload -U colors && colors
-
 autoload -Uz vcs_info
 
 zstyle ':vcs_info:*' stagedstr '%F{green}●'


### PR DESCRIPTION
Repost of #2422 by @LFDM: 

> - Provides a more useful approach to directory switching, as suggested in #2412
> - Deletes aliases.zsh, as almost all things defined in their can find a place in other files present
>   - The directory aliases (some of the which duplicate functionality) are all in directories.zsh
>   - The history alias is in history.zsh. Also refactored to a nicer case switch
>   - Remaining pieces like the please alias for sudo are in misc.zsh
>   - Deletes the .. aliases from the common-aliases plugin, they are in lib anyway
> - Moves a bindkey statement from misc.zsh to key-bindings.zsh
> - Avoids sourcing of autoenv with every call to cd. This plugin related code is also taken out of the lib directory. Its activation file is now sourced only once - if its not present, the user is informed and the plugin disabled.  Overriding cd by hand is not needed, autoenv does this by itself.
> 
> Closes #2412
> Closes #2601

Closes #2422 
Fixes #3491

This also contains the removal of `sl` alias (as per https://github.com/robbyrussell/oh-my-zsh/pull/2422#issuecomment-53995324), and a small cleanup of the `theme-and-appearance.zsh` file as well as redundant `colors` calls in plugins and themes. 

/cc @robbyrussell 