### PR TITLE
brew required a flag to upgrade all formulas

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,2 +1,2 @@
 alias brews='brew list -1'
-alias bubu="brew update && brew upgrade && brew cleanup"
+alias bubu="brew update && brew upgrade --all && brew cleanup"


### PR DESCRIPTION
Add a `--all` flag to upgrade all formulas

```
$ brew upgrade
Warning: brew upgrade with no arguments will change behaviour soon!
It currently upgrades all formula but this will soon change to require '--all'.
Please update any workflows, documentation and scripts!
$ brew upgrade --all
```