### PR TITLE
Git corrections for bugs in git_prompt_status()

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -78,11 +78,12 @@ function git_prompt_long_sha() {
 git_prompt_status() {
   INDEX=$(command git status --porcelain -b 2> /dev/null)
   STATUS=""
-  $(git diff --no-ext-diff --quiet --exit-code) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_MODIFIED"
   repo_info=$(git rev-parse --git-dir --is-inside-git-dir --is-bare-repository --is-inside-work-tree --short HEAD 2>/dev/null)
-  if [ $? -eq 0 ]; then
-      $(git diff-index --cached --quiet HEAD --) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_ADDED"
+  if [ -z $repo_info ]; then 
+    return
   fi
+  $(git diff --no-ext-diff --quiet --exit-code) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_MODIFIED"
+  $(git diff-index --cached --quiet HEAD --) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_ADDED"
   if $(git ls-files --others --exclude-standard --error-unmatch -- ':/*' >/dev/null 2>/dev/null); then
    STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
   fi

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -78,20 +78,13 @@ function git_prompt_long_sha() {
 git_prompt_status() {
   INDEX=$(command git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+  $(git diff --no-ext-diff --quiet --exit-code) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_MODIFIED"
+  repo_info=$(git rev-parse --git-dir --is-inside-git-dir --is-bare-repository --is-inside-work-tree --short HEAD 2>/dev/null)
+  if [ $? -eq 0 ]; then
+      $(git diff-index --cached --quiet HEAD --) ||  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_ADDED"
   fi
-  if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+  if $(git ls-files --others --exclude-standard --error-unmatch -- ':/*' >/dev/null 2>/dev/null); then
+   STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
   fi
   if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"


### PR DESCRIPTION
It seems that `git_prompt_status()`, a function in git.zsh which is used by 20 themes [1]), is returning incorrect values for:
- `ZSH_THEME_GIT_PROMPT_UNTRACKED`
- `ZSH_THEME_GIT_PROMPT_ADDED`
- `ZSH_THEME_GIT_PROMPT_MODIFIED`

Let's make an example to clarify what I mean by 'incorrect values'.
- First of all, add `git_prompt_status` to your omz prompt and set variables mentioned above in your theme or ~/.zshrc file:

```
PROMPT+='$(git_prompt_status)'
ZSH_THEME_GIT_PROMPT_DIRTY=""
ZSH_THEME_GIT_PROMPT_CLEAN=""
ZSH_THEME_GIT_PROMPT_UNTRACKED="%"
ZSH_THEME_GIT_PROMPT_MODIFIED="*"
ZSH_THEME_GIT_PROMPT_ADDED="+"
```
- Now create a git repo with some cases of the above and test your prompt:

```
romeo:/tmp $ mkdir demogit && cd demogit && git init                
Initialized empty Git repository in /tmp/demogit/.git/                                                                         
romeo:/tmp/demogit (_here goes my git_prompt_status) $
romeo:/tmp/demogit (_here goes my git_prompt_status) $ touch a b                        
romeo:/tmp/demogit (%) $  
# correct, new untracked file
romeo:/tmp/demogit (%) $ echo "foo" > a                                                                                     
romeo:/tmp/demogit (%) $ git add a                                                                                         
romeo:/tmp/demogit (+%) $ 
# correct, new file added and new untracked file
romeo:/tmp/demogit (+%) $ git commit -m 'initial version'                                                         
romeo:/tmp/demogit (%) $ echo "foooooo" > a                                                                                          
romeo:/tmp/demogit (*%) $ # correct, file modified and new untracked file        
romeo:/tmp/demogit (*%) $ git add a   
romeo:/tmp/demogit (+%) $ echo "bar" >> a                                                    
romeo:/tmp/demogit (+%) $
==> # incorrect, file is modified and also added, and new untracked file.
    # should be: +*% (ZSH_THEME_GIT_PROMPT_MODIFIED, ZSH_THEME_GIT_PROMPT_ADDED, ZSH_THEME_GIT_PROMPT_UNTRACKED)
```

Let's have another confirmation:

```
    romeo:/tmp/demogit $ git status                                                                  
    On branch master           
    Changes to be committed:      
    modified:   a  
    Changes not staged for commit:
    modified:   a                  
    Untracked files:  
    b                 
```
- To solve this problem, we should change how these three variables are populated (see commit).
- With commit applied, the three variables are populated correctly:

```
romeo:/tmp/demogit (*+%) $
```

[1] 

```
~/.oh-my-zsh/themes $ grep -R -i git_prompt_status | cut -d ':' -f 1 | sort | uniq | wc -l               
20                          
```
