### PR TITLE
Fix minimal.zsh-theme's check for in_svn and add support for mercurial

### DIFF
--- a/themes/minimal.zsh-theme
+++ b/themes/minimal.zsh-theme
@@ -6,10 +6,16 @@ ZSH_THEME_SVN_PROMPT_PREFIX=$ZSH_THEME_GIT_PROMPT_PREFIX
 ZSH_THEME_SVN_PROMPT_SUFFIX=$ZSH_THEME_GIT_PROMPT_SUFFIX
 ZSH_THEME_SVN_PROMPT_DIRTY=$ZSH_THEME_GIT_PROMPT_DIRTY
 ZSH_THEME_SVN_PROMPT_CLEAN=$ZSH_THEME_GIT_PROMPT_CLEAN
+ZSH_THEME_HG_PROMPT_PREFIX=$ZSH_THEME_GIT_PROMPT_PREFIX
+ZSH_THEME_HG_PROMPT_SUFFIX=$ZSH_THEME_GIT_PROMPT_SUFFIX
+ZSH_THEME_HG_PROMPT_DIRTY=$ZSH_THEME_GIT_PROMPT_DIRTY
+ZSH_THEME_HG_PROMPT_CLEAN=$ZSH_THEME_GIT_PROMPT_CLEAN
 
 vcs_status() {
-    if [[ ( $(whence in_svn) != "" ) && ( $(in_svn) == 1 ) ]]; then
+    if [[ $(whence in_svn) != "" ]] && in_svn; then
         svn_prompt_info
+    elif [[ $(whence in_hg) != "" ]] && in_hg; then
+        hg_prompt_info
     else
         git_prompt_info
     fi


### PR DESCRIPTION
6ce08acb27 broke minimal.zsh-theme's check for SVN repos.  I've updated minimal.zsh-theme to use the return code instead of output value.  Additionally took the time to add support for mercurial as well.