### PR TITLE
chucknorris: Keep Chuck's fortunes fresh

### DIFF
--- a/plugins/chucknorris/chucknorris.plugin.zsh
+++ b/plugins/chucknorris/chucknorris.plugin.zsh
@@ -1,6 +1,12 @@
-if [ ! -f $ZSH/plugins/chucknorris/fortunes/chucknorris.dat ]; then
-    strfile $ZSH/plugins/chucknorris/fortunes/chucknorris $ZSH/plugins/chucknorris/fortunes/chucknorris.dat
-fi
+() {
+  # Automatically generate or update Chuck's compiled fortune data file
+  local fdir=$ZSH/plugins/chucknorris/fortunes
+  if [[ ! -f $fdir/chucknorris.dat ]] || [[ $fdir/chucknorris.dat -ot $fdir/chucknorris ]]; then
+    strfile $fdir/chucknorris $fdir/chucknorris.dat
+  fi
 
-alias chuck="fortune -a $ZSH/plugins/chucknorris/fortunes"
-alias chuck_cow="chuck | cowthink"
+  # Aliases
+  alias chuck="fortune -a $fdir"
+  alias chuck_cow="chuck | cowthink"
+}
+

--- a/plugins/chucknorris/chucknorris.plugin.zsh
+++ b/plugins/chucknorris/chucknorris.plugin.zsh
@@ -1,12 +1,11 @@
-() {
-  # Automatically generate or update Chuck's compiled fortune data file
-  local fdir=$ZSH/plugins/chucknorris/fortunes
-  if [[ ! -f $fdir/chucknorris.dat ]] || [[ $fdir/chucknorris.dat -ot $fdir/chucknorris ]]; then
-    strfile $fdir/chucknorris $fdir/chucknorris.dat
-  fi
+# Automatically generate or update Chuck's compiled fortune data file
+DIR=${0:h}/fortunes
+if [[ ! -f $DIR/chucknorris.dat ]] || [[ $DIR/chucknorris.dat -ot $DIR/chucknorris ]]; then
+  strfile $DIR/chucknorris $DIR/chucknorris.dat
+fi
 
-  # Aliases
-  alias chuck="fortune -a $fdir"
-  alias chuck_cow="chuck | cowthink"
-}
+# Aliases
+alias chuck="fortune -a $DIR"
+alias chuck_cow="chuck | cowthink"
 
+unset DIR


### PR DESCRIPTION
Adds auto-updating of the compiled fortune data cache file for when the input Chuck string file is updated. Otherwise, if the fortunes are updated, the stale cache file will prevent any new sayings from Mr. Norris from appearing. The source string file would get updated during an oh-my-zsh update, but since the data file was already built, it wouldn't attempt to build it unless user manually removed the old cache file. Better to do it automatically.

To test this, just `touch chucknorris` and open a new zsh login session.

```
$ pwd
/Users/janke/.oh-my-zsh/plugins/chucknorris/fortunes
$ touch chucknorris
$ zsh -l
"/Users/janke/.oh-my-zsh/plugins/chucknorris/fortunes/chucknorris.dat" created
There were 447 strings
Longest string: 374 bytes
Shortest string: 1 byte
$
```

I threw in an anonymous function so it could use local variables, and switched to holding the fortune directory in a local variable for readability, now that more file paths are being used. Spelled-out files everywhere would have made for a very long conditional expression.


