### PR TITLE
Fix first-tab completion in task command

### DIFF
--- a/plugins/taskwarrior/_task
+++ b/plugins/taskwarrior/_task
@@ -246,3 +246,5 @@ _task_default() {
 
 	return ret
 }
+
+_task


### PR DESCRIPTION
This is done by calling `_task` at the end of the _task completion file, as is standard in completion files.

Fixes #2044.