### PR TITLE
Repair `zsh` Path Permissions on `oh-my-zsh` Startup under Cygwin

### DIFF
--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -1,0 +1,60 @@
+# Handle completions insecurities (i.e., completion-dependent directories with
+# insecure ownership or permissions) by:
+#
+# * Human-readably notifying the user of these insecurities.
+# * Moving away all existing completion caches to a temporary directory. Since
+#   any of these caches may have been generated from insecure directories, they
+#   are all suspect now. Failing to do so typically causes subsequent compinit()
+#   calls to fail with "command not found: compdef" errors. (That's bad.)
+function handle_completion_insecurities() {
+  # List of the absolute paths of all unique insecure directories, split on
+  # newline from compaudit()'s output resembling:
+  #
+  #     There are insecure directories:
+  #     /usr/share/zsh/site-functions
+  #     /usr/share/zsh/5.0.6/functions
+  #     /usr/share/zsh
+  #     /usr/share/zsh/5.0.6
+  #
+  # Since the ignorable first line is printed to stderr and thus not captured,
+  # stderr is squelched to prevent this output from leaking to the user. 
+  local -aU insecure_dirs
+  insecure_dirs=( ${(f@):-"$(compaudit 2>/dev/null)"} )
+
+  # If no such directories exist, get us out of here.
+  if (( ! ${#insecure_dirs} )); then
+      print "[oh-my-zsh] No insecure completion-dependent directories detected."
+      return
+  fi
+
+  # List ownership and permissions of all insecure directories.
+  print "[oh-my-zsh] Insecure completion-dependent directories detected:"
+  ls -ld "${(@)insecure_dirs}"
+  print "[oh-my-zsh] For safety, completions will be disabled until you manually fix all"
+  print "[oh-my-zsh] insecure directory permissions and ownership and restart oh-my-zsh."
+  print "[oh-my-zsh] See the above list for directories with group or other writability.\n"
+
+  # Locally enable the "NULL_GLOB" option, thus removing unmatched filename
+  # globs from argument lists *AND* printing no warning when doing so. Failing
+  # to do so prints an unreadable warning if no completion caches exist below.
+  setopt local_options null_glob
+
+  # List of the absolute paths of all unique existing completion caches.
+  local -aU zcompdump_files
+  zcompdump_files=( "${ZSH_COMPDUMP}"(.) "${ZDOTDIR:-${HOME}}"/.zcompdump* )
+
+  # Move such caches to a temporary directory.
+  if (( ${#zcompdump_files} )); then
+    # Absolute path of the directory to which such files will be moved.
+    local ZSH_ZCOMPDUMP_BAD_DIR="${ZSH_CACHE_DIR}/zcompdump-bad"
+
+    # List such files first.
+    print "[oh-my-zsh] Insecure completion caches also detected:"
+    ls -l "${(@)zcompdump_files}"
+
+    # For safety, move rather than permanently remove such files.
+    print "[oh-my-zsh] Moving to \"${ZSH_ZCOMPDUMP_BAD_DIR}/\"...\n"
+    mkdir -p "${ZSH_ZCOMPDUMP_BAD_DIR}"
+    mv "${(@)zcompdump_files}" "${ZSH_ZCOMPDUMP_BAD_DIR}/"
+  fi
+}

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -8,6 +8,9 @@ fi
 # add a function path
 fpath=($ZSH/functions $ZSH/completions $fpath)
 
+# Load all stock functions (from $fpath files) called below.
+autoload -U compaudit compinit
+
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$ZSH_CUSTOM" ]]; then
@@ -64,9 +67,14 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-# Load and run compinit
-autoload -U compinit
-compinit -i -d "${ZSH_COMPDUMP}"
+# If completion insecurities exist, warn the user without enabling completions.
+if ! compaudit &>/dev/null; then
+  # This function resides in the "lib/compfix.zsh" script sourced above.
+  handle_completion_insecurities
+# Else, enable and cache completions to the desired file.
+else
+  compinit -d "${ZSH_COMPDUMP}"
+fi
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -9,6 +9,13 @@ if [ -d "$ZSH" ]; then
   exit
 fi
 
+# Prevent the cloned repository from having insecure permissions. Failing to do
+# so causes compinit() calls to fail with "command not found: compdef" errors
+# for users with insecure umasks (e.g., "002", allowing group writability). Note
+# that this will be ignored under Cygwin by default, as Windows ACLs take
+# precedence over umasks except for filesystems mounted with option "noacl".
+umask g-w,o-w
+
 echo "\033[0;34mCloning Oh My Zsh...\033[0m"
 hash git >/dev/null 2>&1 && env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
   echo "git not installed"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -39,12 +39,17 @@ sed -i -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
 " ~/.zshrc
 
-TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
-if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
+# If this user's login shell is not already "zsh", attempt to switch.
+if [ "$(expr "$SHELL" : '.*/\(.*\)')" != "zsh" ]; then
+  # If this platform provides a "chsh" command (not Cygwin), do it, man!
+  if hash chsh >/dev/null 2>&1; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
     chsh -s $(grep /zsh$ /etc/shells | tail -1)
+  # Else, suggest the user do so manually.
+  else
+    echo "\033[0;34mPlease manually change your default shell to zsh!\033[0m"
+  fi
 fi
-unset TEST_CURRENT_SHELL
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"
 echo "\033[0;32m"'  ____  / /_     ____ ___  __  __   ____  _____/ /_  '"\033[0m"


### PR DESCRIPTION
This pull request fixes #630 for Cygwin as well as [babun](https://github.com/babun/babun) issues [#159](https://github.com/babun/babun/issues/159), [#281](https://github.com/babun/babun/issues/281), and [#322](https://github.com/babun/babun/issues/322). For non-Cygwin platforms (e.g., Linux, OS X), this only partially addresses #630 by improving startup error reporting in a platform-independent manner. In theory, that should both improve the readability of related bug reports *and* enable end users to locally fix this issue themselves.

## The Problem

The `oh-my-zsh.sh` startup script currently caches completions as follows:

    compinit -i -d "${ZSH_COMPDUMP}"

**That's a problem.** The `-i` option instructs `compinit()` to silently ignore all top-level completion-dependent directories having insecure permissions and/or ownership, typically resulting in an effectively empty `.zcompdump` file [*read:* on the order of 160B rather than the expected 32KB]. That, in turn, results in insanely obscure, non-human-readable output on `oh-my-zsh` startup resembling:

```
add-zsh-hook () {
emulate -L zsh
local -a hooktypes
hooktypes=(chpwd precmd preexec periodic zshaddhistory zshexit zsh_directory_name)
local usage="Usage: $0 hook function\nValid hooks are:\n $hooktypes"
local opt
local -a autoopts
integer del list help
while getopts "dDhLUzk" opt
do
case $opt in
(d) del=1 ;;
(D) del=2 ;;
(h) help=1 ;;
(L) list=1 ;;
([Uzk]) autoopts+=(-$opt) ;;
() return 1 ;;
esac
done
shift $(( OPTIND - 1 ))
if (( list ))
then
typeset -mp "(${1:-${(@j:|:)hooktypes}})_functions"
return $?
elif (( help || $# != 2 || ${hooktypes[(I)$1]} == 0 ))
then
print -u$(( 2 - help )) $usage
return $(( 1 - help ))
fi
local hook="${1}_functions"
local fn="$2"
if (( del ))
then
if (( ${(P)+hook} ))
then
if (( del == 2 ))
then
set -A $hook ${(P)hook:#${~fn}}
else
set -A $hook ${(P)hook:#$fn}
fi
if (( ! ${(P)#hook} ))
then
unset $hook
fi
fi
else
if (( ${(P)+hook} ))
then
if (( ${${(P)hook}[(I)$fn]} == 0 ))
then
set -A $hook ${(P)hook} $fn
fi
else
set -A $hook $fn
fi
autoload $autoopts -- $fn
fi
}
compdump () {
# undefined
builtin autoload -XUz
}
compinit () {
emulate -L zsh
setopt extendedglob
typeset _i_dumpfile _i_files _i_line _i_done _i_dir _i_autodump=1
typeset _i_tag _i_file _i_addfiles _i_fail=ask _i_check=yes _i_name
while [[ $# -gt 0 && $1 = -[dDiuC] ]]
do
case "$1" in
(-d) _i_autodump=1
shift
if [[ $# -gt 0 && "$1" != -[dfQC] ]]
then
_i_dumpfile="$1"
shift
fi ;;
(-D) _i_autodump=0
shift ;;
(-i) _i_fail=ign
shift ;;
(-u) _i_fail=use
shift ;;
(-C) _i_check=
shift ;;
esac
done
typeset -gA _comps _services _patcomps _postpatcomps
typeset -gA _compautos
typeset -gA _lastcomp
if [[ -n $_i_dumpfile ]]
then
typeset -g _comp_dumpfile="$_i_dumpfile"
else
typeset -g _comp_dumpfile="${ZDOTDIR:-$HOME}/.zcompdump"
fi
typeset -ga _comp_options
_comp_options=(bareglobqual extendedglob glob multibyte nullglob rcexpandparam unset NO_allexport NO_aliases NO_cshnullglob NO_cshjunkiequotes NO_errexit NO_globsubst NO_histsubstpattern NO_ignorebraces NO_ignoreclosebraces NO_kshglob NO_ksharrays NO_kshtypeset NO_markdirs NO_octalzeroes NO_shwordsplit NO_shglob NO_warncreateglobal)
typeset -g _comp_setup='local -A _comp_caller_options;
_comp_caller_options=(${(kv)options[@]});
setopt localoptions localtraps ${_comp_options[@]};
local IFS=$'\'\ \t\r\n\0\''
exec </dev/null;
trap - ZERR
local -a reply
local REPLY'
typeset -ga compprefuncs comppostfuncs
compprefuncs=()
comppostfuncs=()
: $funcstack
compdef () {
local opt autol type func delete eval new i ret=0 cmd svc
local -a match mbegin mend
emulate -L zsh
setopt extendedglob
if (( ! $# ))
then
print -u2 "$0: I need arguments"
return 1
fi
while getopts "anpPkKde" opt
do
case "$opt" in
(a) autol=yes ;;
(n) new=yes ;;
([pPkK]) if [[ -n "$type" ]]
then
print -u2 "$0: type already set to $type"
return 1
fi
if [[ "$opt" = p ]]
then
type=pattern
elif [[ "$opt" = P ]]
then
type=postpattern
elif [[ "$opt" = K ]]
then
type=widgetkey
else
type=key
fi ;;
(d) delete=yes ;;
(e) eval=yes ;;
esac
done
shift OPTIND-1
if (( ! $# ))
then
print -u2 "$0: I need arguments"
return 1
fi
if [[ -z "$delete" ]]
then
if [[ -z "$eval" ]] && [[ "$1" = *\= ]]
then
while (( $# ))
do
if [[ "$1" = \= ]]
then
cmd="${1%%\=}"
svc="${1#\=}"
func="$comps[${_services[(r)$svc]:-$svc}]"
[[ -n ${_services[$svc]} ]] && svc=${_services[$svc]}
[[ -z "$func" ]] && func="${${_patcomps[(K)$svc][1]}:-${_postpatcomps[(K)$svc][1]}}"
if [[ -n "$func" ]]
then
_comps[$cmd]="$func"
_services[$cmd]="$svc"
else
print -u2 "$0: unknown command or service: $svc"
ret=1
fi
else
print -u2 "$0: invalid argument: $1"
ret=1
fi
shift
done
return ret
fi
func="$1"
[[ -n "$autol" ]] && autoload -Uz "$func"
shift
case "$type" in
(widgetkey) while [[ -n $1 ]]
do
if [[ $# -lt 3 ]]
then
print -u2 "$0: compdef -K requires "
return 1
fi
[[ $1 = _* ]] || 1="$1"
[[ $2 = .* ]] || 2=".$2"
[[ $2 = .menu-select ]] && zmodload -i zsh/complist
zle -C "$1" "$2" "$func"
if [[ -n $new ]]
then
bindkey "$3" | IFS=$' \t' read -A opt
[[ $opt[-1] = undefined-key ]] && bindkey "$3" "$1"
else
bindkey "$3" "$1"
fi
shift 3
done ;;
(key) if [[ $# -lt 2 ]]
then
print -u2 "$0: missing keys"
return 1
fi
if [[ $1 = .* ]]
then
[[ $1 = .menu-select ]] && zmodload -i zsh/complist
zle -C "$func" "$1" "$func"
else
[[ $1 = menu-select ]] && zmodload -i zsh/complist
zle -C "$func" ".$1" "$func"
fi
shift
for i
do
if [[ -n $new ]]
then
bindkey "$i" | IFS=$' \t' read -A opt
[[ $opt[-1] = undefined-key ]] || continue
fi
bindkey "$i" "$func"
done ;;
() while (( $# ))
do
if [[ "$1" = -N ]]
then
type=normal
elif [[ "$1" = -p ]]
then
type=pattern
elif [[ "$1" = -P ]]
then
type=postpattern
else
case "$type" in
(pattern) if [[ $1 = (#b)()=() ]]
then
_patcomps[$match[1]]="=$match[2]=$func"
else
_patcomps[$1]="$func"
fi ;;
(postpattern) if [[ $1 = (#b)()=() ]]
then
_postpatcomps[$match[1]]="=$match[2]=$func"
else
_postpatcomps[$1]="$func"
fi ;;
() if [[ "$1" = \= ]]
then
cmd="${1%%\=}"
svc=yes
else
cmd="$1"
svc=
fi
if [[ -z "$new" || -z "${_comps[$1]}" ]]
then
_comps[$cmd]="$func"
[[ -n "$svc" ]] && _services[$cmd]="${1#\=}"
fi ;;
esac
fi
shift
done ;;
esac
else
case "$type" in
(pattern) unset "patcomps[$^@]" ;;
(postpattern) unset "_postpatcomps[$^@]" ;;
(key) print -u2 "$0: cannot restore key bindings"
return 1 ;;
() unset "_comps[$^@]" ;;
esac
fi
}
typeset _i_wdirs _i_wfiles
_i_wdirs=()
_i_wfiles=()
autoload -Uz compaudit
if [[ -n "$_i_check" ]]
then
typeset _i_q
if ! eval compaudit
then
if [[ -n "$_i_q" ]]
then
if [[ "$_i_fail" = ask ]]
then
if ! read -q "?zsh compinit: insecure $_i_q, run compaudit for list.
Ignore insecure $_i_q and continue [y] or abort compinit [n]? "
then
print -u2 "$0: initialization aborted"
unfunction compinit compdef
unset _comp_dumpfile _comp_secure compprefuncs comppostfuncs _comps _patcomps _postpatcomps _compautos _lastcomp
return 1
fi
_i_wfiles=()
_i_wdirs=()
else
(( $#_i_wfiles )) && _i_files=("${(@)_i_files:#(${(j:|:)_i_wfiles%.zwc})}")
(( $#_i_wdirs )) && _i_files=("${(@)_i_files:#(${(j:|:)_i_wdirs%.zwc})/}")
fi
fi
typeset -g _comp_secure=yes
fi
fi
autoload -Uz compdump compinstall
_i_done=''
if [[ -f "$_comp_dumpfile" ]]
then
if [[ -n "$_i_check" ]]
then
IFS=$' \t' read -rA _i_line < "$_comp_dumpfile"
if [[ _i_autodump -eq 1 && $_i_line[2] -eq $#_i_files && $ZSH_VERSION = $_i_line[4] ]]
then
builtin . "$_comp_dumpfile"
_i_done=yes
fi
else
builtin . "$_comp_dumpfile"
_i_done=yes
fi
fi
if [[ -z "$_i_done" ]]
then
typeset -A _i_test
for _i_dir in $fpath
do
[[ $_i_dir = . ]] && continue
(( $_i_wdirs[(I)$_i_dir] )) && continue
for _i_file in $_i_dir/^([^]|~|*.zwc)(N)
do
_i_name="${_i_file:t}"
(( $+_i_test[$_i_name] + $_i_wfiles[(I)$_i_file] )) && continue
_i_test[$_i_name]=yes
IFS=$' \t' read -rA _i_line < $_i_file
_i_tag=$_i_line[1]
shift _i_line
case $_i_tag in
(#compdef) if [[ $_i_line[1] = -pPkK ]]
then
compdef ${_i_line[1]}na "${_i_name}" "${(@)_i_line[2,-1]}"
else
compdef -na "${_i_name}" "${_i_line[@]}"
fi ;;
(#autoload) autoload -Uz "$_i_line[@]" ${_i_name}
[[ "$_i_line" != \ # ]] && _compautos[${_i_name}]="$_i_line" ;;
esac
done
done
if [[ $_i_autodump = 1 ]]
then
compdump
fi
fi
for _i_line in complete-word delete-char-or-list expand-or-complete expand-or-complete-prefix list-choices menu-complete menu-expand-or-complete reverse-menu-complete
do
zle -C $_i_line .$_i_line _main_complete
done
zle -la menu-select && zle -C menu-select .menu-select _main_complete
bindkey '^i' | IFS=$' \t' read -A _i_line
if [[ ${_i_line[2]} = expand-or-complete ]] && zstyle -a ':completion:' completer _i_line && (( ${_i_line[(i)_expand]} <= ${#_i_line} ))
then
bindkey '^i' complete-word
fi
unfunction compinit compaudit
autoload -Uz compinit compaudit
return 0
}
compinstall () {
# undefined
builtin autoload -XUz
}
edit-command-line () {
# undefined
builtin autoload -XU
}
url-quote-magic () {
# undefined
builtin autoload -XU
}
compdef: unknown command or service: git
compdef: unknown command or service: git
compdef: unknown command or service: git
compdef: unknown command or service: git
compdef: unknown command or service: git
compdef: unknown command or service: git
compdef: unknown command or service: git
```

Which is almost worse than no output at all. Eliminating the `-i` option to `compinit()` reveals the underlying issue: 

    zsh compinit: insecure directories, run compaudit for list.
    Ignore insecure directories and continue [y] or abort compinit [n]?

**Ah ha!** Running `compaudit()` yields output resembling:

     There are insecure directories:
     /home/Administrator/.oh-my-zsh/plugins/git
     /usr/share/zsh/site-functions
     /usr/share/zsh/5.0.6/functions
     /home/Administrator/.oh-my-zsh/plugins
     /home/Administrator/.oh-my-zsh
     /usr/share/zsh
     /usr/share/zsh/5.0.6

So basically everything then? **Yup.** Under Cygwin, *all* top-level `zsh` directories are installed with insecure permissions enabling group writability. This is a [well-known issue](http://blog.en.edaro.net/2014/01/fix-broken-autocompletion-with-zsh-in.html) with [well-known one-liner fixes](http://www.wezm.net/technical/2008/09/zsh-cygwin-and-insecure-directories/).

In short, there are a number of interlocking issues with `oh-my-zsh.sh`'s completion initialization. Insecure path permissions are hidden rather than listed, preventing sane debugging and issue resolution. Cygwin seemingly *always* installs `zsh` with insecure path permissions, significantly exacerbating this issue on that platform.

## The Solution

If insecure path permissions are detected at `oh-my-zsh` startup:

* Under all platforms including Cygwin:
   * Insecure paths are now explicitly listed to the user *before* completions are initialized.
   * If the current terminal is interactive, the `-i` option is no longer passed to `compinit()`. This instructs `zsh` to query the user as to whether these paths should be ignored *or* completions left unitialized. (See the above prompt.)
* Under Cygwin, if the current terminal is interactive, `oh-my-zsh` now queries the user as to whether these paths should be automatically repaired. Since the core problem is insecure group writability, the solution is to simply disable group writability for all problematic directories with magical one-liner magic. (*It's magical!*)

Thus dies another bug in the night.