### PR TITLE
Laravel 5 support

### DIFF
--- a/plugins/laravel4/laravel4.plugin.zsh
+++ b/plugins/laravel4/laravel4.plugin.zsh
@@ -1,6 +1,6 @@
 # Laravel4 basic command completion
 _laravel4_get_command_list () {
-	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^ +[a-z]+/ { print $1 }'
 }
 
 _laravel4 () {

--- a/plugins/laravel5/laravel5.plugin.zsh
+++ b/plugins/laravel5/laravel5.plugin.zsh
@@ -1,0 +1,20 @@
+# Laravel5 basic command completion
+_laravel5_get_command_list () {
+	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^ +[a-z]+/ { print $1 }'
+}
+
+_laravel5 () {
+  if [ -f artisan ]; then
+    compadd `_laravel5_get_command_list`
+  fi
+}
+
+compdef _laravel5 artisan
+compdef _laravel5 la5
+
+#Alias
+alias la5='php artisan'
+
+alias la5dump='php artisan dump-autoload'
+alias la5cache='php artisan cache:clear'
+alias la5routes='php artisan routes'


### PR DESCRIPTION
Laravel 5 inserts less spaces in in front of help items . So the logic changed and both plugins are now compatible with any artisan version