### PR TITLE
added $OSTYPE check for cygwin

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -14,6 +14,8 @@ open_jira_issue () {
   local open_cmd
   if [[ "$OSTYPE" = darwin* ]]; then
     open_cmd='open'
+  elif [[ "$OSTYPE" = cygwin ]]; then
+    open_cmd='cygstart'
   else
     open_cmd='xdg-open'
   fi


### PR DESCRIPTION
It makes possible to use jira plugin since xdg-open is not available on Cygwin.