### PR TITLE
Repost #2606: fix git status in rkj-repos theme

### DIFF
--- a/themes/rkj-repos.zsh-theme
+++ b/themes/rkj-repos.zsh-theme
@@ -16,14 +16,15 @@ ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%}✗"
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[blue]%}➦"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[magenta]%}✂"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[grey]%}✈"
+ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$fg[grey]%}"
+ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$reset_color%}"
 
 function mygit() {
-  ref1=$(git symbolic-ref HEAD 2> /dev/null) || return
-  gitdir=$(git rev-parse --git-dir 2> /dev/null) || return
-  heads=($gitdir/refs/heads/*(N)) ; [[ -z $heads ]] && ref2="" || ref2=$(git rev-parse HEAD | head -c 6)
-  ref="$ref1 %{$fg[grey]%}$ref2"
-  #ref=$(git symbolic-ref HEAD 2> /dev/null) $(git rev-parse HEAD | head -c 6) || return
-  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$( git_prompt_status )%{$reset_color%}$ZSH_THEME_GIT_PROMPT_SUFFIX "
+  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+    echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(git_prompt_short_sha)$( git_prompt_status )%{$reset_color%}$ZSH_THEME_GIT_PROMPT_SUFFIX "
+  fi
 }
 
 function retcode() {}

--- a/themes/rkj-repos.zsh-theme
+++ b/themes/rkj-repos.zsh-theme
@@ -19,7 +19,8 @@ ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[grey]%}✈"
 
 function mygit() {
   ref1=$(git symbolic-ref HEAD 2> /dev/null) || return
-  ref2=$(git rev-parse HEAD | head -c 6) || return
+  gitdir=$(git rev-parse --git-dir 2> /dev/null) || return
+  heads=($gitdir/refs/heads/*(N)) ; [[ -z $heads ]] && ref2="" || ref2=$(git rev-parse HEAD | head -c 6)
   ref="$ref1 %{$fg[grey]%}$ref2"
   #ref=$(git symbolic-ref HEAD 2> /dev/null) $(git rev-parse HEAD | head -c 6) || return
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$( git_prompt_status )%{$reset_color%}$ZSH_THEME_GIT_PROMPT_SUFFIX "


### PR DESCRIPTION
From #2606 by @pfault:
> 'git rev-parse HEAD' call without existing commits in repo will fail with error message, breaking the theme

Close #2606 

/cc @robbyrussell 