### PR TITLE
Change 'la5routes' alias to Laravel 5's format

### DIFF
--- a/plugins/laravel5/laravel5.plugin.zsh
+++ b/plugins/laravel5/laravel5.plugin.zsh
@@ -17,4 +17,4 @@ alias la5='php artisan'
 
 alias la5dump='php artisan dump-autoload'
 alias la5cache='php artisan cache:clear'
-alias la5routes='php artisan routes'
+alias la5routes='php artisan route:list'


### PR DESCRIPTION
In Laravel 5's Artisan the command ```routes``` (use to show all routes in the app) has changed to ```route:list```

So I made some change from ```alias la5routes='php artisan routes'``` into ```alias la5routes='php artisan route:list'```