### PR TITLE
Adding quotes to git completion discovery path

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -30,7 +30,7 @@ if [ -z "$script" ]; then
 	local -a locations
 	local e
 	locations=(
-		$(dirname ${funcsourcetrace[1]%:*})/git-completion.bash
+		"$(dirname ${funcsourcetrace[1]%:*})/git-completion.bash"
 		'/etc/bash_completion.d/git' # fedora, old debian
 		'/usr/share/bash-completion/completions/git' # arch, ubuntu, new debian
 		'/usr/share/bash-completion/git' # gentoo


### PR DESCRIPTION
The gitfast plugin file `_git` tries to find the `git-completion.bash` file by looking in several directories, including the directory containing `_git`. However, if there are spaces in that directory name (like there are for me because I have my home directory on a secondary hard drive), the search list looks like:

```
/etc/bash_completion.d/git
/usr/share/bash-completion/completions/git
/usr/share/bash-completion/git
/Volumes/Secondary
HD/michael/.oh-my-zsh/plugins/gitfast/git-completion.bash
```

when it should look like:

 ```
/etc/bash_completion.d/git
/usr/share/bash-completion/completions/git
/usr/share/bash-completion/git
/Volumes/Secondary HD/michael/.oh-my-zsh/plugins/gitfast/git-completion.bash
```

This pull request adds quotes to the directory parsing to fix this issue.