### PR TITLE
Add sublime text 3 paths to check list

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -8,6 +8,8 @@ if [[ $('uname') == 'Linux' ]]; then
         "/usr/bin/sublime_text"
         "/usr/local/bin/sublime_text"
         "/usr/bin/subl"
+        "/opt/sublime_text_3/sublime_text"
+        "/usr/bin/subl3"
     )
     for _sublime_path in $_sublime_linux_paths; do
         if [[ -a $_sublime_path ]]; then


### PR DESCRIPTION
Adds paths for Sublime Text 3, which are slightly different. Tested and working on arch linux, and seems to be the same for most other package manager installation locations.