### PR TITLE
update chsh command call

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,7 +34,7 @@ export PATH=\"$PATH\"
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
-    chsh -s `which zsh`
+    chsh -s  $(chsh -l | grep "zsh" -m 1)
 fi
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"


### PR DESCRIPTION
/etc/shells may not point to /usr/bin/zsh (which is the result when using 'which zsh') 
using chsh -l and choosing zsh from there will guarantee chsh to work without failure.

Fixes #3779 