### PR TITLE
Plugins: add a plugin helper plugin

### DIFF
--- a/plugins/plugin-helper/LICENSE
+++ b/plugins/plugin-helper/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 KhasMek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/plugins/plugin-helper/README.md
+++ b/plugins/plugin-helper/README.md
@@ -1,0 +1,48 @@
+## OH-MY-ZSH PLUGIN HELPER
+
+This is a pretty straightforward plugin for oh-my-zsh that's sole purpose is to
+be a helper for other available OMZ plugins.
+
+---
+
+### FEATURES
+
+| Function              | Alias | Description                                   |
+|:----------------------|:-----:|----------------------------------------------:|
+| disable_plugin        | phdp  | Disable specified plugin                      |
+| enable_plugin         | phep  | Enable specified plugin                       |
+| print_all_plugins     | phpap | List all plugins                              |
+| print_enabled_plugins | phpep | List all enabled plugins                      |
+| print_all_readmes     | phpar | Get a list of all plugins with a README       |
+| print_aliases         | phpa  | Print list of aliases for specified plugin(s) |
+| print_readme          | phpr  | Print README for the specified plugin         |
+
+---
+
+### NOTES
+
+The output of the README's  in the print_readme function looks a lot better with
+[Pandoc](http://johnmacfarlane.net/pandoc/), but it's not required.
+
+##### Mac OS
+```
+brew install pandoc
+```
+##### Ubuntu
+```
+sudo apt-get install pandoc
+```
+
+---
+
+### LICENSE
+
+The project is licensed under the
+[MIT-license](https://github.com/mfaerevaag/wd/blob/master/LICENSE).
+
+---
+
+### CONTRIBUTORS
+KhasMek - Creator
+
+---

--- a/plugins/plugin-helper/plugin-helper.plugin.zsh
+++ b/plugins/plugin-helper/plugin-helper.plugin.zsh
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------------
+#          FILE:  plugin-helper.plugin.zsh
+#   DESCRIPTION:  oh-my-zsh plugin helper.
+#        AUTHOR:  Khas Mek (Boushh@gmail.com)
+#       VERSION:  1.0.0
+# ------------------------------------------------------------------------------
+
+local rc=~/.zshrc
+local orn=$(echo -e '\033[33m')
+local red=$(echo -e '\033[31m')
+local rst=$(echo -e '\033[0m')
+local no_plugin=$red"\n  Plugin not found!\n"$rst
+
+function print_enabled_plugins()
+{
+  print "$plugins" | tr " " "\n" | sort
+  print  $orn"\n  Above are the currently enabled plugins."$rst
+}
+alias phpep='print_enabled_plugins'
+
+function print_all_plugins()
+{
+  ls $ZSH/plugins
+  print $orn"\n  Above are the current options."$rst
+}
+alias phpap='print_all_plugins'
+
+function print_all_readmes()
+{
+  for readme in $(find $ZSH/plugins -iname "README*"); do
+    print $readme | awk -F/ '{print $(NF-1)}'
+  done
+  print  $orn"\n  Above are the current plugins with a README file."$rst
+}
+alias phpar='print_all_readmes'
+
+function print_readme()
+{
+  if [[ -n $1 ]]; then
+    if [[ $(find $ZSH/plugins/$1 -iname "README*" | wc -l) -eq 0 ]]; then
+      print $red"\n  Plugin $1 has no readme file!" $rst
+    else
+      for readme in $(find $ZSH/plugins/$1 -iname "README*"); do
+        if [[ -n $(command -v pandoc) ]]; then
+          pandoc -s -f markdown_github -t man "$readme" \
+            | groff -T utf8 -man - \
+            | less
+        else
+          less "$readme"
+        fi
+      done
+    fi
+  else
+    print $red"\n  Please specify a plugin to view the README of!\n"$rst
+    print_all_readmes
+  fi
+}
+alias phpr='print_readme'
+
+function print_aliases()
+{
+  if [[ -n $1 ]]; then
+    for plugin in $(echo "$@"); do
+      print $orn"\n  --$plugin--\n"$rst
+      grep -r '^alias' $ZSH/plugins/$plugin/ --include \*.zsh \
+        | awk '{$1=""; print}' \
+        | sed -e "s/^ /$orn/g" -e "s/=/$rst\ =\ /g" \
+        | sort
+    done
+  else
+    print $red"\n  Please specify a plugin to view the alises of!"$rst
+  fi
+}
+alias phpa='print_aliases'
+
+function enable_plugin()
+{
+  if [[ -n $1 ]]; then
+    if [[ -d $ZSH/plugins/$1 ]]; then
+      sed -i "/^plugins=/s/)$/ $1&/" $rc
+      print $orn"\n  Re-sourcing $rc"$rst
+      source $rc
+    else
+      print $no_plugin
+      print_all_plugins
+    fi
+  else
+    print $red"\n  Please specify a plugin to enable!\n"$rst
+    print_all_plugins
+  fi
+}
+alias phep='enable_plugin'
+
+function disable_plugin()
+{
+  if [[ -n $1 ]]; then
+    if [[ -n $(grep -E "^plugins=.*[( ]$1[ )]" $rc) ]]; then
+      local line_number=$(grep -En "^plugins=.*[( ]$1[ )]" $rc | cut -f 1 -d:)
+      sed -i -e "${line_number}s/\([( ]\)$1\([ )]\)/\1\2/g" \
+        -e "${line_number}s/  */ /g" \
+        -e "${line_number}s/( /(/g" \
+        -e "${line_number}s/ )/)/g" $rc
+      print $orn"\n  Re-sourcing $rc"$rst
+      source $rc
+    else
+      print $no_plugin
+      print_enabled_plugins
+    fi
+  else
+    print $red"\n  Please specify a plugin to disable!\n"$rst
+    print_enabled_plugins
+  fi
+}
+alias phdp='disable_plugin'
+


### PR DESCRIPTION
  The purpose of this plugin is to assist with the use
  and interaction of other plugins.

  Current features are as follows
  - list all plugins
  - list all enabled plugins
  - list all plugins with README files
  - print the README file of specified plugin (similar
    to the man function for other CLI programs)
  - print all aliases of specified plugin(s)
  - enable a specified plugin
  - disable a specified plugin