### PR TITLE
Repost #3426: move DISABLE_AUTO_TITLE check to hooks

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -1,8 +1,16 @@
-#usage: title short_tab_title looooooooooooooooooooooggggggg_windows_title
-#http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
-#Fully support screen, iterm, and probably most modern xterm and rxvt
+# Set terminal window and tab/icon title
+#
+# usage: title short_tab_title [long_window_title]
+#
+# See: http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
+# Fully supports screen, iterm, and probably most modern xterm and rxvt
+# (In screen, only short_tab_title is used)
+# Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
-  if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
+  if [[ $2 == "" ]]; then
+    2="$1"
+  fi
+  if [[ "$EMACS" == *term* ]]; then
     return
   fi
   if [[ "$TERM" == screen* ]]; then
@@ -18,6 +26,10 @@ ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
 # Runs before showing the prompt
 function omz_termsupport_precmd {
+  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+    return
+  fi
+
   title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 
   # Notify Terminal.app of current directory using undocumented OSC sequence
@@ -30,6 +42,10 @@ function omz_termsupport_precmd {
 
 # Runs before executing the command
 function omz_termsupport_preexec {
+  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+    return
+  fi
+
   emulate -L zsh
   setopt extended_glob
 

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -7,12 +7,12 @@
 # (In screen, only short_tab_title is used)
 # Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
-  if [[ $2 == "" ]]; then
-    2="$1"
-  fi
-  if [[ "$EMACS" == *term* ]]; then
-    return
-  fi
+  [[ "$EMACS" == *term* ]] && return
+
+  # if $2 is unset use $1 as default
+  # if it is set and empty, leave it as is
+  : ${2=$1}
+
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -15,7 +15,7 @@ function title {
 
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name
   fi


### PR DESCRIPTION
From #3426 by @apjanke:
> This moves the DISABLE_AUTO_TITLE check from title() itself to the precmd/preexec hook functions that call it. It also allows single-argument use by defaulting the long window title ($2) to the short icon title ($1).

> I'd like to do this because it would allow the title() function to be used directly by the user or other callers. In my workflow, I like to set the terminal tab title manually, and had my own settitle() function set up to do that. The OMZ title() function is already out there in the global function namespace, so it makes more sense to do that.

> This arrangement of the check in the hooks was discussed in #266 but dismissed as DRY/not needed for performance. But I think it's worth reconsidering: this isn't for performance, but an interface/functionality change that makes title() more useful.
> 
> Also reformatted the comments to match comments in other OMZ lib/*.zsh files.

Close #3426

It also reformats some code to suite better zsh style and quotes `$TERM` every place it's used.

/cc @robbyrussell 