### PR TITLE
Use the newest Vundle commands

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -13,15 +13,15 @@ function vundle-init () {
 
 function vundle () {
   vundle-init
-  vim -c "execute \"BundleInstall\" | q | q"
+  vim -c "execute \"PluginInstall\" | q | q"
 }
 
 function vundle-update () {
   vundle-init
-  vim -c "execute \"BundleInstall!\" | q | q"
+  vim -c "execute \"PluginInstall!\" | q | q"
 }
 
 function vundle-clean () {
   vundle-init
-  vim -c "execute \"BundleClean!\" | q | q"
+  vim -c "execute \"PluginClean!\" | q | q"
 }


### PR DESCRIPTION
Vundle changed the command names during an interface update. The old commands will be deprecated. Ref https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396