### PR TITLE
Update brew upgrade command

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,2 +1,2 @@
 alias brews='brew list -1'
-alias bubu="brew update && brew upgrade && brew cleanup"
+alias bubu="brew update && brew upgrade --all && brew cleanup"


### PR DESCRIPTION
The default upgrade command has been changed. To upgrade all outdated packages the flag `--all` should be used. Also see the homebrew FAQ: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#faq