### PR TITLE
Don't clobber default LSCOLORS, if DISABLE_LS_COLORS is set to true.

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -1,10 +1,10 @@
 # ls colors
 autoload -U colors && colors
-export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
 # Enable ls colors
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
+  export LSCOLORS="Gxfxcxdxbxegedabagacad"
   # Find the option for using colors in ls, depending on the version: Linux or BSD
   if [[ "$(uname -s)" == "NetBSD" ]]; then
     # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);


### PR DESCRIPTION
This change makes oh-my-zsh touch the LSCOLORS variable only if DISABLE_LS_COLORS is not set.

Background:
I don't want colors by default, and I manually run `ls -G` (on Mac OS X) when I want colors.

For users who've grown accustomed to the default `ls` colors, it's a bit jarring to have oh-my-zsh show everything in new colors, even when they think they've turned off this setting with `DISABLE_LS_COLORS=true`.

Anyway, there is no good reason to `export LSCOLORS` when `DISABLE_LS_COLORS` is set, so this change should be strictly better.