### PR TITLE
[Hotfix] Search for .git rather than .venv inside loop.

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -38,7 +38,7 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       WORKON_CWD=1
       # Check if this is a Git repo
       PROJECT_ROOT=`pwd`
-      while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
+      while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.git" ]]; do
         PROJECT_ROOT=`realpath $PROJECT_ROOT/..`
       done
       if [[ "$PROJECT_ROOT" == "/" ]]; then


### PR DESCRIPTION
Fix automatic activate for virtualenvs once a .git file is found. As the comment said "Check if this is a Git repo" and not .venv