### PR TITLE
Misc theme plugin cleanup (var and pwd hygiene)

### DIFF
--- a/lib/_theme
+++ b/lib/_theme
@@ -1,0 +1,3 @@
+#compdef theme
+
+_arguments "1: :($(lstheme | tr "\n" " "))"

--- a/lib/_theme
+++ b/lib/_theme
@@ -1,3 +1,0 @@
-#compdef theme
-
-_arguments "1: :($(lstheme | tr "\n" " "))"

--- a/plugins/themes/_theme
+++ b/plugins/themes/_theme
@@ -1,3 +1,3 @@
 #compdef theme
 
-_arguments "1: :($(lstheme | tr "\n" " "))"
+_arguments "1: :($(lstheme))"

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -70,8 +70,8 @@ function _omz_load_theme_from_file() {
     values_before[$param]=${(P)param}
   done
 
-  # Actually load the theme
-  source $file
+  # Actually load the theme, using an indirection function
+  _omz_source_theme_file $file
 
   # Debugging stuff
   if [[ $ZSH_THEME_DEBUG == true ]]; then
@@ -126,6 +126,14 @@ function _omz_load_theme_from_file() {
       echo "WARNING: Theme changed precmd()"
     fi
   fi
+}
+
+# Sources the given file
+# The only reason this function exists is to provide a layer of
+# indirection so that the theme file runs in its own function call stack frame
+# and "local" statements in the theme definitions work as intended.
+function _omz_source_theme_file() {
+  source $1
 }
 
 # Resets all theme settings to their default state

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,24 +1,55 @@
-function theme
-{
-  if [ -z "$1" ] || [ "$1" = "random" ]; then
-    themes=($ZSH/themes/*zsh-theme)
-    N=${#themes[@]}
-    ((N=(RANDOM%N)+1))
-    RANDOM_THEME=${themes[$N]}
-    source "$RANDOM_THEME"
-    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+# Load a theme
+# 
+# Usage:
+#   "theme <name>" loads the named theme
+#   "theme random" or "theme" with no argument loads a random theme
+# Return value:
+#   0 on success
+#   Nonzero on failure, such as requested theme not being found
+function theme() {
+  if [[ -z "$1" ]] || [[ "$1" = "random" ]]; then
+    # Select a random theme
+    local themes n random_theme
+    themes=($(lstheme))
+    n=${#themes[@]}
+    ((n=(RANDOM%n)+1))
+    random_theme=${themes[$n]}
+    echo "[oh-my-zsh] Loading random theme '$random_theme'..."
+    theme $random_theme
   else
-    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-    then
-      source "$ZSH_CUSTOM/$1.zsh-theme"
-    else
-      source "$ZSH/themes/$1.zsh-theme"
+    # Main case: load named theme
+    local name theme_dir found
+    name=$1
+    found=false
+    for theme_dir ($ZSH_CUSTOM $ZSH_CUSTOM/themes $ZSH/themes); do
+      if [[ -f "$theme_dir/$name.zsh-theme" ]]; then
+        source "$theme_dir/$name.zsh-theme"
+        found=true
+        break
+      fi
+    done
+    if [[ $found == false ]]; then
+      echo "[oh-my-zsh] Theme not found: $name"
+      return 1
     fi
   fi
 }
 
-function lstheme
-{
-  cd $ZSH/themes
-  ls *zsh-theme | sed 's,\.zsh-theme$,,'
+# List available themes by name
+#
+# The list will always be in sorted order, so you can index in to it.
+function lstheme(){
+  local themes x theme_dir
+  themes=()
+  for theme_dir ($ZSH_CUSTOM $ZSH_CUSTOM/themes $ZSH/themes); do
+    if [[ -d $theme_dir ]]; then
+      themes+=($(_omz_lstheme_dir $theme_dir))
+    fi
+  done
+  echo ${(F)themes} | sort | uniq
+}
+
+# List themes defined in a given dir
+function _omz_lstheme_dir() {
+  ls $1 | grep '.zsh-theme$' | sed 's,\.zsh-theme$,,'
 }

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,24 +1,24 @@
 function theme
 {
-    if [ -z "$1" ] || [ "$1" = "random" ]; then
-	themes=($ZSH/themes/*zsh-theme)
-	N=${#themes[@]}
-	((N=(RANDOM%N)+1))
-	RANDOM_THEME=${themes[$N]}
-	source "$RANDOM_THEME"
-	echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  if [ -z "$1" ] || [ "$1" = "random" ]; then
+    themes=($ZSH/themes/*zsh-theme)
+    N=${#themes[@]}
+    ((N=(RANDOM%N)+1))
+    RANDOM_THEME=${themes[$N]}
+    source "$RANDOM_THEME"
+    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  else
+    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
+    then
+      source "$ZSH_CUSTOM/$1.zsh-theme"
     else
-	if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-	then
-	    source "$ZSH_CUSTOM/$1.zsh-theme"
-	else
-	    source "$ZSH/themes/$1.zsh-theme"
-	fi
+      source "$ZSH/themes/$1.zsh-theme"
     fi
+  fi
 }
 
 function lstheme
 {
-    cd $ZSH/themes
-    ls *zsh-theme | sed 's,\.zsh-theme$,,'
+  cd $ZSH/themes
+  ls *zsh-theme | sed 's,\.zsh-theme$,,'
 }

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -79,7 +79,7 @@ function _omz_load_theme_from_file() {
     params_added=(${params_after:|params_before})
     ignore_params=(LINENO RANDOM _ parameters prompt values_before modules \
       params_added ignore_params params_before params_after params_changed \
-      SECONDS TTYIDLE)
+      SECONDS TTYIDLE PS1 PS2 PS3 PS4 RPS1 RPS2)
     params_before=(${params_before:|ignore_params})
     local params_changed
     params_changed=()
@@ -104,7 +104,7 @@ function _omz_load_theme_from_file() {
     if [[ -n $params_changed ]]; then
       printf '=== %s ===\n%s\n' "Theme changed parameters:" ${(F)params_changed}
     fi
-    if [[ -n "$_OMZ_THEME_CHPWD_FUNCTIONS$_OMZ_THEME_PRECMD_FUNCTIONS$_OMZ_THEME_PREEXEC_FUNCTIONS" ]]; then
+    if [[ -n "${_OMZ_THEME_CHPWD_FUNCTIONS}${_OMZ_THEME_PRECMD_FUNCTIONS}${_OMZ_THEME_PREEXEC_FUNCTIONS}" ]]; then
       printf '=== %s ===\n' "Theme added hooks:"
       if [[ -n $_OMZ_THEME_CHPWD_FUNCTIONS ]]; then
         echo "Theme added chpwd hooks: $_OMZ_THEME_CHPWD_FUNCTIONS"
@@ -142,7 +142,12 @@ function _omz_source_theme_file() {
 # It will also remove any hook functions installed by the current theme, if it
 # was loaded by the theme() function
 function _omz_reset_theme() {
+  # Prompts
   PROMPT="%n@%m:%~%# "
+  PROMPT2='%_> '
+  PROMPT3='?# '
+  PROMPT4='+%N:%i> '
+  unset RPROMPT RPROMPT2
 
   # This assumes that all ZSH_THEME_<aspect>_* variables are owned by
   # OMZ theming, and can be reset en masse

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,3 +1,8 @@
+# Set to true to enable debugging output for theme functions
+# Note that this can cause unstable behavior, especially with these themes:
+# agnoster dstufft
+ZSH_THEME_DEBUG=${ZSH_THEME_DEBUG:-false}
+
 # Load a theme
 # 
 # Usage:
@@ -23,8 +28,8 @@ function theme() {
     found=false
     for theme_dir ($ZSH_CUSTOM $ZSH_CUSTOM/themes $ZSH/themes); do
       if [[ -f "$theme_dir/$name.zsh-theme" ]]; then
-        source "$theme_dir/$name.zsh-theme"
         found=true
+        _omz_load_theme_from_file $name "$theme_dir/$name.zsh-theme"
         break
       fi
     done
@@ -35,10 +40,169 @@ function theme() {
   fi
 }
 
+# Variables to track hook functions installed by themes
+_OMZ_THEME_CHPWD_FUNCTIONS=()
+_OMZ_THEME_PRECMD_FUNCTIONS=()
+_OMZ_THEME_PREEXEC_FUNCTIONS=()
+
+# Implementation of loading a theme
+# Most of the code in here is for tracking hooks and debugging support
+function _omz_load_theme_from_file() {
+  local name=$1 file=$2 params_before exclude_params
+  local -A values_before
+
+  # Reset so theme is loaded into a clean slate
+  _omz_reset_theme
+
+  # Set up tracking and debugging
+  local chpwd_fcns_0 precmd_fcns_0 preexec_fcns_0 chpwd_0 precmd_0 preexec_0
+  local params_after params_added param ignore_params
+  chpwd_0=$(which chpwd)
+  precmd_0=$(which precmd)
+  preexec_0=$(which preexec)
+  chpwd_fcns_0=($chpwd_functions)
+  precmd_fcns_0=($precmd_functions)
+  preexec_fcns_0=($preexec_functions)
+  if [[ $ZSH_THEME_DEBUG == true ]]; then
+    params_before=($(set +))
+  fi
+  for param ($params_before); do
+    values_before[$param]=${(P)param}
+  done
+
+  # Actually load the theme
+  source $file
+
+  # Debugging stuff
+  if [[ $ZSH_THEME_DEBUG == true ]]; then
+    params_after=($(set +))
+    params_added=(${params_after:|params_before})
+    ignore_params=(LINENO RANDOM _ parameters prompt values_before modules \
+      params_added ignore_params params_before params_after params_changed \
+      SECONDS TTYIDLE)
+    params_before=(${params_before:|ignore_params})
+    local params_changed
+    params_changed=()
+    for param ($params_before); do
+      if [[ ${(P)param} != ${values_before[$param]} ]]; then
+        params_changed+=($param)
+      fi
+    done
+  fi
+
+  # Track changes to hooks
+  _OMZ_THEME_CHPWD_FUNCTIONS=(${chpwd_functions:|chpwd_fcns_0})
+  _OMZ_THEME_PRECMD_FUNCTIONS=(${precmd_functions:|precmd_fcns_0})
+  _OMZ_THEME_PREEXEC_FUNCTIONS=(${preexec_functions:|preexec_fcns_0})
+
+  # Post-loading debugging
+  if [[ $ZSH_THEME_DEBUG == true ]]; then
+    echo "Loaded theme $name from file $file"
+    if [[ -n $params_added ]]; then
+      printf '=== %s ===\n%s\n' "Theme added parameters:" ${(F)params_added}
+    fi
+    if [[ -n $params_changed ]]; then
+      printf '=== %s ===\n%s\n' "Theme changed parameters:" ${(F)params_changed}
+    fi
+    if [[ -n "$_OMZ_THEME_CHPWD_FUNCTIONS$_OMZ_THEME_PRECMD_FUNCTIONS$_OMZ_THEME_PREEXEC_FUNCTIONS" ]]; then
+      printf '=== %s ===\n' "Theme added hooks:"
+      if [[ -n $_OMZ_THEME_CHPWD_FUNCTIONS ]]; then
+        echo "Theme added chpwd hooks: $_OMZ_THEME_CHPWD_FUNCTIONS"
+      fi
+      if [[ -n $_OMZ_THEME_PRECMD_FUNCTIONS ]]; then
+        echo "Theme added precmd hooks: $_OMZ_THEME_PRECMD_FUNCTIONS"
+      fi
+      if [[ -n $_OMZ_THEME_PREEXEC_FUNCTIONS ]]; then
+        echo "Theme added preexec hooks: $_OMZ_THEME_PREEXEC_FUNCTIONS"
+      fi
+    fi
+    if [[ $(which chpwd) != $chpwd_0 ]]; then
+      echo "WARNING: Theme changed chpwd()"
+    fi
+    if [[ $(which preexec) != $preexec_0 ]]; then
+      echo "WARNING: Theme changed preexec()"
+    fi
+    if [[ $(which precmd) != $precmd_0 ]]; then
+      echo "WARNING: Theme changed precmd()"
+    fi
+  fi
+}
+
+# Resets all theme settings to their default state
+# (To the extent that we know what themes do, that is.)
+# This will reset all variables used by the core OMZ *_prompt_info functions.
+# It will also remove any hook functions installed by the current theme, if it
+# was loaded by the theme() function
+function _omz_reset_theme() {
+  PROMPT="%n@%m:%~%# "
+
+  # This assumes that all ZSH_THEME_<aspect>_* variables are owned by
+  # OMZ theming, and can be reset en masse
+  # All the commented-out variables are there to serve as a list of things
+  # that are used by theme support and could be given default values
+
+  # git_prompt_info variables
+  unset -m 'ZSH_THEME_GIT_PROMPT_*'
+  ZSH_THEME_GIT_PROMPT_PREFIX="git:("   # Prefix at the very beginning of the prompt, before the branch name
+  ZSH_THEME_GIT_PROMPT_SUFFIX=")"       # At the very end of the prompt
+  #ZSH_THEME_GIT_PROMPT_PREFIX=
+  #ZSH_THEME_GIT_PROMPT_SUFFIX=
+  #ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX=
+  #ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX=
+  ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
+  ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+  #ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE=
+  #ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE=
+  #ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE=
+  #ZSH_THEME_GIT_PROMPT_AHEAD=
+  #ZSH_THEME_GIT_PROMPT_BEHIND=
+  #ZSH_THEME_GIT_PROMPT_SHA_BEFORE=
+  #ZSH_THEME_GIT_PROMPT_SHA_AFTER=
+  #ZSH_THEME_GIT_PROMPT_ADDED=
+  #ZSH_THEME_GIT_PROMPT_MODIFIED=
+  #ZSH_THEME_GIT_PROMPT_RENAMED=
+  #ZSH_THEME_GIT_PROMPT_DELETED=
+  #ZSH_THEME_GIT_PROMPT_STASHED=
+  #ZSH_THEME_GIT_PROMPT_UNMERGED=
+  #ZSH_THEME_GIT_PROMPT_DIVERGED=
+  #ZSH_THEME_GIT_PROMPT_UNTRACKED=
+  # nvm_prompt_info variables
+  unset -m 'ZSH_THEME_NVM_PROMPT_*'
+  #ZSH_THEME_NVM_PROMPT_PREFIX=
+  #ZSH_THEME_NVM_PROMPT_SUFFIX=
+  # rvm_prompt_info variables
+  unset -m 'ZSH_THEME_RVM_PROMPT_*'
+  #ZSH_THEME_RVM_PROMPT_PREFIX=
+  #ZSH_THEME_RVM_PROMPT_SUFFIX=
+  #ZSH_THEME_RVM_PROMPT_OPTIONS=
+  # svn_prompt_info variables
+  unset -m 'ZSH_THEME_SVN_PROMPT_*'
+  #ZSH_THEME_SVN_PROMPT_CLEAN
+  #ZSH_THEME_SVN_PROMPT_DIRTY
+  #ZSH_THEME_SVN_PROMPT_PREFIX
+  #ZSH_THEME_SVN_PROMPT_SUFFIX
+
+  # Hook functions
+  if [[ -n $_OMZ_THEME_CHPWD_FUNCTIONS ]]; then
+    #echo Removing chpwd hooks: $_OMZ_THEME_CHPWD_FUNCTIONS
+    chpwd_functions=(${chpwd_functions:|_OMZ_THEME_CHPWD_FUNCTIONS})
+  fi
+  if [[ -n $_OMZ_THEME_PRECMD_FUNCTIONS ]]; then
+    #echo Removing precmd hooks: $_OMZ_THEME_PRECMD_FUNCTIONS
+    precmd_functions=(${precmd_functions:|_OMZ_THEME_PRECMD_FUNCTIONS})
+  fi
+  if [[ -n $_OMZ_THEME_PREEXEC_FUNCTIONS ]]; then
+    #echo Removing preexec hooks: $_OMZ_THEME_PREEXEC_FUNCTIONS
+    preexec_functions=(${preexec_functions:|_OMZ_THEME_PREEXEC_FUNCTIONS})
+  fi
+
+}
+
+
 # List available themes by name
 #
 # The list will always be in sorted order, so you can index in to it.
-function lstheme(){
+function lstheme() {
   local themes x theme_dir
   themes=()
   for theme_dir ($ZSH_CUSTOM $ZSH_CUSTOM/themes $ZSH/themes); do
@@ -53,3 +217,5 @@ function lstheme(){
 function _omz_lstheme_dir() {
   ls $1 | grep '.zsh-theme$' | sed 's,\.zsh-theme$,,'
 }
+
+


### PR DESCRIPTION
Rewrite of the themes plugin to fix some hygiene and consistency issues.

Fixes #3585.
Close #3337.

There are a few related issues in the `themes` plugin. I'm listing them all in one Issue because they're interrelated and I plan on fixing them all in one PR.

* lstheme() changes the pwd as a side effect
* lstheme() does not include custom themes
* theme() leaks variables `$N`, `$themes`, and `$RANDOM_THEME` when setting random theme
* mixed tabs and spaces for indentation
* theme() reads custom themes from `$ZSH_CUSTOM` but not `$ZSH_CUSTOM/themes`.

### lstheme pwd side effect

If you call lstheme, it dumps you in to the themes dir. It shouldn't change the directory.

```
[@ in ~]
~ » pwd
/Users/janke
~ » lstheme > /dev/null
.oh-my-zsh/themes [master] » pwd
/Users/janke/.oh-my-zsh/themes
.oh-my-zsh/themes [master] »
```

### Custom theme locations

It seems like the dir structure of $ZSH_CUSTOM should mirror the directory structure of the main oh-my-zsh directory. Theme() looks under the themes/ subdir of the main dir, but the root dir under $ZSH_CUSTOM. This is also inconsistent with `oh-my-zsh.sh`, which looks in both `/` and `themes/` under $ZSH_CUSTOM.

Really, most of the theme plugin implementation is duplicated by the theme loading section in the `oh-my-zsh.zsh` script. The theme plugin should probably be moved in to `lib/theme-and-appearance.zsh` and `oh-my-zsh.zsh` should call it.