### PR TITLE
Add match for `MM` in git prompt status

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -85,10 +85,14 @@ git_prompt_status() {
     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
   elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+  elif $(echo "$INDEX" | grep '^MM ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
   elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+  elif $(echo "$INDEX" | grep '^MM ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
   elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"


### PR DESCRIPTION
Add match for `MM` (file modified, some modifications added, but modifications still exist) to git_prompt_status.

Steps to repro:

```
cd /tmp
mkdir foo$$
cd foo$$
git init
touch foo
git add foo
git commit -m foo
echo 'asdf' > foo
git add foo
echo 'asdf' >> foo
```

Expected:
Shows modifications added, and modifications exist.

Actual:
The repo is shown as dirty, but no reason for it being dirty.
