### PR TITLE
correct la5routes alias

### DIFF
--- a/plugins/laravel5/laravel5.plugin.zsh
+++ b/plugins/laravel5/laravel5.plugin.zsh
@@ -17,4 +17,4 @@ alias la5='php artisan'
 
 alias la5dump='php artisan dump-autoload'
 alias la5cache='php artisan cache:clear'
-alias la5routes='php artisan routes'
+alias la5routes='php artisan route:list'


### PR DESCRIPTION
the command "php artisan routes" as been deleted in laravel 5. "php artisan route:list" is now doing the same job.