### PR TITLE
Installer: Remove "sed -i" for portability and hygiene

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -23,14 +23,16 @@ fi
 
 echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[0m"
 cp $ZSH/templates/zshrc.zsh-template ~/.zshrc
-sed -i -e "/^export ZSH=/ c\\
+sed "/^export ZSH=/ c\\
 export ZSH=$ZSH
-" ~/.zshrc
+" ~/.zshrc > ~/.zshrc-omztemp
+mv -f ~/.zshrc-omztemp ~/.zshrc
 
 echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
-sed -i -e "/export PATH=/ c\\
+sed "/export PATH=/ c\\
 export PATH=\"$PATH\"
-" ~/.zshrc
+" ~/.zshrc > ~/.zshrc-omztemp
+mv -f ~/.zshrc-omztemp ~/.zshrc
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"


### PR DESCRIPTION
Fixes #3367 
Fixes #3612
Closes #4186

The installer uses the nonstandard `sed -i` extension for in-place editing. This makes it not portable to systems whose `sed` doesn't have the `-i` extension, in particular OpenBSD (#3367). This replaces the `sed -i` with explicitly-managed temp files.

This also fixes the problem of leaking `~/.zshrc-e` files due to incorrect use of the `-i` option in the current installer (#3612).

###   Testing   ###

To test this, run the following in a user account that does not already have OMZ installed. (Careful... it seems a little difficult to copy and paste from this little field in some browsers.)

```
sh -c "$(curl -fsSL https://raw.githubusercontent.com/apjanke/oh-my-zsh/remove-sed-i/tools/install.sh)"
```