### PR TITLE
Adding ssh-config to vagrant plugin autocomplete. Was missing

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -113,7 +113,7 @@ case $state in
       (box)
           __vagrant-box
       ;;
-      (up|provision|package|destroy|reload|ssh|halt|resume|status)
+      (up|provision|package|destroy|reload|ssh|ssh-config|halt|resume|status)
 	_arguments ':feature:__vm_list'
     esac
   ;;


### PR DESCRIPTION
A command I personally end up having to use in my day-to-day. I thought maybe others could benefit from it. I found that ssh-config was not autocompleting the list of available vagrant machines. Found it was missing from the list of supported autocomplete commands in the _vagrant script. 