### PR TITLE
Timebox `git status` checks inside prompt_info

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -39,6 +39,11 @@ ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of th
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
 ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
 ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+ZSH_THEME_GIT_PROMPT_TIMEDOUT="?"            # Text to display if status check timed out
+
+# Timeout (in seconds, fractions OK) for SCM (git/hg/etc) info checks done
+# inside prompt
+ZSH_THEME_SCM_CHECK_TIMEOUT=1
 
 # Setup the prompt with pretty colors
 setopt prompt_subst

--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -4,4 +4,5 @@ PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(g
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_TIMEDOUT="%{$fg[blue]%}) %{$fg[red]%}?%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
This adds a user-configurable timeout to the `git status` call done inside `git_prompt_info()` so the prompt doesn't hang when you are in a slow-to-check repo, such as a very large repo or one accessed over a network file system.

Fixes #3009.
Fixes #3706.
Fixes #3723.
Maybe #3351.
Fixes #1160.
Maybe #38.

When it times out, it'll include an explicit "?" indicator in the prompt to show that it doesn't know what the repo's status is, instead of spuriously reporting either clean or dirty.

Gives "robbyrussell" theme support for the timed-out status check, with a "?" indicator.

The current way to deal with slow repos is to set `git config --add oh-my-zsh.hide-status 1` to turn off status display. This has a couple drawbacks:

* It requires you to identify and manually configure each slow repo.
* It affects all views of configured repos, regardless of how they're accessed. Some repos may only be slow when they're accessed via a remote filesystem, so you'd still want to see their status when viewed on a fast local filesystem.
* It is indistinguishable from a clean repo in the prompt's output, so you have to remember that it's been set for that repo.

### Implementation

Uses zsh's `coproc` and `read -p -t` to put a timeout on the `git status` call inside `git_prompt_info()`.

Introduces new theme configuration variables:
* `$ZSH_THEME_GIT_PROMPT_TIMEDOUT` - how the timeout appears in the theme's prompt
* `$ZSH_THEME_SCM_CHECK_TIMEOUT` - how long the timeout is

I chose the generic "SCM" instead of "GIT" in `$ZSH_THEME_SCM_CHECK_TIMEOUT` so the same control could be reused for `hg` and other source control systems if they want to implement timeboxing, too.

###  Effects

When you're in a slow git repo using a theme that includes git prompt info, it'll give up and show a "?" or other theme-defined status indicator instead of a clean/dirty indicator. Fast repos (where `git status` is <1 second, by default) work just as they did before.

If you really want it to grind out a status for every prompt, you can just set the $ZSH_THEME_SCM_CHECK_TIMEOUT to a very large number in your `~/.zshrc`.

Here's an example of what it looks like in the `robbyrussell` theme. When in a repo over a slow network connection (under `/Volumes/janke`), it times out and shows a "?". In a fast local repo (under `~`), it shows the normal clean/dirty indicator.

![git timeboxing in robbyrussell theme](https://cloud.githubusercontent.com/assets/2618447/6858325/fa69c61e-d3e3-11e4-9819-fe5de9a8c91a.png)

###   Future enhancements

If this works out, it could be improved further by having `git.zsh` track which repos have been slow in this session, and skip future `git status` checks for them for the rest of the session, so the prompt would be instantaneous, instead of eating the 1-second timeout each time it's presented.
