### PR TITLE
Fix typo & Improve README in coffee plugin.

### DIFF
--- a/plugins/coffee/README.md
+++ b/plugins/coffee/README.md
@@ -7,11 +7,13 @@ When writing Coffeescript it's very common to want to preview the output of a
 certain snippet of code, either because you want to test the output or because
 you'd like to execute it in a browser console which doesn't accept Coffeescript.
 
-Preview the compiled result of your coffeescript with `cf "code"` as per the
-following:
+Preview the compiled result of your coffeescript with `cf "code"`, as shown in this example:
 
 ```zsh
-$ cf 'if a then be else c'
+$ cf 'if a then b else c'
+```
+which would output the following:
+```zsh
 if (a) {
   b;
 } else {

--- a/plugins/coffee/coffee.plugin.zsh
+++ b/plugins/coffee/coffee.plugin.zsh
@@ -10,7 +10,7 @@ cfc () {
 }
 
 # compile from pasteboard & print
-alias cfp='coffeeMe "$(pbpaste)"'
+alias cfp='cf "$(pbpaste)"'
 
 # compile from pasteboard and copy to clipboard
 alias cfpc='cfp | pbcopy'


### PR DESCRIPTION
* `cfp` alias was referencing an old version of the `cf` command which
no longer exists. This has been updated to reference a valid command.

* Fixed typo in README and made the example more readable.