### PR TITLE
Use camelCase for npm aliases

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,8 +1,14 @@
 eval "$(npm completion 2>/dev/null)"
 
-# Install and save to dependencies
-alias npms="npm i -S "
 
-# Install and save to dev-dependencies
-# Skipped if npmd module installed
-[[ ! -e $(which npmd) ]] && alias npmd="npm i -D "
+# npm package names are lowercase
+# - https://twitter.com/substack/status/23122603153150361
+# Thus, we've used camelCase for the following aliases:
+
+# Install and save to dependencies in your package.json
+# npms is used by https://www.npmjs.com/package/npms
+alias npmS="npm i -S "
+
+# Install and save to dev-dependencies in your package.json
+# npmd is used by https://github.com/dominictarr/npmd
+alias npmD="npm i -D "

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -4,4 +4,5 @@ eval "$(npm completion 2>/dev/null)"
 alias npms="npm i -S "
 
 # Install and save to dev-dependencies
-alias npmd="npm i -D "
+# Skipped if npmd module installed
+[[ ! -e $(which npmd) ]] && alias npmd="npm i -D "


### PR DESCRIPTION
A member of the community contacted me, letting me know they use an npm module that is globally installed as npmd. This module does not have very wide adoption, but it does highlight that I could have done better to prevent conflicts. As these aliases are for devs that use npm, and npm enforces lowercase names, a potential solve is to use camelCased aliases. 

Fixes #3640