### PR TITLE
Correcting spelling error.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -14,7 +14,7 @@ if [[ -z "$ZSH_CUSTOM" ]]; then
     ZSH_CUSTOM="$ZSH/custom"
 fi
 
-# Set ZSH_CACHE_DIR to the path where cache files sould be created
+# Set ZSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/
 if [[ -z "$ZSH_CACHE_DIR" ]]; then
   ZSH_CACHE_DIR="$ZSH/cache/"


### PR DESCRIPTION
Correcting spelling error.
The word 'sould' should be 'should'.