### PR TITLE
Use 'quit all' instead of counting needed quits

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -13,15 +13,15 @@ function vundle-init () {
 
 function vundle () {
   vundle-init
-  vim -c "execute \"PluginInstall\" | q | q"
+  vim -c "execute \"PluginInstall\" | qa"
 }
 
 function vundle-update () {
   vundle-init
-  vim -c "execute \"PluginInstall!\" | q | q"
+  vim -c "execute \"PluginInstall!\" | qa"
 }
 
 function vundle-clean () {
   vundle-init
-  vim -c "execute \"PluginClean!\" | q | q"
+  vim -c "execute \"PluginClean!\" | qa"
 }


### PR DESCRIPTION
Instead of quiting each window manually, quit all directly.