### PR TITLE
Update Homebrew plugin as `brew upgrade` soon will require `--all` parameter

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,2 +1,2 @@
 alias brews='brew list -1'
-alias bubu="brew update && brew upgrade && brew cleanup"
+alias bubu="brew update && brew upgrade --all && brew cleanup"


### PR DESCRIPTION
In the latest version of Homebrew, when you try to run `brew upgrade`, it will prompt you

```
Warning: brew upgrade with no arguments will change behaviour soon!
It currently upgrades all formula but this will soon change to require '--all'.
Please update any workflows, documentation and scripts!
```

So, add this parameter to avoid errors when upgrading Homebrew in the future (possibly).