### PR TITLE
Move custom *.zsh file sourcing up so that they can load plugins

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -29,6 +29,11 @@ for config_file ($ZSH/lib/*.zsh); do
   source $config_file
 done
 
+# Load all of your custom configurations from custom/
+for config_file ($ZSH_CUSTOM/*.zsh(N)); do
+  source $config_file
+done
+unset config_file
 
 is_plugin() {
   local base_dir=$1
@@ -71,12 +76,6 @@ for plugin ($plugins); do
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
-
-# Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)); do
-  source $config_file
-done
-unset config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]; then


### PR DESCRIPTION
I want use custom/*.zsh files to load plugins so that I can create one file that both loads and customizes a plugin. For example:

```
plugins+=(vi-mode)
bindkey -M viins 'jj' vi-cmd-mode
```