### PR TITLE
[Hotfix] Git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -101,8 +101,12 @@ git push --force origin "${b:=$1}"
 }
 compdef _git ggf=git-checkout
 ggl() {
+if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
+git pull origin "${*}"
+else
 [[ "$#" == 0 ]] && local b="$(current_branch)"
-git pull origin "${b:=$1}" "${*[2,-1]}"
+git pull origin "${b:=$1}"
+fi
 }
 compdef _git ggl=git-checkout
 alias ggpull='git pull origin $(current_branch)'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -105,7 +105,7 @@ ggl() {
 git pull origin "${b:=$1}" "${*[2,-1]}"
 }
 compdef _git ggl=git-checkout
-alias ggpull='ggl'
+alias ggpull='git pull origin $(current_branch)'
 compdef _git ggpull=git-checkout
 ggp() {
 if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
@@ -116,7 +116,7 @@ git push origin "${b:=$1}"
 fi
 }
 compdef _git ggp=git-checkout
-alias ggpush='ggp'
+alias ggpush='git push origin $(current_branch)'
 compdef _git ggpush=git-checkout
 ggpnp() {
 if [[ "$#" == 0 ]]; then


### PR DESCRIPTION
There are still two bugs to fix after #2790, related to `gg*` aliases/functions when called without arguments or without a branch name.

Specifically, this:
* fixes #3995
* fixes #4053
* fixes #4055
* fixes #4056
* fixes [this](https://github.com/robbyrussell/oh-my-zsh/pull/2790#issuecomment-112716330)

@robbyrussell please get this ASAP, then I will be done fixing the aftermath of #2790.

***

Roadmap after this is:
* update the wiki
* deprecate destructive aliases
* implement safe aliasing