### PR TITLE
Fixing spaces in title and message given to bgnotify on OS X

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -34,7 +34,7 @@ bgnotify () {
   if hash notify-send 2>/dev/null; then #ubuntu!
     notify-send $1 $2
   elif hash terminal-notifier 2>/dev/null; then #osx
-    terminal-notifier -message $2 -title $1
+    terminal-notifier -message "$2" -title "$1"
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m $1 $2
   elif hash notifu 2>/dev/null; then #cygwyn support!


### PR DESCRIPTION
On my OS X Mavericks bgnotify only used the first word when I created a custom message in the bgnotify_formatted function. 