### PR TITLE
Use local command properly in plugins/git/git.plugin.zsh

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -1,5 +1,4 @@
 # Query/use custom command for `git`.
-local git_cmd=
 zstyle -s ":vcs_info:git:*:-all-" "command" git_cmd
 : ${git_cmd:=git}
 
@@ -12,7 +11,7 @@ zstyle -s ":vcs_info:git:*:-all-" "command" git_cmd
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
 # it's not a symbolic ref, but in a Git repo.
 function current_branch() {
-  local ref=
+  local ref
   ref=$($git_cmd symbolic-ref --quiet HEAD 2> /dev/null)
   local ret=$?
   if [[ $ret != 0 ]]; then

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -1,5 +1,5 @@
 # Query/use custom command for `git`.
-local git_cmd
+local git_cmd=
 zstyle -s ":vcs_info:git:*:-all-" "command" git_cmd
 : ${git_cmd:=git}
 
@@ -12,7 +12,7 @@ zstyle -s ":vcs_info:git:*:-all-" "command" git_cmd
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
 # it's not a symbolic ref, but in a Git repo.
 function current_branch() {
-  local ref
+  local ref=
   ref=$($git_cmd symbolic-ref --quiet HEAD 2> /dev/null)
   local ret=$?
   if [[ $ret != 0 ]]; then


### PR DESCRIPTION
zsh `local` command will print out pair or variable name and value if it has value. [1]

What supposed to happen is:
![screenshot from 2015-06-07 16 49 57](https://cloud.githubusercontent.com/assets/337728/8024473/3e4083a2-0d35-11e5-85c1-764750665620.png)

What actually happend is:
![screenshot from 2015-06-07 16 38 18](https://cloud.githubusercontent.com/assets/337728/8024435/f06d2f46-0d33-11e5-82ae-4339a1b1d360.png)

[1] http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html