### PR TITLE
Updates to ember-cli plugin

### DIFF
--- a/plugins/ember-cli/README.md
+++ b/plugins/ember-cli/README.md
@@ -1,22 +1,19 @@
-# Ember-cli
+# Ember CLI
 
-**Maintainer:** [BilalBudhani](http://www.github.com/BilalBudhani)
+**Maintainers:** [BilalBudhani](http://www.github.com/BilalBudhani), [eubenesa](http://www.github.com/eubenesa)
 
-Ember-cli (http://www.ember-cli.com/)
+Ember CLI (http://www.ember-cli.com/)
 
 ### List of Aliases
 
-alias es='ember serve'
-alias ea='ember addon'
-alias eb='ember build'
-alias ed='ember destroy'
-alias eg='ember generate'
-alias eh='ember help'
-alias ein='ember init'
-alias eia='ember install:addon'
-alias eib='ember install:bower'
-alias ein='ember install:npm'
-alias ei='ember install'
-alias et='ember test'
-alias eu='ember update'
-alias ev='ember version'
+    alias es='ember serve'
+    alias ea='ember addon'
+    alias eb='ember build'
+    alias ed='ember destroy'
+    alias eg='ember generate'
+    alias eh='ember help'
+    alias ein='ember init'
+    alias ei='ember install'
+    alias et='ember test'
+    alias eu='ember update'
+    alias ev='ember version'

--- a/plugins/ember-cli/ember-cli.plugin.zsh
+++ b/plugins/ember-cli/ember-cli.plugin.zsh
@@ -1,5 +1,5 @@
-# Ember ClI 
-# visit http://www.ember-cli.com/ to view user guid 
+# Ember CLI
+# Visit http://www.ember-cli.com/ to view user guide
 
 alias es='ember serve'
 alias ea='ember addon'
@@ -8,9 +8,6 @@ alias ed='ember destroy'
 alias eg='ember generate'
 alias eh='ember help'
 alias ein='ember init'
-alias eia='ember install:addon'
-alias eib='ember install:bower'
-alias ein='ember install:npm'
 alias ei='ember install'
 alias et='ember test'
 alias eu='ember update'


### PR DESCRIPTION
1. `ember install:addon <addon-name>` is deprecated, and `ember install <addonName>` is to be used instead.
2. Bower and npm package installs are now managed by the user (The commands are removed.). `bower install <packageName> --save-dev --save-exact` and `npm install <packageName> --save-dev --save-exact` are to be used instead.