### PR TITLE
Fixes detection of homebrew installed rbenv

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -3,7 +3,7 @@ _homebrew-installed() {
 }
 
 _rbenv-from-homebrew-installed() {
-  brew --prefix rbenv &> /dev/null
+  brew ls rbenv &> /dev/null
 }
 
 FOUND_RBENV=0

--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -3,7 +3,7 @@ _homebrew-installed() {
 }
 
 _rbenv-from-homebrew-installed() {
-  brew ls rbenv &> /dev/null
+  [ -e "$(brew --prefix)/opt/rbenv" ]
 }
 
 FOUND_RBENV=0


### PR DESCRIPTION
This test doesn't work at all, `brew --prefix rbenv` simply returns `/usr/local/Cellar/rbenv/0.4.0` if rbenv isn't installed. Changing it to `brew ls rbenv` fixes it.

It's a performance improvement if rbenv isn't installed through homebrew. On my machine, zsh startup time is reduced from 0.59s to 0.46s. 

Ideally, I'd love to get rid of both calls to `brew ls rbenv` and `brew --prefix rbenv` if possible, they're quite expensive. Removing both cuts my zsh startup time by almost half. 

This change only affects Homebrew users on OS X.
