### PR TITLE
install.sh: fail gracefully when zsh is not installed

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -33,8 +33,16 @@ export PATH=\"$PATH\"
 " ~/.zshrc
 
 if [ "$SHELL" != "$(which zsh)" ]; then
+  zsh --version > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
+    echo "\033[0;34mRunning:\033[0;1m chsh -s `which zsh`\033[0m"
     chsh -s `which zsh`
+  else
+    echo "\033[0;33mzsh does not appear to be installed.\033[0m"
+    echo "\033[0;33mPlease install \033[0;1mzsh\033[0;33m and then run:\033[0;1m chsh -s \`which zsh\`\033[0m"
+    exit
+  fi
 fi
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"


### PR DESCRIPTION
This is in response to #3360.

Basically this changes two things:

- It prints out `Running: chsh -s /bin/zsh` right before running `chsh` so if that fails the user can fix the problem and copy-paste, try again.
- If zsh is not installed it tells the user this and then instructs the user to install zsh then run `` chsh -s `which zsh` `` afterwards.

In the latter case it exits afterwards to prevent the next step from failing, i.e. `env zsh`.

This could be improved on by restructuring the logic further and bailing out earlier when `zsh` is not installed, similar to how it handles `git` not being available. However, this is still better than the current behavior of `chsh` failing and the install stopping in the middle:

```
$ curl -L http://install.ohmyz.sh | sh
[...]
Cloning Oh My Zsh...
Cloning into '/home/user/.oh-my-zsh'...
[...]
Looking for an existing zsh config...
Using the Oh My Zsh template file and adding it to ~/.zshrc
Copying your current PATH and adding it to the end of ~/.zshrc for you.
Time to change your default shell to zsh!
chsh: option requires an argument -- 's'
Usage: chsh [options] [LOGIN]

Options:
  -h, --help                    display this help message and exit
  -s, --shell SHELL             new login shell for the user account

```

Here's a screen show of the new lines:

![screen shot 2015-04-21 at 8 03 40 pm](https://cloud.githubusercontent.com/assets/100427/7266638/9fe01eea-e861-11e4-90a7-b4a21f8186bf.png)
