### PR TITLE
Revert "Added migration notification for rails plugin"

### DIFF
--- a/plugins/rails3/rails3.plugin.zsh
+++ b/plugins/rails3/rails3.plugin.zsh
@@ -1,4 +1,0 @@
-echo "It looks like you have been using the 'rails3' plugin,"
-echo "which has been deprecated in favor of a newly consolidated 'rails' plugin."
-echo "You will want to modify your ~/.zshrc configuration to begin using it."
-echo "Learn more at https://github.com/robbyrussell/oh-my-zsh/pull/2240"

--- a/plugins/rails4/rails4.plugin.zsh
+++ b/plugins/rails4/rails4.plugin.zsh
@@ -1,4 +1,0 @@
-echo "It looks like you have been using the 'rails4' plugin,"
-echo "which has been deprecated in favor of a newly consolidated 'rails' plugin."
-echo "You will want to modify your ~/.zshrc configuration to begin using it."
-echo "Learn more at https://github.com/robbyrussell/oh-my-zsh/pull/2240"


### PR DESCRIPTION
This reverts commit 1493d88e3f92c7034da5c1b1638ba19544aa3ccb, made to put a deprecated notice on `rails3` and `rails4` plugins, so that users would migrate to the unified `rails` plugin.

[It's been 1.5 years since that](https://github.com/robbyrussell/oh-my-zsh/pull/2240), so everyone should be migrated to the good one.

This also caused a minor confusion for one user: #3936.

/cc @robbyrussell 