### PR TITLE
Format the time as mm:ss, not just m

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -13,8 +13,10 @@ autoload -Uz add-zsh-hook || { print "can't add zsh hook!"; return }
 
 if ! (type bgnotify_formatted | grep -q 'function'); then
   function bgnotify_formatted {
-    ## exit_status, command, elapsed_time
-    [ $1 -eq 0 ] && title="#win (took $3 s)" || title="#fail (took $3 s)"
+    ## exit_status, command, elapsed_seconds
+    minutes=$(( $3 / 60 ))
+    seconds=$(( $3 % 60 ))
+    [ $1 -eq 0 ] && title="#win (took $minutes:$seconds)" || title="#fail (took $minutes:$seconds)"
     bgnotify "$title" "$2"
   }
 fi


### PR DESCRIPTION
I prefer `12:34` over `754s` since it's more readable, but feel free to disreguard if you don't think it's necessary.