### PR TITLE
Remove '.' from $cdpath to avoid Cygwin breakage

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -34,7 +34,6 @@ fi
 
 # disable named-directories autocompletion
 zstyle ':completion:*:cd:*' tag-order local-directories directory-stack path-directories
-cdpath=(.)
 
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1


### PR DESCRIPTION
Fixes #3550. Leave $cdpath at its default (`()`) instead of adding explicit `.`, which runs in to a file normalization bug on cygwin.