### PR TITLE
gradle plugin: also list tasks in subprojects

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -72,7 +72,7 @@ _gradle_tasks () {
   if [ in_gradle ]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
-     gradle tasks --all | grep "^[ ]*[a-zA-Z0-9]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
+      gradle tasks --all | awk '/[a-zA-Z0-9:-]* - / {print $1}' > .gradletasknamecache
     fi
     compadd -X "==== Gradle Tasks ====" `cat .gradletasknamecache`
   fi
@@ -82,7 +82,7 @@ _gradlew_tasks () {
   if [ in_gradle ]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
-     gradlew tasks --all | grep "^[ ]*[a-zA-Z0-9]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
+      gradlew tasks --all | awk '/[a-zA-Z0-9:-]* - / {print $1}' > .gradletasknamecache
     fi
     compadd -X "==== Gradlew Tasks ====" `cat .gradletasknamecache`
   fi


### PR DESCRIPTION
With this fix gradle autocomplete also lists tasks in subprojects (separated by ':') and task and project names containing '-'. I also simplified the mathing by using awk.