### PR TITLE
lib/misc.zsh: fix parse error near `then' error

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,6 @@
 ## Load smart urls if available
 for d in $fpath; do
-	if [[ -e "$d/url-quote-magic"]]; then
+	if [[ -e "$d/url-quote-magic" ]]; then
 		autoload -U url-quote-magic
 		zle -N self-insert url-quote-magic
 	fi


### PR DESCRIPTION
fix parse error
$HOME/.oh-my-zsh/lib/misc.zsh:3: parse error near `then'`