### PR TITLE
Fix invocation of gradlew

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -82,7 +82,7 @@ _gradlew_tasks () {
   if [ in_gradle ]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
-     gradlew tasks --all | grep "^[ ]*[a-zA-Z0-9:]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
+     ./gradlew tasks --all | grep "^[ ]*[a-zA-Z0-9:]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
     fi
     compadd -X "==== Gradlew Tasks ====" `cat .gradletasknamecache`
   fi


### PR DESCRIPTION
Gradle wrapper is typically in the current directory, not on PATH.

Closes #4166