### PR TITLE
Verify zle is active before trying to reset-prompt.

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -16,14 +16,7 @@ function zle-keymap-select zle-line-init zle-line-finish {
 
 # Ensure that the prompt is redrawn when the terminal size changes.
 TRAPWINCH() {
-  if [[ -o zle ]]; then
-    # Verify that zle is active before trying to reset-prompt.
-    zle
-    if [[ $? -eq 0 ]]; then
-      zle reset-prompt
-      zle -R
-    fi
-  fi
+  zle && { zle reset-prompt; zle -R }
 }
 
 zle -N zle-line-init

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -17,8 +17,12 @@ function zle-keymap-select zle-line-init zle-line-finish {
 # Ensure that the prompt is redrawn when the terminal size changes.
 TRAPWINCH() {
   if [[ -o zle ]]; then
-    zle reset-prompt
-    zle -R
+    # Verify that zle is active before trying to reset-prompt.
+    zle
+    if [[ $? -eq 0 ]]; then
+      zle reset-prompt
+      zle -R
+    fi
   fi
 }
 


### PR DESCRIPTION
Fix the problem with running zle commands when it is not active. This is to fix https://github.com/robbyrussell/oh-my-zsh/issues/3605.

Relevant documentation (http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html):
With no options and no arguments, only the return status will be set. It is zero if ZLE is currently active and widgets could be invoked using this builtin command and non-zero otherwise. Note that even if non-zero status is returned, zle may still be active as part of the completion system; this does not allow direct calls to ZLE widgets.