### PR TITLE
[theme] Fix color problem of steeef theme

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -26,12 +26,14 @@ if [[ $TERM = *256color* || $TERM = *rxvt* ]]; then
     purple="%F{135}"
     hotpink="%F{161}"
     limegreen="%F{118}"
+    PR_RST="%f"
 else
     turquoise="$fg[cyan]"
     orange="$fg[yellow]"
     purple="$fg[magenta]"
     hotpink="$fg[red]"
     limegreen="$fg[green]"
+    PR_RST="%{${reset_color}%}"
 fi
 
 # enable VCS systems you use
@@ -48,7 +50,6 @@ zstyle ':vcs_info:*:prompt:*' check-for-changes true
 # %a - action (e.g. rebase-i)
 # %R - repository path
 # %S - path in the repository
-PR_RST="%{${reset_color}%}"
 FMT_BRANCH="(%{$turquoise%}%b%u%c${PR_RST})"
 FMT_ACTION="(%{$limegreen%}%a${PR_RST})"
 FMT_UNSTAGED="%{$orange%}●"
@@ -96,5 +97,5 @@ function steeef_precmd {
 add-zsh-hook precmd steeef_precmd
 
 PROMPT=$'
-%{$purple%}%n%{$reset_color%} at %{$orange%}%m%{$reset_color%} in %{$limegreen%}%~%{$reset_color%} $vcs_info_msg_0_$(virtualenv_info)%{$reset_color%}
+%{$purple%}%n${PR_RST} at %{$orange%}%m${PR_RST} in %{$limegreen%}%~${PR_RST} $vcs_info_msg_0_$(virtualenv_info)%{$reset_color%}
 $ '


### PR DESCRIPTION
steeef theme sets colors depending on $TERM, however if %F is
used, it must be closed by %f instead of %{$reset_color%}.