### PR TITLE
Add fontello command into bundled list as default

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,6 +6,7 @@ alias bu="bundle update"
 alias bi="bundle_install"
 
 bundled_commands=(
+  fontello
   annotate
   cap
   capify


### PR DESCRIPTION
The command is from this very useful gem for rails developers: https://github.com/railslove/fontello_rails_converter