### PR TITLE
Create Ubuntu/Debian/Mint/... plugin, based on Debian plugin

### DIFF
--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -12,7 +12,7 @@ There are two exeptions since ...
 agu  = sudo Apt-Get Update  - we have ...  
 agug = sudo Apt-Get UpGrade - as the exeptional 4 letter alias for a single command.
 
-afs = Apt-F*ile Search --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
+afs = Apt-File Search --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
 
 Then there are the 2 other 4 letter aliases for combined commands, that are straight forward and easy to remember.  
 aguu = sudo Apt-Get Update && sudo apt-get Upgrade      - better then adg or not?  

--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -1,21 +1,21 @@
 This plugin was created because the aliases in the debian plugin are inconsistent and hard to remember. Also this apt-priority detection that switched between apt-get and aptitude was dropped to keep it simpler. This plugin uses apt-get for everything but a few things that are only possible with aptitude I guess. Ubuntu does not have aptitude installed by default.
 
-acs = **a**pt-**c**ache **s**earch  
-acp = **a**pt-**c**ache **p**olicy
+acs = Apt-Cache Search  
+acp = Apt-Cache Policy
 
-ag  = sudo **a**pt-**g**et  
-agi = sudo **a**pt-**g**et **i**nstall  
-agd = sudo **a**pt-**g**et **d**select-upgrade  
+ag  = sudo Apt-Get  
+agi = sudo Apt-Get Install  
+agd = sudo Apt-Get Dselect-upgrade  
 By now you already can guess almost all aliases  
 
 There are two exeptions since ...  
-agu  = sudo **a**pt-**g**et **u**pdate  - we have ...  
-agug = sudo **a**pt-**g**et **u**p**g**rade - as the exeptional 4 letter alias for a single command.
+agu  = sudo Apt-Get Update  - we have ...  
+agug = sudo Apt-Get UpGrade - as the exeptional 4 letter alias for a single command.
 
-afs = **a**pt-**f**ile **s**earch --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
+afs = Apt-F*ile Search --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
 
 Then there are the 2 other 4 letter aliases for combined commands, that are straight forward and easy to remember.  
-aguu = sudo **a**pt-**g**et **u**pdate && sudo apt-get **u**pgrade      - better then adg or not?  
-agud = sudo **a**pt-**g**et **u**pdate && sudo apt-get **d**ist-upgrade
+aguu = sudo Apt-Get Update && sudo apt-get Upgrade      - better then adg or not?  
+agud = sudo Apt-Get Update && sudo apt-get Dist-upgrade
 
 For a full list aliases and the functions just watch the plugins code https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/ubuntu/ubuntu.plugin.zsh, look at the comments if you want to switch from the debian plugin. Ubuntu, Mint and & co users will like the new aar function to install packages from ppas with a single command.

--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -1,6 +1,4 @@
-This plugin was created because the aliases in the debian plugin are inconsistent and hard to remember. Also this apt-priority detaction that switched between apt-get and aptitude was dropped to keep it simpler. This plugin uses apt-get for everything but a few things that are only possible with aptitude I guess. Ubuntu does not have aptitude installed by default.
-
-The aliases for this plugin are easy to remember because they are consistent (the debian plugin is not). 
+This plugin was created because the aliases in the debian plugin are inconsistent and hard to remember. Also this apt-priority detection that switched between apt-get and aptitude was dropped to keep it simpler. This plugin uses apt-get for everything but a few things that are only possible with aptitude I guess. Ubuntu does not have aptitude installed by default.
 
 acs = **a**pt-**c**ache **s**earch  
 acp = **a**pt-**c**ache **p**olicy

--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -1,0 +1,23 @@
+This plugin was created because the aliases in the debian plugin are inconsistent and hard to remember. Also this apt-priority detaction that switched between apt-get and aptitude was dropped to keep it simpler. This plugin uses apt-get for everything but a few things that are only possible with aptitude I guess. Ubuntu does not have aptitude installed by default.
+
+The aliases for this plugin are easy to remember because they are consistent (the debian plugin is not). 
+
+acs = **a**pt-**c**ache **s**earch  
+acp = **a**pt-**c**ache **p**olicy
+
+ag  = sudo **a**pt-**g**et  
+agi = sudo **a**pt-**g**et **i**nstall  
+agd = sudo **a**pt-**g**et **d**select-upgrade  
+By now you already can guess almost all aliases  
+
+There are two exeptions since ...  
+agu  = sudo **a**pt-**g**et **u**pdate  - we have ...  
+agug = sudo **a**pt-**g**et **u**pgrade - as the exeptional 4 letter alias for a single command.
+
+afs = **a**pt-**f**ile **s**earch --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
+
+Then there are the 2 other 4 letter aliases for combined commands, that are straight forward and easy to remember.  
+aguu = sudo **a**pt-**g**et **u**pdate && sudo apt-get **u**pgrade      - better then adg or not?  
+agud = sudo **a**pt-**g**et **u**pdate && sudo apt-get **d**ist-upgrade
+
+For a full list aliases and the functions just watch the plugins code https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/debian/debian.plugin.zsh, look at the comments if you want to switch from the debian plugin. Ubuntu, Mint and & co users will like the new aar function to install packages from ppas with a single command.

--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -18,4 +18,4 @@ Then there are the 2 other 4 letter aliases for combined commands, that are stra
 aguu = sudo **a**pt-**g**et **u**pdate && sudo apt-get **u**pgrade      - better then adg or not?  
 agud = sudo **a**pt-**g**et **u**pdate && sudo apt-get **d**ist-upgrade
 
-For a full list aliases and the functions just watch the plugins code https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/debian/debian.plugin.zsh, look at the comments if you want to switch from the debian plugin. Ubuntu, Mint and & co users will like the new aar function to install packages from ppas with a single command.
+For a full list aliases and the functions just watch the plugins code https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/ubuntu/ubuntu.plugin.zsh, look at the comments if you want to switch from the debian plugin. Ubuntu, Mint and & co users will like the new aar function to install packages from ppas with a single command.

--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -10,7 +10,7 @@ By now you already can guess almost all aliases
 
 There are two exeptions since ...  
 agu  = sudo **a**pt-**g**et **u**pdate  - we have ...  
-agug = sudo **a**pt-**g**et **u**pgrade - as the exeptional 4 letter alias for a single command.
+agug = sudo **a**pt-**g**et **u**p**g**rade - as the exeptional 4 letter alias for a single command.
 
 afs = **a**pt-**f**ile **s**earch --regexp - this has the regexp switch on without being represented in the alias, I guess this makes sense since the debian plugin has it, I never used that command.
 

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -1,0 +1,141 @@
+# Authors:
+# https://github.com/AlexBio
+# https://github.com/dbb
+# https://github.com/Mappleconfusers
+# Nicolas Jonas nextgenthemes.com
+#
+# Debian, Ubuntu and friends related zsh aliases and functions for zsh
+
+alias acs='apt-cache search'
+compdef _acs acs='apt-cache search'
+
+alias afs='apt-file search --regexp'
+compdef _afs afs='apt-file search --regexp'
+
+# These are apt-get only
+alias ags='apt-get source'   # asrc
+compdef _ags ags='apt-get source'
+
+alias acp='apt-cache policy' # app
+compdef _acp acp='apt-cache policy'
+
+# superuser operations ######################################################
+alias afu='sudo apt-file update'
+compdef _afu afu='sudo apt-file update'
+
+alias ppap='sudo ppa-purge'
+compdef _ppap ppap='sudo ppa-purge'
+
+alias ag='sudo apt-get'            # age - but without sudo
+alias aga='sudo apt-get autoclean' # aac
+alias agb='sudo apt-get build-dep' # abd
+alias agc='sudo apt-get clean'     # adc
+alias agd='sudo apt-get dselect-upgrade' # ads
+alias agi='sudo apt-get install'  # ai
+alias agp='sudo apt-get purge'    # ap
+alias agr='sudo apt-get remove'   # ar
+alias agu='sudo apt-get update'   # ad
+alias agud='sudo apt-get update && sudo apt-get dist-upgrade' #adu
+alias agug='sudo apt-get upgrade' # ag
+alias aguu='sudo apt-get update && sudo apt-get upgrade'      #adg
+
+compdef _ag ag='sudo apt-get'
+compdef _aga aga='sudo apt-get autoclean'
+compdef _agb agb='sudo apt-get build-dep'
+compdef _agc agc='sudo apt-get clean'
+compdef _agd agd='sudo apt-get dselect-upgrade'
+compdef _agi agi='sudo apt-get install'
+compdef _agp agp='sudo apt-get purge'
+compdef _agr agr='sudo apt-get remove'
+compdef _agu agu='sudo apt-get update'
+compdef _agud agud='sudo apt-get update && sudo apt-get dist-upgrade'
+compdef _agug agug='sudo apt-get upgrade'
+compdef _aguu aguu='sudo apt-get update && sudo apt-get upgrade'
+
+# Remove ALL kernel images and headers EXCEPT the one in use
+alias kclean='sudo aptitude remove -P ?and(~i~nlinux-(ima|hea) \
+	?not(~n`uname -r`))'
+
+# Misc. #####################################################################
+# print all installed packages
+alias allpkgs='aptitude search -F "%p" --disable-columns ~i'
+
+# Create a basic .deb package
+alias mydeb='time dpkg-buildpackage -rfakeroot -us -uc'
+
+# apt-add-repository with automatic install/upgrade of the desired package
+# Usage: aar ppa:xxxxxx/xxxxxx [packagename]
+# If packagename is not given as 2nd arument the function will ask for it and guess the defaupt by taking
+# the part after the / from the ppa name wich is sometimes the right name for the package you want to install
+aar() {
+	if [ -n "$2" ]; then
+		PACKAGE=$2
+	else
+		read "PACKAGE?Type in the package name to install/upgrade with this ppa [${1##*/}]: "
+	fi
+	
+	if [ -z "$PACKAGE" ]; then
+		PACKAGE=${1##*/}
+	fi
+	
+	sudo apt-add-repository $1 && sudo apt-get update
+	sudo apt-get install $PACKAGE
+}
+
+# Prints apt history
+# Usage:
+#   apt-history install
+#   apt-history upgrade
+#   apt-history remove
+#   apt-history rollback
+#   apt-history list
+# Based On: http://linuxcommando.blogspot.com/2008/08/how-to-show-apt-log-history.html
+apt-history () {
+  case "$1" in
+    install)
+      zgrep --no-filename 'install ' $(ls -rt /var/log/dpkg*)
+      ;;
+    upgrade|remove)
+      zgrep --no-filename $1 $(ls -rt /var/log/dpkg*)
+      ;;
+    rollback)
+      zgrep --no-filename upgrade $(ls -rt /var/log/dpkg*) | \
+        grep "$2" -A10000000 | \
+        grep "$3" -B10000000 | \
+        awk '{print $4"="$5}'
+      ;;
+    list)
+      zcat $(ls -rt /var/log/dpkg*)
+      ;;
+    *)
+      echo "Parameters:"
+      echo " install - Lists all packages that have been installed."
+      echo " upgrade - Lists all packages that have been upgraded."
+      echo " remove - Lists all packages that have been removed."
+      echo " rollback - Lists rollback information."
+      echo " list - Lists all contains of dpkg logs."
+      ;;
+  esac
+}
+
+# Kernel-package building shortcut
+kerndeb () {
+    # temporarily unset MAKEFLAGS ( '-j3' will fail )
+    MAKEFLAGS=$( print - $MAKEFLAGS | perl -pe 's/-j\s*[\d]+//g' )
+    print '$MAKEFLAGS set to '"'$MAKEFLAGS'"
+	appendage='-custom' # this shows up in $ (uname -r )
+    revision=$(date +"%Y%m%d") # this shows up in the .deb file name
+
+    make-kpkg clean
+
+    time fakeroot make-kpkg --append-to-version "$appendage" --revision \
+        "$revision" kernel_image kernel_headers
+}
+
+# List packages by size
+function apt-list-packages {
+    dpkg-query -W --showformat='${Installed-Size} ${Package} ${Status}\n' | \
+    grep -v deinstall | \
+    sort -n | \
+    awk '{print $1" "$2}'
+}


### PR DESCRIPTION
* Easy to remember consistent aliases
* Simplified, no more switch between apt-get and aptitude, just uses apt-get ans assumes sudo is installed
* Added aar() function for `sudo apt-add-repository xxxx && apt-get upgrade && apt-get install xxxx`
* More complete autocompletion ;)