### PR TITLE
Fix for gpg-agent on OSX

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -30,7 +30,7 @@ if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
         if ssh-add -l > /dev/null 2> /dev/null; then
             # ssh-agent running, start gpg-agent without ssh support
             start_agent_nossh;
-        else if [][ "$OSTYPE" = "darwin"* ]; then
+        elif [[ "$OSTYPE" = "darwin"* ]]; then
             start_agent_nossh
         else
             # otherwise start gpg-agent with ssh support

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -30,6 +30,8 @@ if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
         if ssh-add -l > /dev/null 2> /dev/null; then
             # ssh-agent running, start gpg-agent without ssh support
             start_agent_nossh;
+        else if [][ "$OSTYPE" = "darwin"* ]; then
+            start_agent_nossh
         else
             # otherwise start gpg-agent with ssh support
             start_agent_withssh;


### PR DESCRIPTION
If the native osx ssh-agent isn't running (e.g. if ssh hasn't yet been run on the mac since boot), then gpg-agent will start with ssh support when a new shell window is opened, precluding the use of native ssh-agent support (inc. keychain access).
