### PR TITLE
added new required flag --all to brew upgrade

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,2 +1,2 @@
 alias brews='brew list -1'
-alias bubu="brew update && brew upgrade && brew cleanup"
+alias bubu="brew update && brew upgrade --all && brew cleanup"


### PR DESCRIPTION
homebrew reports that the behavior of "brew upgrade" will soon change and the old behavior (upgrading all formulas) will require the --all flag. This is already working, so no reason not to adjust it already.