### PR TITLE
rr theme: keep $ret_status really local with anonymous function

### DIFF
--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -1,6 +1,7 @@
-local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
-PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
-
+() {
+  local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
+  PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+}
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗%{$reset_color%}"


### PR DESCRIPTION
Changes the `robbyrussell` theme for variable hygiene. This wraps the use of "local" variable `$ret_status` in an anonymous function so it's local to just the theme setup, and doesn't leak `$ret_status` in to the global namespace.

Theme definitions are `source`d, and not autoloaded and called as functions, so they do not have their own scope for variable definitions aside from the caller's. Without the anonymous function, the `local ret_status` happens at the top level of the `zsh` session, and so is in the global namespace and still visible after the theme is loaded.

```
➜  ~  zsh -l
➜  ~  echo $ret_status
%(?:%{%}➜ :%{%}➜ %s)
➜  ~
```

Caused by #3742, which has a longer explanation.