### PR TITLE
archlinux: Remove yasu / yaourt --sucre

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -37,7 +37,6 @@
 | yarem        | yaourt -Rns                             | Remove the specified package(s), its configuration(s) and unneeded dependencies                                     |
 | yarep        | yaourt -Si                              | Display information about a given package in the repositories                                                       |
 | yareps       | yaourt -Ss                              | Search for package(s) in the repositories                                                                           |
-| yasu         | yaourt --sucre                          | Same as yaupg, but without confirmation                                                                             |
 | yaupd        | yaourt -Sy && sudo abs && sudo aur      | Update and refresh the local package, ABS and AUR databases against repositories                                    |
 | yaupd        | yaourt -Sy && sudo abs                  | Update and refresh the local package and ABS databases against repositories                                         |
 | yaupd        | yaourt -Sy && sudo aur                  | Update and refresh the local package and AUR databases against repositories                                         |

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -9,7 +9,6 @@ if [[ -x `command -v yaourt` ]]; then
   alias yaconf='yaourt -C'        # Fix all configuration files with vimdiff
   # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
   alias yaupg='yaourt -Syua'        # Synchronize with repositories before upgrading packages (AUR packages too) that are out of date on the local system.
-  alias yasu='yaourt --sucre'      # Same as yaupg, but without confirmation
   alias yain='yaourt -S'           # Install specific package(s) from the repositories
   alias yains='yaourt -U'          # Install specific package not from the repositories but from a file
   alias yare='yaourt -R'           # Remove the specified package(s), retaining its configuration(s) and required dependencies


### PR DESCRIPTION
The option has been removed from yaourt:  archlinuxfr/yaourt@0cedad581a35e66b670853dc3be3077258d8eab7