### PR TITLE
cask: check for Homebrew path for completion file

### DIFF
--- a/plugins/cask/cask.plugin.zsh
+++ b/plugins/cask/cask.plugin.zsh
@@ -1,5 +1,21 @@
-if which cask &> /dev/null; then
-  source $(dirname $(which cask))/../etc/cask_completion.zsh
-else
-  print "zsh cask plugin: cask not found"
-fi
+() {
+  if which cask &> /dev/null; then
+    local cask_bin cask_base f comp_files
+    cask_bin=$(which cask)
+    cask_base=${cask_bin:h:h}
+    # Plain cask installation location (for Cask 0.7.2 and earlier)
+    comp_files=( $cask_base/etc/cask_completion.zsh )
+    # Mac Homebrew installs the completion in a different location
+    if which brew &> /dev/null; then
+      comp_files+=`brew --prefix`/share/zsh/site-functions/cask_completion.zsh
+    fi
+    for f in $comp_files; do
+      if [[ -f $f ]]; then
+        source $f;
+        break;
+      fi
+    done
+  else
+    print "zsh cask plugin: cask not found"
+  fi
+}


### PR DESCRIPTION
Fixes #3629.

Mac Homebrew installs the Cask zsh completion files to a different location (relative to the `cask` binary) than the plain Cask installation does. Add code to detect homebrew and check its cask completion location, too.

I've tested on OS X 10.9, and it works for me for regular Cask, Homebrew Cask, and having both installed. For the regular Cask, I had to grab version 0.7.2 instead of the head of master, because they're recently removed the zsh completions from the main Cask project. To install non-homebrew Cask version 0.7.2 for testing, do this:

```
cd
git clone https://github.com/cask/cask.git .cask
cd .cask
git checkout tags/v0.7.1
export PATH="~/.cask/bin:$PATH"
```

And then do `zsh -l` from that session. Or add that PATH statement in your `~/.zshrc` so that all new sessions pick it up.


