### PR TITLE
docker containers based on defined names

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -11,7 +11,7 @@
 # Output a selectable list of all running docker containers
 __docker_containers() {
     declare -a cont_cmd
-    cont_cmd=($(docker ps | awk 'NR>1{print $1":[CON("$1")"$2"("$3")]"}'))
+    cont_cmd=($(docker ps | awk 'NR>1{print $NF":[CON("$1")"$2"("$3")]"}'))
     _describe 'containers' cont_cmd
 }
 


### PR DESCRIPTION
docker container autocomplete listing uses containers ID instead of names.
Most users identify their containers by name. ID is only needed and used on a dynamic environment more suited in scripts.
This modification uses the name of the container rather than the ID to autocomplete.