### PR TITLE
Update misc.zsh

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,6 @@
 ## Load smart urls if available
 for d in $fpath; do
-	if [[ -e "$d/url-quote-magic"]]; then
+	if [[ -e "$d/url-quote-magic" ]]; then
 		autoload -U url-quote-magic
 		zle -N self-insert url-quote-magic
 	fi


### PR DESCRIPTION
On OS X 10.10.3 with zsh 5.0.7 (x86_64-apple-darwin14.0.0),  while opening new session the following error message occurs:

> ~/.oh-my-zsh/lib/misc.zsh:3: parse error near `then'