### PR TITLE
Add bbda for quick branch deletion

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -55,6 +55,7 @@ compdef _git gb=git-branch
 alias gba='git branch -a'
 compdef _git gba=git-branch
 alias gbr='git branch --remote'
+alias gbda='git branch --merged | grep -v "\*" | xargs -n 1 git branch -d'
 alias gcount='git shortlog -sn'
 compdef gcount=git
 alias gcl='git config --list'


### PR DESCRIPTION
Add the `gbda` ("git branch delete all") alias for quickly deleting all branches that have been merged into the current branch.

As far as I could tell, this is the only change that was necessary.