### PR TITLE
Use consistent wording when updating

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,4 +1,4 @@
-printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
+printf '\033[0;34m%s\033[0m\n' "Updating Oh My Zsh"
 cd "$ZSH"
 if git pull --rebase --stat origin master
 then


### PR DESCRIPTION
When the user is asked to update oh-my-zsh it says "[Oh My Zsh] Would
you like to check for updates? [Y/n]:". When the user agreed to update
the next text would say "Upgrading Oh My Zsh" which is inconsistent
with the question.