### PR TITLE
No input for Update Check defaults to Yes

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -41,10 +41,9 @@ then
     then
       _upgrade_zsh
     else
-      echo "[Oh My Zsh] Would you like to check for updates?"
-      echo "Type Y to update oh-my-zsh: \c"
+      echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
       read line
-      if [ "$line" = Y ] || [ "$line" = y ]; then
+      if [ "$line" = Y ] || [ "$line" = y ] || [ -z "$line" ]; then
         _upgrade_zsh
       else
         _update_zsh_update


### PR DESCRIPTION
This fixes issue #3735 by adding a [Y/n] to the update request, and defaults to continue if there is no input.

Fixes #3735 