### PR TITLE
Allow setting path to nvm install dir.

### DIFF
--- a/plugins/nvm/_nvm
+++ b/plugins/nvm/_nvm
@@ -1,7 +1,7 @@
 #compdef nvm
 #autoload
 
-[[ -s ~/.nvm/nvm.sh ]] || return 0
+[[ -s "${NVM_DIR:=~/.nvm}" ]] || return 0
 
 local -a _1st_arguments
 _1st_arguments=(

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,3 +1,4 @@
 # The addition 'nvm install' attempts in ~/.profile
 
-[[ -s ~/.nvm/nvm.sh ]] && . ~/.nvm/nvm.sh
+NVM_DIR="${NVM_DIR:=~/.nvm}"
+[[ -s "${NVM_DIR}/nvm.sh" ]] && . "${NVM_DIR}/nvm.sh"


### PR DESCRIPTION
This PR is a very small change to the `nvm` plugin.

The plugin is now closer to the code that the `nvm` install script puts in the `.bashrc` file by default. This allows for specifying where `nvm` is installed so that global installs can be achieved. The plugin now looks for the `NVM_DIR` environment variable that should contain the `nvm` install path. The default value is `~/.nvm` to not break config of people using this plugin.