### PR TITLE
FIX a parse error with zsh 5.0.2

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,6 @@
 ## Load smart urls if available
 for d in $fpath; do
-	if [[ -e "$d/url-quote-magic"]]; then
+	if [[ -e "$d/url-quote-magic" ]]; then
 		autoload -U url-quote-magic
 		zle -N self-insert url-quote-magic
 	fi


### PR DESCRIPTION
The error: ``…/.oh-my-zsh/lib/misc.zsh:3: parse error near `then'``

```
$ zsh --version

zsh 5.0.2 (x86_64-pc-linux-gnu)
```

The added space fixes the parse error.