### PR TITLE
Bring back -h (--human-readable) option to ls variants

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -24,9 +24,9 @@ alias d='dirs -v | head -10'
 
 # List directory contents
 alias lsa='ls -lah'
-alias l='ls -la'
-alias ll='ls -l'
-alias la='ls -lA'
+alias l='ls -lah'
+alias ll='ls -lh'
+alias la='ls -lAh'
 
 # Push and pop directories on directory stack
 alias pu='pushd'


### PR DESCRIPTION
The `-h` options in `l`, `ll`, and `la` were lost in 25b1cd6 when `ls` variants were factored from `aliases.zsh` into `directories.zsh`. There's no reason to remove the `--human-readable` option.