### PR TITLE
Correct documentation on how to load the plugin

### DIFF
--- a/plugins/history-substring-search/README.markdown
+++ b/plugins/history-substring-search/README.markdown
@@ -1,6 +1,6 @@
 To activate this script, please include it the `plugins` variable within `~/.zshrc`
 
-  `plugins=(git history-substring-search.zsh)`
+  `plugins=(git history-substring-search)`
 
 See the "history-substring-search.zsh" file for more information:
 


### PR DESCRIPTION
So far the `README.markdown` stated that the string
`history-substring-search.zsh` had to be added to the `plugins` list in order to
load the plugin.

This commits corrects the information by removing the trailing `.zsh`.