### PR TITLE
Removed extra % at the end of prompt for the kolo theme

### DIFF
--- a/themes/kolo.zsh-theme
+++ b/themes/kolo.zsh-theme
@@ -16,7 +16,7 @@ theme_precmd () {
 }
 
 setopt prompt_subst
-PROMPT='%B%F{magenta}%c%B%F{green}${vcs_info_msg_0_}%B%F{magenta} %{$reset_color%}%% '
+PROMPT='%B%F{magenta}%c%B%F{green}${vcs_info_msg_0_}%B%F{magenta} %{$reset_color%}% '
 
 autoload -U add-zsh-hook
 add-zsh-hook precmd  theme_precmd


### PR DESCRIPTION
I removed an extra % symbol at the end of the prompt for the kolo theme. The symbol was showing in terminal.