### PR TITLE
'la -> ls -A' shows all files in column format; 'l -> ls' shows output of 'ls'

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -24,9 +24,9 @@ alias d='dirs -v | head -10'
 
 # List directory contents
 alias lsa='ls -lah'
-alias l='ls -lah'
+alias l='ls'
 alias ll='ls -lh'
-alias la='ls -lAh'
+alias la='ls -A'
 
 # Push and pop directories on directory stack
 alias pu='pushd'


### PR DESCRIPTION
Three of the aliases, `l`, `la`, `ll`, had nearly the same output when executed. I think this implementation will differentiate more clearly what each of its intended purposes are.

Here are the changes I have proposed.
- `l`: `ls` output. Trivial.
- `la`: `ls -A` output. Lists *all* files and directories, in column format. Much easier to view at a glance.

I had also considered `alias -='cd -'`, but there is a rule against aliases for quoted and escaped characters.

Let me know what you think!

![screen shot 2015-06-27 at 15 05 17](https://cloud.githubusercontent.com/assets/5502706/8394086/f8a87ee0-1cdd-11e5-84f1-97d2e0e66d4d.png)