### PR TITLE
Reduce prompt delay in large git repos

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -39,9 +39,7 @@ function _ruby_version() {
 # use a neutral color, otherwise colors will vary according to time.
 function _git_time_since_commit() {
 # Only proceed if there is actually a commit.
-  if git log -1 > /dev/null 2>&1; then
-    # Get the last commit.
-    last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
+  if last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null); then
     now=$(date +%s)
     seconds_since_last_commit=$((now-last_commit))
 


### PR DESCRIPTION
The avit theme's _git_time_since_commit function was running git up to
three times, one of which piped the entire git log for the current
branch to /dev/null. Replace it with a single call to `git log`,
checking the exit code for success.
