### PR TITLE
Rbenv directory search order with brew

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -9,7 +9,7 @@ _rbenv-from-homebrew-installed() {
 FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
 if _homebrew-installed && _rbenv-from-homebrew-installed ; then
-    rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
+    rbenvdirs=("${rbenvdirs[@]}" $(brew --prefix rbenv))
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
The bug is that as-written, rbenv (if installed by brew) always uses the brew prefix directory and the RBENV_ROOT. But the default desired behavior of rbenv is to use the $HOME/.rbenv to store installed rubies. As a result, you get the system ruby only.

My change builds upon the #3275 pull request from @mbologna and reverses the order of the search directories for rbenv to put the brew prefix last.

Since this bug only occurs for brew users, non-OSX users will not be affected.
