### PR TITLE
fasd: drop-in replacement for the autojump j alias

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -8,4 +8,5 @@ if [ $commands[fasd] ]; then # check if fasd is installed
 
   alias v='f -e vim'
   alias o='a -e open_command'
+  alias j='zz'
 fi


### PR DESCRIPTION
I really got used to that autojump alias which got into my muscle memory, so I am now bringing fasd closer to an autojump drop-in replacement.
