### PR TITLE
Fixes robbyrussell/oh-my-zsh#4018 - parse error near 'then' after update

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,6 @@
 ## Load smart urls if available
 for d in $fpath; do
-	if [[ -e "$d/url-quote-magic"]]; then
+	if [[ -e "$d/url-quote-magic" ]]; then
 		autoload -U url-quote-magic
 		zle -N self-insert url-quote-magic
 	fi


### PR DESCRIPTION
This pull request fixes robbyrussell/oh-my-zsh#4018 - parse error near `then' after update which is caused by [lib/misc.zsh:3](/robbyrussell/oh-my-zsh/blob/422db48e37beadf31fd9081b7590f9498f7194b2/lib/misc.zsh#L3).

```shell
	if [[ -e "$d/url-quote-magic"]]; then
```
There must be a space char between `...magic"` and `]]; ...` so it must be
```shell
	if [[ -e "$d/url-quote-magic" ]]; then
```
I've tested with mine and it works fine after adding the space.
