### PR TITLE
Add initial JHBuild plugin support

### DIFF
--- a/plugins/jhbuild/README.md
+++ b/plugins/jhbuild/README.md
@@ -1,0 +1,4 @@
+## JHBuild
+**Maintainer:** [Miguel Vaello](https://github.com/miguxbe)
+
+This plugin adds some jhbuild aliases and increase the completion function provided by zsh.

--- a/plugins/jhbuild/jhbuild.plugin.zsh
+++ b/plugins/jhbuild/jhbuild.plugin.zsh
@@ -1,0 +1,28 @@
+# Aliases
+#
+alias jh='jhbuild'
+# Build
+alias jhb='jhbuild build'
+alias jhbo='jhbuild buildone'
+# Checks
+alias jhckb='jhbuild checkbranches'
+alias jhckm='jhbuild checkmodulesets'
+# Info & list
+alias jhi='jhbuild info'
+alias jhl='jhbuild list'
+# Clean
+alias jhc='jhbuild clean'
+alias jhco='jhbuild cleanone'
+# Run
+alias jhr='jhbuild run'
+# Depends
+alias jhrd='jhbuild rdepends'
+alias jhsd='jhbuild sysdeps'
+# Update
+alias jhu='jhbuild update'
+alias jhuo='jhbuild updateone'
+# Uninstall
+alias jhun='jhbuild uninstall'
+
+
+


### PR DESCRIPTION
This is a bunch of alias for the JHBuild tool.
A well known tool in the GNOME dev project.