### PR TITLE
Only load url-quote-magic if it is available.

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,10 @@
-## smart urls
-autoload -U url-quote-magic
-zle -N self-insert url-quote-magic
+## Load smart urls if available
+for d in $fpath; do
+	if [[ -e "$d/url-quote-magic"]]; then
+		autoload -U url-quote-magic
+		zle -N self-insert url-quote-magic
+	fi
+done
 
 ## jobs
 setopt long_list_jobs


### PR DESCRIPTION
Partially fixes #3614 by checking to see if url-quote-magic exists before loading it.