### PR TITLE
Grep bug in Agnoster

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -126,7 +126,7 @@ prompt_hg() {
       if `hg st | grep -q "^\?"`; then
         prompt_segment red black
         st='±'
-      elif `hg st | grep -q "^(M|A)"`; then
+      elif `hg st | grep -q "^[MA]"`; then
         prompt_segment yellow black
         st='±'
       else


### PR DESCRIPTION
In Agnoster theme, in order to detect a modified file, hg status is grepped
Currently it uses regex "^(M|A)" to look for a M or A after a line break, when instead it should be "^[MA]"