### PR TITLE
Add .gitattributes file to use the right line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF ending by default
+* eol=lf


### PR DESCRIPTION
#### STATUS: not ready

~~This enforces the following EOL character in the following files:~~
- ~~**LF** in zsh related files: `.sh`, `.zsh`, `.zsh-theme` and `_*` (completion). This setting forces `\n` as a line ending, given it is the only acceptable one parsed by zsh. This is important for cygwin users, for instance.~~
- ~~**Native EOL** (default in `core.eol` setting). This will use the native EOL in all text files except above, regardless of the core.autocrlf setting which is considered harmful at this point. This means files like READMEs and such. _I'm not 100% sure about this point, feel free to discuss it._~~
- ~~Binary files (as interpreted by git) **will not be EOL-converted**.~~

The current choice is to enforce `LF` on all files by default. This is probably wrong but it is temporary until we figure out the best possible choice.

Closes #3090.
Closes #4069.

Related issues:
#1363, #1483, #2770, #3079, #3595, #3687, #3963, #4402, #4665, #4783.

Related links:
- http://blog.subgit.com/line-endings-handling-in-svn-git-and-subgit/
- http://git-scm.com/docs/gitattributes
