### PR TITLE
Remove `--max-count` option from `git log`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -60,9 +60,9 @@ compdef gcount=git
 alias gcl='git config --list'
 alias gcp='git cherry-pick'
 compdef _git gcp=git-cherry-pick
-alias glg='git log --stat --max-count=10'
+alias glg='git log --stat'
 compdef _git glg=git-log
-alias glgg='git log --graph --max-count=10'
+alias glgg='git log --graph'
 compdef _git glgg=git-log
 alias glgga='git log --graph --decorate --all'
 compdef _git glgga=git-log


### PR DESCRIPTION
Seriously, I don't want to use `--max-count=10` for `git log`. I used `glgga` all times because of this.