### PR TITLE
Add hyphen insensitivity

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -15,7 +15,12 @@ if [ "x$CASE_SENSITIVE" = "xtrue" ]; then
   zstyle ':completion:*' matcher-list 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
   unset CASE_SENSITIVE
 else
-  zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  if [ "x$HYPHEN_INSENSITIVE" = "xtrue" ]; then
+    zstyle ':completion:*' matcher-list 'm:{a-zA-Z-_}={A-Za-z_-}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+    unset HYPHEN_INSENSITIVE
+  else
+    zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  fi
 fi
 
 zstyle ':completion:*' list-colors ''


### PR DESCRIPTION
I find it quite useful to be able to type a hyphen ('-') and then have it be completed to an underscore. 

This could be bundled in with case insensitivity, but that might be an annoying change for some users.