### PR TITLE
Updating README

### DIFF
--- a/plugins/history-substring-search/README.markdown
+++ b/plugins/history-substring-search/README.markdown
@@ -1,6 +1,6 @@
 To activate this script, please include it the `plugins` variable within `~/.zshrc`
 
-  `plugins=(git history-substring-search.zsh)`
+  `plugins=(git history-substring-search)`
 
 See the "history-substring-search.zsh" file for more information:
 


### PR DESCRIPTION
This Change remove the .zsh on the plugin activate example, cause with the .zsh at the end the plugin won't be activated