### PR TITLE
Fix chsh prompt for pipes

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,7 +34,7 @@ export PATH=\"$PATH\"
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
-    chsh -s `which zsh`
+    chsh -s `which zsh` < /dev/tty
 fi
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"


### PR DESCRIPTION
When oh-my-zsh is installed via pipes like `curl -L http://.../install.sh | sh`
authorization of `chsh` fails because it can't get password from its input.
This change forces `chsh` to take input from tty.
resolve #3516 