### PR TITLE
Adds ubuntu/linux support to atom plugin

### DIFF
--- a/plugins/atom/atom.plugin.zsh
+++ b/plugins/atom/atom.plugin.zsh
@@ -5,10 +5,16 @@ _atom_paths=(
 )
 
 for _atom_path in $_atom_paths; do
-    if [[ -a $_atom_path ]]; then
-        alias at="open -a '$_atom_path'"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+          alias at="/usr/bin/atom"
+    elif [[ -a $_atom_path ]]; then
+          alias at="open -a '$_atom_path'"
         break
     fi
 done
 
 alias att='at .'
+
+
+
+

--- a/plugins/atom/atom.plugin.zsh
+++ b/plugins/atom/atom.plugin.zsh
@@ -14,7 +14,3 @@ for _atom_path in $_atom_paths; do
 done
 
 alias att='at .'
-
-
-
-


### PR DESCRIPTION
Checks if the OS is linux and in that case starts atom from /usr/bin/atom. If not the previous way is used.