### PR TITLE
Modify theme to optimize the usability, when you use solarized dark as s...

### DIFF
--- a/themes/rkj-repos.zsh-theme
+++ b/themes/rkj-repos.zsh-theme
@@ -15,8 +15,8 @@ ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg[yellow]%}✱"
 ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%}✗"
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[blue]%}➦"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[magenta]%}✂"
-ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[grey]%}✈"
-ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$fg[grey]%}"
+ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[blue]%}✈"
+ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$fg[blue]%}"
 ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$reset_color%}"
 
 function mygit() {


### PR DESCRIPTION
When you use the git plugin you cannot see the git id,  because color scheme issues. With my change you can see the two icons again :-)