### PR TITLE
Use param expansion instead of `realpath` (fixes #4030)

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -39,7 +39,7 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       # Look for a proper PROJECT_ROOT path
       PROJECT_ROOT=`pwd`
       while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
-        PROJECT_ROOT=$(cd -P "$PROJECT_ROOT/.."; pwd)
+        PROJECT_ROOT=${PROJECT_ROOT:A:h}
       done
       if [[ "$PROJECT_ROOT" == "/" ]]; then
         PROJECT_ROOT="."

--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -36,10 +36,10 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
   function workon_cwd {
     if [ ! $WORKON_CWD ]; then
       WORKON_CWD=1
-      # Check if this is a Git repo
+      # Look for a proper PROJECT_ROOT path
       PROJECT_ROOT=`pwd`
       while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
-        PROJECT_ROOT=`realpath $PROJECT_ROOT/..`
+        PROJECT_ROOT=$(cd -P "$PROJECT_ROOT/.."; pwd)
       done
       if [[ "$PROJECT_ROOT" == "/" ]]; then
         PROJECT_ROOT="."


### PR DESCRIPTION
This fix #4030, just like what #4025 does, but using different approach.

This fix use `cd -P` instead of detecting the existence of `realpath` or `readlink -f`.