### PR TITLE
Modify agnoster theme for Mac OSX Yosemite

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,7 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR='⮀'
+SEGMENT_SEPARATOR='\ue0b0'
 
 
 # Begin a segment
@@ -76,7 +76,7 @@ prompt_git() {
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment red black 
-      st=' ±'
+      st=' \u00b1'
     else
       prompt_segment green black
 
@@ -101,7 +101,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\//⭠ }${vcs_info_msg_0_%% }${mode}"
+    echo -n "${ref/refs\/heads\//\ue0a0 }${vcs_info_msg_0_%% }${mode}"
   fi
 }
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -76,7 +76,6 @@ prompt_git() {
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment red black 
-      st=' \u00b1'
     else
       prompt_segment green black
 
@@ -89,7 +88,6 @@ prompt_git() {
     elif [[ -e "${repo_path}/rebase" || -e "${repo_path}/rebase-apply" || -e "${repo_path}/rebase-merge" || -e "${repo_path}/../.dotest" ]]; then
       mode=" >R>"
     fi
-    mode=$st;
     setopt promptsubst
     autoload -Uz vcs_info
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,8 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
+SEGMENT_SEPARATOR='⮀'
+
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -74,9 +75,11 @@ prompt_git() {
     dirty=$(parse_git_dirty)
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
-      prompt_segment yellow black
+      prompt_segment red black 
+      st=' ±'
     else
       prompt_segment green black
+
     fi
 
     if [[ -e "${repo_path}/BISECT_LOG" ]]; then
@@ -86,7 +89,7 @@ prompt_git() {
     elif [[ -e "${repo_path}/rebase" || -e "${repo_path}/rebase-apply" || -e "${repo_path}/rebase-merge" || -e "${repo_path}/../.dotest" ]]; then
       mode=" >R>"
     fi
-
+    mode=$st;
     setopt promptsubst
     autoload -Uz vcs_info
 
@@ -98,7 +101,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_%% }${mode}"
+    echo -n "${ref/refs\/heads\//⭠ }${vcs_info_msg_0_%% }${mode}"
   fi
 }
 


### PR DESCRIPTION
Agnoster theme for OSX Yosemite stopped working since the update.
Changed the unicode character for separator as well as adding the ± symbol for git so the theme would display correctly on Yosemite.