### PR TITLE
OSX plugin: iTunes status/nowplaying

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -161,16 +161,16 @@ function itunes() {
 		vol)
 			opt="set sound volume to $1" #$1 Due to the shift
 			;;
-    status|nowplaying)
-      local state=`osascript -e 'tell application "iTunes" to player state as string'`
-      echo "iTunes is currently $state"
-      if [ "$state" = "playing" ]; then
-        artist=`osascript -e 'tell application "iTunes" to artist of current track as string'`
-        track=`osascript -e 'tell application "iTunes" to name of current track as string'`
-        echo "Current track: $artist / $track";
-      fi
-      return 0
-      ;;
+		status|nowplaying)
+			local state=`osascript -e 'tell application "iTunes" to player state as string'`
+			echo "iTunes is currently $state"
+			if [ "$state" = "playing" ]; then
+				artist=`osascript -e 'tell application "iTunes" to artist of current track as string'`
+				track=`osascript -e 'tell application "iTunes" to name of current track as string'`
+				echo "Current track: $artist / $track";
+			fi
+			return 0
+			;;
 		shuf|shuff|shuffle)
 			# The shuffle property of current playlist can't be changed in iTunes 12,
 			# so this workaround uses AppleScript to simulate user input instead.

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -161,6 +161,16 @@ function itunes() {
 		vol)
 			opt="set sound volume to $1" #$1 Due to the shift
 			;;
+    status)
+      its_status=`osascript -e 'tell application "iTunes" to player state as string'`
+      echo "iTunes is currently $its_status"
+      if [ "$its_status" = "playing" ]; then
+        artist=`osascript -e 'tell application "iTunes" to artist of current track as string'`
+        track=`osascript -e 'tell application "iTunes" to name of current track as string'`
+        echo "Current track: $artist / $track";
+      fi
+      return 0
+      ;;
 		shuf|shuff|shuffle)
 			# The shuffle property of current playlist can't be changed in iTunes 12,
 			# so this workaround uses AppleScript to simulate user input instead.

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -161,10 +161,10 @@ function itunes() {
 		vol)
 			opt="set sound volume to $1" #$1 Due to the shift
 			;;
-    status)
-      its_status=`osascript -e 'tell application "iTunes" to player state as string'`
-      echo "iTunes is currently $its_status"
-      if [ "$its_status" = "playing" ]; then
+    status|nowplaying)
+      local state=`osascript -e 'tell application "iTunes" to player state as string'`
+      echo "iTunes is currently $state"
+      if [ "$state" = "playing" ]; then
         artist=`osascript -e 'tell application "iTunes" to artist of current track as string'`
         track=`osascript -e 'tell application "iTunes" to name of current track as string'`
         echo "Current track: $artist / $track";

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -144,25 +144,24 @@ function vncviewer() {
 
 # iTunes control function
 function itunes() {
-  local opt=$1
-  shift
-  case "$opt" in
-    launch|play|pause|stop|rewind|resume|quit)
-      ;;
-    mute)
-      opt="set mute to true"
-      ;;
-    unmute)
-      opt="set mute to false"
-      ;;
-    next|previous)
-      opt="$opt track"
-      ;;
-    vol)
-      opt="set sound volume to $1" #$1 Due to the shift
-      ;;
+	local opt=$1
+	shift
+	case "$opt" in
+		launch|play|pause|stop|rewind|resume|quit)
+			;;
+		mute)
+			opt="set mute to true"
+			;;
+		unmute)
+			opt="set mute to false"
+			;;
+		next|previous)
+			opt="$opt track"
+			;;
+		vol)
+			opt="set sound volume to $1" #$1 Due to the shift
+			;;
     status|nowplaying)
-      # Inspired by: http://hints.macworld.com/article.php?story=20011108211802830
       local state=`osascript -e 'tell application "iTunes" to player state as string'`
       echo "iTunes is currently $state"
       if [ "$state" = "playing" ]; then
@@ -172,51 +171,51 @@ function itunes() {
       fi
       return 0
       ;;
-    shuf|shuff|shuffle)
-      # The shuffle property of current playlist can't be changed in iTunes 12,
-      # so this workaround uses AppleScript to simulate user input instead.
-      # Defaults to toggling when no options are given.
-      # The toggle option depends on the shuffle button being visible in the Now playing area.
-      # On and off use the menu bar items.
-      local state=$1
+		shuf|shuff|shuffle)
+			# The shuffle property of current playlist can't be changed in iTunes 12,
+			# so this workaround uses AppleScript to simulate user input instead.
+			# Defaults to toggling when no options are given.
+			# The toggle option depends on the shuffle button being visible in the Now playing area.
+			# On and off use the menu bar items.
+			local state=$1
 
-      if [[ -n "$state" && ! "$state" =~ "^(on|off|toggle)$" ]]
-      then
-        print "Usage: itunes shuffle [on|off|toggle]. Invalid option."
-        return 1
-      fi
+			if [[ -n "$state" && ! "$state" =~ "^(on|off|toggle)$" ]]
+			then
+				print "Usage: itunes shuffle [on|off|toggle]. Invalid option."
+				return 1
+			fi
 
-      case "$state" in
-        on|off)
-          # Inspired by: http://stackoverflow.com/a/14675583
-          osascript 1>/dev/null 2>&1 <<-EOF
-          tell application "System Events" to perform action "AXPress" of (menu item "${state}" of menu "Shuffle" of menu item "Shuffle" of menu "Controls" of menu bar item "Controls" of menu bar 1 of application process "iTunes" )
+			case "$state" in
+				on|off)
+					# Inspired by: http://stackoverflow.com/a/14675583
+					osascript 1>/dev/null 2>&1 <<-EOF
+					tell application "System Events" to perform action "AXPress" of (menu item "${state}" of menu "Shuffle" of menu item "Shuffle" of menu "Controls" of menu bar item "Controls" of menu bar 1 of application process "iTunes" )
 EOF
-          return 0
-          ;;
-        toggle|*)
-          osascript 1>/dev/null 2>&1 <<-EOF
-          tell application "System Events" to perform action "AXPress" of (button 2 of process "iTunes"'s window "iTunes"'s scroll area 1)
+					return 0
+					;;
+				toggle|*)
+					osascript 1>/dev/null 2>&1 <<-EOF
+					tell application "System Events" to perform action "AXPress" of (button 2 of process "iTunes"'s window "iTunes"'s scroll area 1)
 EOF
-          return 0
-          ;;
-      esac
-      ;;
-    ""|-h|--help)
-      echo "Usage: itunes <option>"
-      echo "option:"
-      echo "\tlaunch|play|pause|stop|rewind|resume|quit"
-      echo "\tmute|unmute\tcontrol volume set"
-      echo "\tnext|previous\tplay next or previous track"
-      echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
-      echo "\tvol\tSet the volume, takes an argument from 0 to 100"
-      echo "\thelp\tshow this message and exit"
-      return 0
-      ;;
-    *)
-      print "Unknown option: $opt"
-      return 1
-      ;;
-  esac
-  osascript -e "tell application \"iTunes\" to $opt"
+					return 0
+					;;
+			esac
+			;;
+		""|-h|--help)
+			echo "Usage: itunes <option>"
+			echo "option:"
+			echo "\tlaunch|play|pause|stop|rewind|resume|quit"
+			echo "\tmute|unmute\tcontrol volume set"
+			echo "\tnext|previous\tplay next or previous track"
+			echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
+			echo "\tvol\tSet the volume, takes an argument from 0 to 100"
+			echo "\thelp\tshow this message and exit"
+			return 0
+			;;
+		*)
+			print "Unknown option: $opt"
+			return 1
+			;;
+	esac
+	osascript -e "tell application \"iTunes\" to $opt"
 }

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -144,24 +144,25 @@ function vncviewer() {
 
 # iTunes control function
 function itunes() {
-	local opt=$1
-	shift
-	case "$opt" in
-		launch|play|pause|stop|rewind|resume|quit)
-			;;
-		mute)
-			opt="set mute to true"
-			;;
-		unmute)
-			opt="set mute to false"
-			;;
-		next|previous)
-			opt="$opt track"
-			;;
-		vol)
-			opt="set sound volume to $1" #$1 Due to the shift
-			;;
+  local opt=$1
+  shift
+  case "$opt" in
+    launch|play|pause|stop|rewind|resume|quit)
+      ;;
+    mute)
+      opt="set mute to true"
+      ;;
+    unmute)
+      opt="set mute to false"
+      ;;
+    next|previous)
+      opt="$opt track"
+      ;;
+    vol)
+      opt="set sound volume to $1" #$1 Due to the shift
+      ;;
     status|nowplaying)
+      # Inspired by: http://hints.macworld.com/article.php?story=20011108211802830
       local state=`osascript -e 'tell application "iTunes" to player state as string'`
       echo "iTunes is currently $state"
       if [ "$state" = "playing" ]; then
@@ -171,51 +172,51 @@ function itunes() {
       fi
       return 0
       ;;
-		shuf|shuff|shuffle)
-			# The shuffle property of current playlist can't be changed in iTunes 12,
-			# so this workaround uses AppleScript to simulate user input instead.
-			# Defaults to toggling when no options are given.
-			# The toggle option depends on the shuffle button being visible in the Now playing area.
-			# On and off use the menu bar items.
-			local state=$1
+    shuf|shuff|shuffle)
+      # The shuffle property of current playlist can't be changed in iTunes 12,
+      # so this workaround uses AppleScript to simulate user input instead.
+      # Defaults to toggling when no options are given.
+      # The toggle option depends on the shuffle button being visible in the Now playing area.
+      # On and off use the menu bar items.
+      local state=$1
 
-			if [[ -n "$state" && ! "$state" =~ "^(on|off|toggle)$" ]]
-			then
-				print "Usage: itunes shuffle [on|off|toggle]. Invalid option."
-				return 1
-			fi
+      if [[ -n "$state" && ! "$state" =~ "^(on|off|toggle)$" ]]
+      then
+        print "Usage: itunes shuffle [on|off|toggle]. Invalid option."
+        return 1
+      fi
 
-			case "$state" in
-				on|off)
-					# Inspired by: http://stackoverflow.com/a/14675583
-					osascript 1>/dev/null 2>&1 <<-EOF
-					tell application "System Events" to perform action "AXPress" of (menu item "${state}" of menu "Shuffle" of menu item "Shuffle" of menu "Controls" of menu bar item "Controls" of menu bar 1 of application process "iTunes" )
+      case "$state" in
+        on|off)
+          # Inspired by: http://stackoverflow.com/a/14675583
+          osascript 1>/dev/null 2>&1 <<-EOF
+          tell application "System Events" to perform action "AXPress" of (menu item "${state}" of menu "Shuffle" of menu item "Shuffle" of menu "Controls" of menu bar item "Controls" of menu bar 1 of application process "iTunes" )
 EOF
-					return 0
-					;;
-				toggle|*)
-					osascript 1>/dev/null 2>&1 <<-EOF
-					tell application "System Events" to perform action "AXPress" of (button 2 of process "iTunes"'s window "iTunes"'s scroll area 1)
+          return 0
+          ;;
+        toggle|*)
+          osascript 1>/dev/null 2>&1 <<-EOF
+          tell application "System Events" to perform action "AXPress" of (button 2 of process "iTunes"'s window "iTunes"'s scroll area 1)
 EOF
-					return 0
-					;;
-			esac
-			;;
-		""|-h|--help)
-			echo "Usage: itunes <option>"
-			echo "option:"
-			echo "\tlaunch|play|pause|stop|rewind|resume|quit"
-			echo "\tmute|unmute\tcontrol volume set"
-			echo "\tnext|previous\tplay next or previous track"
-			echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
-			echo "\tvol\tSet the volume, takes an argument from 0 to 100"
-			echo "\thelp\tshow this message and exit"
-			return 0
-			;;
-		*)
-			print "Unknown option: $opt"
-			return 1
-			;;
-	esac
-	osascript -e "tell application \"iTunes\" to $opt"
+          return 0
+          ;;
+      esac
+      ;;
+    ""|-h|--help)
+      echo "Usage: itunes <option>"
+      echo "option:"
+      echo "\tlaunch|play|pause|stop|rewind|resume|quit"
+      echo "\tmute|unmute\tcontrol volume set"
+      echo "\tnext|previous\tplay next or previous track"
+      echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
+      echo "\tvol\tSet the volume, takes an argument from 0 to 100"
+      echo "\thelp\tshow this message and exit"
+      return 0
+      ;;
+    *)
+      print "Unknown option: $opt"
+      return 1
+      ;;
+  esac
+  osascript -e "tell application \"iTunes\" to $opt"
 }

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -209,6 +209,7 @@ EOF
 			echo "\tnext|previous\tplay next or previous track"
 			echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
 			echo "\tvol\tSet the volume, takes an argument from 0 to 100"
+			echo "\tstatus|nowplaying\tShow iTunes status. If playing, shows current artist and track name."
 			echo "\thelp\tshow this message and exit"
 			return 0
 			;;


### PR DESCRIPTION
Inspired by http://hints.macworld.com/article.php?story=20011108211802830, I added a simple `status` option to the `itunes` command of the OSX plugin.

Running `itunes status` or `itunes nowplaying` will display iTunes status, and if it's currently playing something, the artist and track name.

```
$ itunes nowplaying                                                                                                                            (master) 
iTunes is currently playing
Current track: Cincinnati Pops Orchestra & Erich Kunzel / The Raiders' March from Raiders of the Lost Ark
```
