### PR TITLE
agnoster: Use current Powerline chars everywhere, and clarify behavior

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -32,17 +32,19 @@ CURRENT_BG='NONE'
 
 # Special Powerline characters
 
-# NOTE: This segment separator character is correct.  In 2012, Powerline changed
-# the code points they use for their special characters. This is the new code point.
-# If this is not working for you, you probably have an old version of the 
-# Powerline-patched fonts installed. Download and install the new version.
-# Do not submit PRs to change this unless you have reviewed the Powerline code point
-# history and have new information.
-# This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
-# what font the user is viewing this source code in. Do not replace the
-# escape sequence with a single literal character.
-SEGMENT_SEPARATOR='\ue0b0' # 
-
+() {
+  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+  # NOTE: This segment separator character is correct.  In 2012, Powerline changed
+  # the code points they use for their special characters. This is the new code point.
+  # If this is not working for you, you probably have an old version of the 
+  # Powerline-patched fonts installed. Download and install the new version.
+  # Do not submit PRs to change this unless you have reviewed the Powerline code point
+  # history and have new information.
+  # This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
+  # what font the user is viewing this source code in. Do not replace the
+  # escape sequence with a single literal character.
+  SEGMENT_SEPARATOR=$'\ue0b0' # 
+}
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -83,7 +85,12 @@ prompt_context() {
 
 # Git: branch/detached head, dirty status
 prompt_git() {
-  local PL_BRANCH_CHAR='\ue0a0'         # 
+
+  local PL_BRANCH_CHAR
+  () {
+    local LC_ALL="" LC_CTYPE="en_US.UTF-8"
+    PL_BRANCH_CHAR=$'\ue0a0'         # 
+  }
   local ref dirty mode repo_path
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -7,6 +7,9 @@
 #
 # In order for this theme to render correctly, you will need a
 # [Powerline-patched font](https://github.com/Lokaltog/powerline-fonts).
+# Make sure you have a recent version: the code points that Powerline
+# uses changed in 2012, and older versions will display incorrectly,
+# in confusing ways.
 #
 # In addition, I recommend the
 # [Solarized theme](https://github.com/altercation/solarized/) and, if you're
@@ -27,12 +30,19 @@
 
 CURRENT_BG='NONE'
 
-# Fix odd char on mac
-if [[ `uname` == 'Darwin' ]]; then
-    SEGMENT_SEPARATOR='\ue0b0'
-else
-    SEGMENT_SEPARATOR=''
-fi
+# Special Powerline characters
+
+# NOTE: This segment separator character is correct.  In 2012, Powerline changed
+# the code points they use for their special characters. This is the new code point.
+# If this is not working for you, you probably have an old version of the 
+# Powerline-patched fonts installed. Download and install the new version.
+# Do not submit PRs to change this unless you have reviewed the Powerline code point
+# history and have new information.
+# This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
+# what font the user is viewing this source code in. Do not replace the
+# escape sequence with a single literal character.
+SEGMENT_SEPARATOR='\ue0b0' # 
+
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -73,6 +83,7 @@ prompt_context() {
 
 # Git: branch/detached head, dirty status
 prompt_git() {
+  local PL_BRANCH_CHAR='\ue0a0'         # 
   local ref dirty mode repo_path
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 
@@ -104,7 +115,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_%% }${mode}"
+    echo -n "${ref/refs\/heads\//$PL_BRANCH_CHAR }${vcs_info_msg_0_%% }${mode}"
   fi
 }
 


### PR DESCRIPTION
Updates the agnoster theme to define its special Powerline characters using Unicode escape sequences, and use the current Powerline code point for SEGMENT_SEPARATOR on all platforms.

This makes the theme consistent with the current definition of Powerline, and removes the spurious Mac special case. There is no special handling necessary for Mac; that's just a result of users with old fonts misdiagnosing it.

In 2012, Powerline changed which Unicode code points are used for its special prompt characters, which has resulted in confusion. There are old versions of the Powerline-patched fonts out there that have the glyphs in the old code point slots. This means that whether Powerline looks "right" depends on which version of the fonts you have installed, which version of the code points your theme/prompt definition is using, and whether they are consistent.

We periodically get bug reports or PRs asking to change this character, and they're often because a user has an old version of the Powerline font installed. (#1906, #2869, #2985, #3713, #4001, #4065, #4083) See #3713 for a good long discussion of the issue.

These bugs are hard to diagnose and discuss because when literal Powerline characters are included in the source code, the appearance *of the source code itself* depends on which version of the powerline fonts you have installed and which you're using in your editor.

Switching to using escape sequences in the theme definition source code means that it is unambiguously readable by anybody, regardless of whether they are using Powerline-patched fonts in the editor, and whether they have the new or obsolete version of them.

This change also adds comments to the source code explaining the situation, and discouraging users from making further PRs for the segment separator character.

I've tested on OS X with current versions of the Powerline fonts.

Testers needed. 

Attn: @agnoster – sorry for being presumptuous and updating your theme, but I think this change will really help some users out and cut down on noise in the bug tracker. Look good to you?
Attn: @mrbfrank, @ivanfoo, @gdetrez, since you've done work on the Powerline-related stuff in Agnoster. Thoughts?

Closes #4083