### PR TITLE
virtualenvwrapper: Remove `realpath` dependency using zsh `:A`

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -30,16 +30,17 @@ if [[ "$WORKON_HOME" == "" ]]; then
 fi
 
 if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
-  # Automatically activate Git projects's virtual environments based on the
+  # Automatically activate Git projects' virtual environments based on the
   # directory name of the project. Virtual environment name can be overridden
   # by placing a .venv file in the project root with a virtualenv name in it
   function workon_cwd {
     if [ ! $WORKON_CWD ]; then
       WORKON_CWD=1
       # Check if this is a Git repo
-      PROJECT_ROOT=`pwd`
+      # Get absolute path, resolving symlinks
+      PROJECT_ROOT="${PWD:A}"
       while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
-        PROJECT_ROOT=`realpath $PROJECT_ROOT/..`
+        PROJECT_ROOT="${PROJECT_ROOT:h}"
       done
       if [[ "$PROJECT_ROOT" == "/" ]]; then
         PROJECT_ROOT="."
@@ -50,7 +51,7 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       elif [[ -f "$PROJECT_ROOT/.venv/bin/activate" ]];then
         ENV_NAME="$PROJECT_ROOT/.venv"
       elif [[ "$PROJECT_ROOT" != "." ]]; then
-        ENV_NAME=`basename "$PROJECT_ROOT"`
+        ENV_NAME="${PROJECT_ROOT:t}"
       else
         ENV_NAME=""
       fi


### PR DESCRIPTION
PR #3918 introduced a dependency on the command `realpath` to the virtualenvwrapper plugin. This is a problem because `realpath` is not installed on many systems by default. (It's not even available in the main Homebrew tap for OS X.) This caused problems for some users (#4079).

This PR removes the `realpath` dependency by replacing `realpath` calls with `zsh`'s native `:A` [parameter expansion modifier](http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers), which does the same thing as `realpath`, except portably and with no external dependency. This is also a performance win because it avoids the need to shell out to an external command.

The original code also called `realpath` at every step of the directory tree it was walking up. This is unnecessary because the first `realpath` or `:A` call resolves intermediate symlinks. This PR removes the extra calls.

Uses `$PWD` instead of `$(pwd)`, to avoid an unnecessary shell-out (for performance) and to make the `:A` modifier call a one-liner.

Fixes #4079.
Fixes #4030.
Fixes #4052. (I think.)
Closes #4025, which attempted to fix the issue by checking for the existence of `realpath`. Using `:A` results in simpler, faster code. (Sorry for stepping on your PR, @SandyRogers, but people are asking for a fix for immediate breakage.)
Closes #4074, which is basically the same thing. (Sorry for stepping on your PR, too, @mail6543210. I didn't see it when I searched for existing fixes.)
Closes #2376 (Really, #3918 should have auto-closed #2376, but since this follows on #3918's commits, may as well do it here to avoid the extra clerical work.)
