### PR TITLE
Revert usage of install.ohmyz.sh URL, until HTTPS support.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,11 +18,11 @@ You can install this via the command-line with either @curl@ or @wget@.
 
 h4. via @curl@:
 
-@curl -L http://install.ohmyz.sh | sh@
+@curl -L https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh | sh@
 
 h4. via @wget@:
 
-@wget --no-check-certificate http://install.ohmyz.sh -O - | sh@
+@wget --no-check-certificate https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O - | sh@
 
 h4. *Optionally*, change the install directory:
 


### PR DESCRIPTION
This reverts commit b6cbba9dfee5985232b473e94595c2fb1ab83715.

Use full Github URL until support for HTTPS in [ohmyz.sh](http://ohmyz.sh) is available.

Close #3459
Close #3461