### PR TITLE
Make spectrum_ls implementation consistent with $FG and spectrum_bls

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -25,13 +25,13 @@ ZSH_SPECTRUM_TEXT=${ZSH_SPECTRUM_TEXT:-Arma virumque cano Troiae qui primus ab o
 # Show all 256 colors with color number
 function spectrum_ls() {
   for code in {000..255}; do
-    print -P -- "$code: %F{$code}$ZSH_SPECTRUM_TEXT%f"
+    print -P -- "$code: %{$FG[$code]%}$ZSH_SPECTRUM_TEXT%{$reset_color%}"
   done
 }
 
 # Show all 256 colors where the background is set to specific color
 function spectrum_bls() {
   for code in {000..255}; do
-    print -P -- "$BG[$code]$code: $ZSH_SPECTRUM_TEXT %{$reset_color%}"
+    print -P -- "$code: %{$BG[$code]%}$ZSH_SPECTRUM_TEXT%{$reset_color%}"
   done
 }


### PR DESCRIPTION
Fixes #3964 

The current `spectrum_ls` is using `%F/%f` prompt codes. These don't seem to support 256 colors. This changes it to use the control sequences it's defined in `$FG`.

Also adjusts the spectrum_bls implementation so the leading number is not included in the coloration, to ensure that it's always readable, even when the background color being displayed is close to the foreground text color.