### PR TITLE
Quick way to "git branch --set-upstream-to=origin/<branch> <branch>"

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -146,6 +146,8 @@ alias ggpush='git push origin $(current_branch)'
 compdef ggpush=git
 alias ggpnp='git pull origin $(current_branch) && git push origin $(current_branch)'
 compdef ggpnp=git
+alias ggsup='git branch --set-upstream-to=origin/$(current_branch) $(current_branch)'
+compdef ggsup=git
 
 # Pretty log messages
 function _git_log_prettily(){


### PR DESCRIPTION
I have been using this for sometime now and decided to share. :grin: 

It uses the `$(current_branch)` function from _git.plugin.zsh_ and sets the upstream to the remote named `origin`.

Use: call the `ggsup` alias. :wink:
