### PR TITLE
Fixed odd chars on mac for agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,13 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
+
+# Fix odd char on mac
+if [[ `uname` == 'Darwin' ]]; then
+    SEGMENT_SEPARATOR='\ue0b0'
+else
+    SEGMENT_SEPARATOR=''
+fi
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,


### PR DESCRIPTION
Quick fix to solve odd separator char when using agnoster theme on Mac