### PR TITLE
Plugin for iTerm2

### DIFF
--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -47,4 +47,22 @@ if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
     ITERM_PROFILE="$profile"
   }
 
+  ###
+  # iterm2_tab_color(): Changes the color of iTerm2's currently active tab.
+  # Usage: iterm2_tab_color <red> <green> <blue>
+  #        where red/green/blue are on the range 0-255.
+  function iterm2_tab_color() {
+    _iterm2_command "6;1;bg;red;brightness;$1"
+    _iterm2_command "6;1;bg;green;brightness;$2"
+    _iterm2_command "6;1;bg;blue;brightness;$3"
+  }
+
+
+  ###
+  # iterm2_tab_color_reset(): Resets the color of iTerm2's current tab back to
+  # default.
+  function iterm2_tab_color_reset() {
+    _iterm2_command "6;1;bg;*;default"
+  }
+
 fi

--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -8,6 +8,27 @@
 if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
 
   ###
+  # Executes an arbitrary iTerm2 command via an escape code sequce.
+  # See https://iterm2.com/documentation-escape-codes.html for all supported commands.
+  # Example: $ _iterm2_command "1337;StealFocus"
+  function _iterm2_command() {
+    local cmd="$1"
+
+    # Escape codes for wrapping commands for iTerm2.
+    local iterm2_prefix="\x1B]"
+    local iterm2_suffix="\x07"
+
+    # If we're in tmux, a special escape code must be prepended/appended so that
+    # the iTerm2 escape code is passed on into iTerm2.
+    if [[ -n $TMUX ]]; then
+      local tmux_prefix="\x1BPtmux;\x1B"
+      local tmux_suffix="\x1B\\"
+    fi
+
+    echo -n "${tmux_prefix}${iterm2_prefix}${cmd}${iterm2_suffix}${tmux_suffix}"
+  }
+
+  ###
   # iterm2_profile(): Function for changing the current terminal window's
   # profile (colors, fonts, settings, etc).
   # To change the current iTerm2 profile, call this function and pass in a name
@@ -16,20 +37,11 @@ if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
     # Desired name of profile
     local profile="$1"
 
-    # iTerm2 escape code for changing profile
-    local iterm2_code="\x1b]50;SetProfile=$profile\x7"
-
-    # If we're in tmux, a special escape code must be prepended
-    # so that the iTerm2 escape code is passed on into iTerm2.
-    local prefix=''
-    local suffix=''
-    if [[ -n $TMUX ]]; then
-      prefix='\033Ptmux;\033'
-      suffix='\033\\'
-    fi
+    # iTerm2 command for changing profile
+    local cmd="1337;SetProfile=$profile"
 
     # send the sequence
-    echo -n "${prefix}${iterm2_code}${suffix}"
+    _iterm2_command "${cmd}"
 
     # update shell variable
     ITERM_PROFILE="$profile"

--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -1,0 +1,38 @@
+#####################################################
+# iTerm2 plugin for oh-my-zsh                       #
+# Author: Aviv Rosenberg (github.com/avivrosenberg) #
+#####################################################
+
+###
+# This plugin is only relevant if the terminal is iTerm2 on OSX.
+if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
+
+  ###
+  # iterm2_profile(): Function for changing the current terminal window's
+  # profile (colors, fonts, settings, etc).
+  # To change the current iTerm2 profile, call this function and pass in a name
+  # of another existing iTerm2 profile (name can contain spaces).
+  function iterm2_profile() {
+    # Desired name of profile
+    local profile="$1"
+
+    # iTerm2 escape code for changing profile
+    local iterm2_code="\x1b]50;SetProfile=$profile\x7"
+
+    # If we're in tmux, a special escape code must be prepended
+    # so that the iTerm2 escape code is passed on into iTerm2.
+    local prefix=''
+    local suffix=''
+    if [[ -n $TMUX ]]; then
+      prefix='\033Ptmux;\033'
+      suffix='\033\\'
+    fi
+
+    # send the sequence
+    echo -n "${prefix}${iterm2_code}${suffix}"
+
+    # update shell variable
+    ITERM_PROFILE="$profile"
+  }
+
+fi


### PR DESCRIPTION
This plugin works when running in iTerm2 on OSX.

Currently it contains one function, `iterm2_profile()`, which allows easily changing the current user settings profile, without creating a new tab or window, just by calling the function.

For example, this is handy for switching from a dark to a light colored
profile without having to re-open anything.

In addition, it also works within tmux running inside iTerm2.

A usage example:
This allows running `bg_dark` or `bg_light` to switch between the two solarized themes (and also update the tmux bar).

``` shell
# OSX Specific
if [[ "$OSTYPE" = darwin* ]] ; then

  # These functions rely on the 'iterm2' zsh plugin
  if [[ "$plugins" =~ "iterm2" ]]; then

    function bg_dark() {
      iterm2_profile "Solarized Dark"
      update_tmux_colors
    }

    function bg_light() {
      iterm2_profile "Solarized Light"
      update_tmux_colors
    }

    function update_tmux_colors() {
      if [[ -n $TMUX ]]; then
        local tmux_file=''

        if [[ "$ITERM_PROFILE" =~ "[Ll]ight" ]]; then
          tmux_file="$DOTFILES/tmux/airline-colors-light.conf"
        else
          tmux_file="$DOTFILES/tmux/airline-colors-dark.conf"
        fi

        tmux source-file "$tmux_file" > /dev/null
      fi
    }

  fi
fi
```
