### PR TITLE
Hide spectrum.zsh var values to avoid junky output to terminal

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -3,7 +3,7 @@
 # P.C. Shyamshankar <sykora@lucentbeing.com>
 # Copied from http://github.com/sykora/etc/blob/master/zsh/functions/spectrum/
 
-typeset -Ag FX FG BG
+typeset -AHg FX FG BG
 
 FX=(
     reset     "%{[00m%}"


### PR DESCRIPTION
This "hides" the values of the `FG`, `BG`, and `FX` parameters defined in `lib/spectrum.zsh` by giving them the `-H` attribute. This means that when they're listed in the output of `set` or related commands, only their names are included, and their values are hidden. This is the same mechanism that Zsh's own `colors` function uses to hide the contents of the `$fg` and `$bg` arrays.

When the parameters aren't hidden, doing `set` sends junky output to the terminal, since the control sequences are emitted literally, and there may not be a `$reset_color` bracketing them. This makes the output of `set` harder to read, and makes `grep` fussy when searching through it, complaining about it being a binary file. (Doing `| grep -a` works around it, but it's an annoyance to have to remember to do it, and some users may not know about it.)

Here's an example of the ugly `set` output I currently get, and that this PR resolves.

![screen shot 2015-06-08 at 7 06 23 am](https://cloud.githubusercontent.com/assets/2618447/8033599/d498a942-0dad-11e5-9b7d-b08a1368a723.png)

![screen shot 2015-06-08 at 7 06 31 am](https://cloud.githubusercontent.com/assets/2618447/8033600/d79a0406-0dad-11e5-8c24-afc838daa3f9.png)

```
$ set | grep terminfo
Binary file (standard input) matches
[@ in ~]
$
```