### PR TITLE
Add gcop alias for git checkout --patch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -31,6 +31,7 @@ alias gcmsg='git commit -m'
 compdef _git gcmsg=git-commit
 alias gco='git checkout'
 compdef _git gco=git-checkout
+alias gcop='git checkout --patch'
 alias gcm='git checkout master'
 alias gr='git remote'
 compdef _git gr=git-remote


### PR DESCRIPTION
`git checkout --patch` is just similar to `git add --patch` but for undoing changes in index.