### PR TITLE
Use existing ssh-agent when invoking a sudo shell

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -30,7 +30,12 @@ if [[ $_agent_forwarding == "yes" && -n "$SSH_AUTH_SOCK" ]]; then
 elif [[ -f "$_ssh_env_cache" ]]; then
 	# Source SSH settings, if applicable
 	. $_ssh_env_cache > /dev/null
-	ps x | grep ssh-agent | grep -q $SSH_AGENT_PID || {
+	if [[ $USER == "root" ]]; then
+		FILTER="ax"
+	else
+		FILTER="x"
+	fi
+	ps $FILTER | grep ssh-agent | grep -q $SSH_AGENT_PID || {
 		_start_agent
 	}
 else


### PR DESCRIPTION
When invoking a shell as root using `sudo -s`, the ssh-agent plugin starts a new agent although it already exists.

The problem boils down to a check if ssh-agent is running using `ps x`. If that is extended to `ps ax` for root, then the existing ssh-agent will still work.
