### PR TITLE
Specify log format for git checks

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -51,15 +51,15 @@ git_remote_status() {
 
 # Checks if there are commits ahead from remote
 function git_prompt_ahead() {
-  if $(echo "$(command git log @{upstream}..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
+  if [ -n "$(command git log --pretty=oneline @{upstream}..HEAD 2> /dev/null)" ]; then
     echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
 }
 
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
-  if $(echo "$(command git log @{upstream}..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
-    COMMITS=$(command git log @{upstream}..HEAD | grep '^commit' | wc -l | tr -d ' ')
+  if [ -n "$(command git log --pretty=oneline @{upstream}..HEAD 2> /dev/null)" ]; then
+    COMMITS=$(command git log --pretty=oneline @{upstream}..HEAD | wc -l | tr -d ' ')
     echo "$ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX$COMMITS$ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
   fi
 }


### PR DESCRIPTION
Some git configs override the default log format so `git log` alone behaves differently on different machines. This should normalize it and it simplifies the conditionals.
