### PR TITLE
Added environment based shortcuts in symfony2 plugin

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -25,5 +25,5 @@ alias sfcw='sf cache:warmup'
 alias sfroute='sf router:debug'
 alias sfcontainer='sf container:debug'
 alias sfgb='sf generate:bundle'
-alias dev="sf --env=dev"
-alias prod="sf --env=prod"
+alias sfdev='sf --env=dev'
+alias sfprod='sf --env=prod'

--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -25,3 +25,5 @@ alias sfcw='sf cache:warmup'
 alias sfroute='sf router:debug'
 alias sfcontainer='sf container:debug'
 alias sfgb='sf generate:bundle'
+alias dev="sf --env=dev"
+alias prod="sf --env=prod"


### PR DESCRIPTION
I've been using the "dev" and "prod" aliases for a while.
They've proven to be really useful when you type in commands based on symfony environment.
Credit for this tip goes to @hhamon 

The only downside I see is that the names of these aliases might not be specific enough.