### PR TITLE
Detect the .venv in any parent directory of the current directory

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -29,8 +29,11 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
     if [ ! $WORKON_CWD ]; then
       WORKON_CWD=1
       # Check if this is a Git repo
-      PROJECT_ROOT=`git rev-parse --show-toplevel 2> /dev/null`
-      if (( $? != 0 )); then
+      PROJECT_ROOT=`pwd`
+      while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
+        PROJECT_ROOT=`realpath $PROJECT_ROOT/..`
+      done
+      if [[ "$PROJECT_ROOT" == "/" ]]; then
         PROJECT_ROOT="."
       fi
       # Check for virtualenv name override


### PR DESCRIPTION
This patch allow the autoactivation of virtualenv in any parent directory.

This is useful when the .venv directory is not at the root of the git repository.

In addition, it works even if the .venv is not in a git repository.

