### PR TITLE
Add magic-enter plugin

### DIFF
--- a/plugins/magic-enter/Readme.md
+++ b/plugins/magic-enter/Readme.md
@@ -3,3 +3,12 @@
 **Maintainer:** [@dufferzafar](https://github.com/dufferzafar)
 
 Makes your enter key magical, by binding commonly used commands to it.
+
+You can set the commands to be run in your .zshrc, before the line containing plugins!
+
+```bash
+MAGIC_ENTER_GIT_COMMAND='git status -u .'
+MAGIC_ENTER_OTHER_COMMAND='ls -lh .'
+
+plugins=(magic-enter)
+```

--- a/plugins/magic-enter/Readme.md
+++ b/plugins/magic-enter/Readme.md
@@ -1,0 +1,5 @@
+## Magic Enter
+
+**Maintainer:** [@dufferzafar](https://github.com/dufferzafar)
+
+Makes your enter key magical, by binding commonly used commands to it.

--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -1,0 +1,19 @@
+# Bind quick stuff to enter!
+#
+# Pressing enter in a git directory runs `git status`
+# in other directories `ls`
+magic-enter () {
+  if [[ -z $BUFFER ]]; then
+    echo ""
+    if git rev-parse --is-inside-work-tree &>/dev/null; then
+      git status -u .
+    else
+      ls -lh
+    fi
+    zle redisplay
+  else
+    zle accept-line
+  fi
+}
+zle -N magic-enter
+bindkey "^M" magic-enter

--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -3,12 +3,17 @@
 # Pressing enter in a git directory runs `git status`
 # in other directories `ls`
 magic-enter () {
+
+  # If commands are not already set, use the defaults
+  [ -z "$MAGIC_ENTER_GIT_COMMAND" ] && MAGIC_ENTER_GIT_COMMAND="git status -u ."
+  [ -z "$MAGIC_ENTER_OTHER_COMMAND" ] && MAGIC_ENTER_OTHER_COMMAND="ls -lh ."
+
   if [[ -z $BUFFER ]]; then
     echo ""
     if git rev-parse --is-inside-work-tree &>/dev/null; then
-      git status -u .
+      eval "$MAGIC_ENTER_GIT_COMMAND"
     else
-      ls -lh
+      eval "$MAGIC_ENTER_OTHER_COMMAND"
     fi
     zle redisplay
   else


### PR DESCRIPTION
Allows commonly used commands to be binded to the Enter key.

I found this trick on some forum (perhaps it was stack overflow.)
