### PR TITLE
Installer: More thorough cleanup of files and unneeded `source` calls

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -3,7 +3,7 @@ function zsh_stats() {
 }
 
 function uninstall_oh_my_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/uninstall.sh
+  env ZSH=$ZSH SHORT_HOST=$SHORT_HOST zsh $ZSH/tools/uninstall.zsh
 }
 
 function upgrade_oh_my_zsh() {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -46,5 +46,5 @@ echo "\033[0;32m"'                        /____/                       ....is no
 echo "\n\n \033[0;32mPlease look over the ~/.zshrc file to select plugins, themes, and options.\033[0m"
 echo "\n\n \033[0;32mp.s. Follow us at http://twitter.com/ohmyzsh.\033[0m"
 echo "\n\n \033[0;32mp.p.s. Get stickers and t-shirts at http://shop.planetargon.com.\033[0m"
+
 env zsh
-. ~/.zshrc

--- a/tools/uninstall.zsh
+++ b/tools/uninstall.zsh
@@ -1,16 +1,23 @@
-echo "Removing ~/.oh-my-zsh"
-if [[ -d ~/.oh-my-zsh ]]
-then
-  rm -rf ~/.oh-my-zsh
+#!/usr/bin/env zsh
+
+echo "Removing $ZSH"
+if [[ -d $ZSH ]]; then
+  rm -rf $ZSH
 fi
 
+echo "Removing Oh My Zsh data files"
+if [[ -z $SHORT_HOST ]]; then
+  SHORT_HOST=${HOST/.*/}
+fi
+setopt null_glob
+rm -fv ~/.zsh-update ${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-*
+
+
 echo "Looking for original zsh config..."
-if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]
-then
+if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]; then
   echo "Found ~/.zshrc.pre-oh-my-zsh -- Restoring to ~/.zshrc";
 
-  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]
-  then
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
     ZSHRC_SAVE=".zshrc.omz-uninstalled-`date +%Y%m%d%H%M%S`";
     echo "Found ~/.zshrc -- Renaming to ~/${ZSHRC_SAVE}";
     mv ~/.zshrc ~/${ZSHRC_SAVE};
@@ -18,11 +25,9 @@ then
 
   mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
 
-  source ~/.zshrc;
 else
   echo "Switching back to bash"
   chsh -s /bin/bash
-  source /etc/profile
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."

--- a/tools/uninstall.zsh
+++ b/tools/uninstall.zsh
@@ -10,7 +10,7 @@ if [[ -z $SHORT_HOST ]]; then
   SHORT_HOST=${HOST/.*/}
 fi
 setopt null_glob
-rm -fv ~/.zsh-update ${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-*
+rm -fv ~/.zsh-update ~/.zshrc-e ${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-*
 
 
 echo "Looking for original zsh config..."


### PR DESCRIPTION
This makes the installer and uninstaller a bit better about hygiene, removing some extra data files and reducing the chance of missing `.oh-my-zsh` at a custom location.

* Change `uninstall.sh` to run under `zsh`, so we have access to better file globbing, string substitution, and $ZDOTDIR. (We can assume zsh is available at this point, becuase the `uninstall_oh_my_zsh` function that calls it is a `zsh` function.
* Have `uninstall.zsh` respect `$ZSH` for finding the `.oh-my-zsh` dir
* Remove additional oh-my-zsh data files in `uninstall.zsh`: `~/.zsh-update` and `~/.zcompdump-${SHORT_HOST}-*`
* Remove unneeded `source ~/.zshrc` in `uninstall.zsh`
* remove bogus `. ~/.zshrc` at end of install.sh: it would just read it in the `sh` process running `install.sh` right before exiting, so it would have no effect aside from sometimes kicking out syntax errors.

We could probably go a bit further with the principle of not deleting user-produced data during the uninstallation process, and preserve any files in their `$ZSH_CUSTOM` dir. As is, the default location for the custom dir is under `$ZSH`, so it gets blown away during the uninstall.