### PR TITLE
Disable --no-check-certificate flag on wget

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -22,7 +22,7 @@ h4. via @curl@:
 
 h4. via @wget@:
 
-@wget --no-check-certificate https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O - | sh@
+@wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O - | sh@
 
 h4. *Optionally*, change the install directory:
 


### PR DESCRIPTION
It was implemented in #258 to solve github.com's use of a wildcard certificate but it's no longer needed and it poses a security risk as commented on https://github.com/robbyrussell/oh-my-zsh/pull/3607#issuecomment-75392512.

/cc @robbyrussell 