### PR TITLE
Fixed typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,7 @@ Most plugins (should! we're working on this) include a __README__, which documen
 
 ### Themes
 
-We'll admit it. Early in the Oh My Zsh world... we may have gotten a far too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://wiki.github.com/robbyrussell/oh-my-zsh/themes) on the wiki. Check them out!
+We'll admit it. Early in the Oh My Zsh world... we may have gotten far too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://wiki.github.com/robbyrussell/oh-my-zsh/themes) on the wiki. Check them out!
 
 #### Selecting a Theme
 


### PR DESCRIPTION
Fixed typo in README.markdown:

"a far too theme happy" -> "far too theme happy"