### PR TITLE
Xcode plugin: use regexp to find projects or workspaces

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -1,6 +1,6 @@
 #xc function courtesy of http://gist.github.com/subdigital/5420709
 function xc {
-  xcode_proj=`ls | grep "\.xc" | sort -r | head -1`
+  xcode_proj=`ls | grep -E "\.(xcworkspace|xcodeproj)" | sort -r | head -1`
   if [[ `echo -n $xcode_proj | wc -m` == 0 ]]
   then
     echo "No xcworkspace/xcodeproj file found in the current directory."


### PR DESCRIPTION
In a project I'm working on, there are `xcconfig`s files in the project's root directory, which means that 
using the `xc` alias finds and opens the first one instead of the workspace or the project. 
Using `grep` with a regexp fixes this.    