### PR TITLE
Update aliases in laravel5.plugin.zsh file

### DIFF
--- a/plugins/laravel5/laravel5.plugin.zsh
+++ b/plugins/laravel5/laravel5.plugin.zsh
@@ -15,6 +15,6 @@ compdef _laravel5 la5
 #Alias
 alias la5='php artisan'
 
-alias la5dump='php artisan dump-autoload'
 alias la5cache='php artisan cache:clear'
-alias la5routes='php artisan routes'
+alias la5routes='php artisan route:list'
+alias la5vendor='php artisan vendor:publish'


### PR DESCRIPTION
Some minor changes to the aliases.
* removed php artisan dump-autoload since is no longer a command in laravel 5
* updated the la5routes alias to the new version of the command
* added a la5vendor alias to publish assets from vendor packages