### PR TITLE
Don't leak extendedglob to global environment.

### DIFF
--- a/plugins/history-substring-search/history-substring-search.zsh
+++ b/plugins/history-substring-search/history-substring-search.zsh
@@ -175,7 +175,6 @@ fi
 # implementation details
 #-----------------------------------------------------------------------------
 
-setopt extendedglob
 zmodload -F zsh/parameter
 
 #
@@ -284,6 +283,7 @@ if [[ $+functions[_zsh_highlight] -eq 0 ]]; then
 fi
 
 function _history-substring-search-begin() {
+  setopt localoptions extendedglob
   _history_substring_search_move_cursor_eol=false
   _history_substring_search_query_highlight=
 
@@ -350,6 +350,7 @@ function _history-substring-search-begin() {
 }
 
 function _history-substring-search-end() {
+  setopt localoptions extendedglob
   _history_substring_search_result=$BUFFER
 
   # move the cursor to the end of the command line


### PR DESCRIPTION
When history-substring-search is loaded, it would set extendedglob globally.  This can lead to problem when user do not want extendedglob, for instance, ^ would be interpreted like *.

The proposed change pushes extendedglob to -begin() and -end() as local options.