### PR TITLE
gnzh theme: fix "eval" and related scope problems.

### DIFF
--- a/themes/gnzh.zsh-theme
+++ b/themes/gnzh.zsh-theme
@@ -1,53 +1,50 @@
 # ZSH Theme - Preview: http://dl.dropbox.com/u/4109351/pics/gnzh-zsh-theme.png
 # Based on bira theme
 
-# load some modules
-autoload -U zsh/terminfo # Used in the colour alias below
 setopt prompt_subst
 
-# make some aliases for the colours: (could use normal escape sequences too)
-for color in RED GREEN YELLOW BLUE MAGENTA CYAN WHITE; do
-  eval PR_$color='%{$fg[${(L)color}]%}'
-done
-eval PR_NO_COLOR="%{$terminfo[sgr0]%}"
-eval PR_BOLD="%{$terminfo[bold]%}"
+() {
+
+local PR_USER PR_USER_OP PR_PROMPT PR_HOST
 
 # Check the UID
 if [[ $UID -ne 0 ]]; then # normal user
-  eval PR_USER='${PR_GREEN}%n${PR_NO_COLOR}'
-  eval PR_USER_OP='${PR_GREEN}%#${PR_NO_COLOR}'
-  local PR_PROMPT='$PR_NO_COLOR➤ $PR_NO_COLOR'
+  PR_USER='%F{green}%n%f'
+  PR_USER_OP='%F{green}%#%f'
+  PR_PROMPT='%f➤ %f'
 else # root
-  eval PR_USER='${PR_RED}%n${PR_NO_COLOR}'
-  eval PR_USER_OP='${PR_RED}%#${PR_NO_COLOR}'
-  local PR_PROMPT='$PR_RED➤ $PR_NO_COLOR'
+  PR_USER='%F{red}%n%f'
+  PR_USER_OP='%F{red}%#%f'
+  PR_PROMPT='%F{red}➤ %f'
 fi
 
 # Check if we are on SSH or not
 if [[ -n "$SSH_CLIENT"  ||  -n "$SSH2_CLIENT" ]]; then
-  eval PR_HOST='${PR_YELLOW}%M${PR_NO_COLOR}' #SSH
+  PR_HOST='%F{red}%M%f' # SSH
 else
-  eval PR_HOST='${PR_GREEN}%M${PR_NO_COLOR}' # no SSH
+  PR_HOST='%F{green}%M%f' # no SSH
 fi
 
-local return_code="%(?..%{$PR_RED%}%? ↵%{$PR_NO_COLOR%})"
 
-local user_host='${PR_USER}${PR_CYAN}@${PR_HOST}'
-local current_dir='%{$PR_BOLD$PR_BLUE%}%~%{$PR_NO_COLOR%}'
+local return_code="%(?..%F{red}%? ↵%f)"
+
+local user_host="${PR_USER}%F{cyan}@${PR_HOST}"
+local current_dir="%B%F{blue}%~%f%b"
 local rvm_ruby=''
-if ${HOME}/.rvm/bin/rvm-prompt &> /dev/null; then # detect local user rvm installation
-  rvm_ruby='%{$PR_RED%}‹$(${HOME}/.rvm/bin/rvm-prompt i v g s)›%{$PR_NO_COLOR%}'
-elif which rvm-prompt &> /dev/null; then # detect sysem-wide rvm installation
-  rvm_ruby='%{$PR_RED%}‹$(rvm-prompt i v g s)›%{$PR_NO_COLOR%}'
-elif which rbenv &> /dev/null; then # detect Simple Ruby Version management
-  rvm_ruby='%{$PR_RED%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$PR_NO_COLOR%}'
+if ${HOME}/.rvm/bin/rvm-prompt &> /dev/null; then # detect user-local rvm installation
+  rvm_ruby='%F{red}‹$(${HOME}/.rvm/bin/rvm-prompt i v g s)›%f'
+elif which rvm-prompt &> /dev/null; then # detect system-wide rvm installation
+  rvm_ruby='%F{red}‹$(rvm-prompt i v g s)›%f'
+elif which rbenv &> /dev/null; then # detect Simple Ruby Version Management
+  rvm_ruby='%F{red}‹$(rbenv version | sed -e "s/ (set.*$//")›%f'
 fi
-local git_branch='$(git_prompt_info)%{$PR_NO_COLOR%}'
+local git_branch='$(git_prompt_info)'
 
-#PROMPT="${user_host} ${current_dir} ${rvm_ruby} ${git_branch}$PR_PROMPT "
 PROMPT="╭─${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
 ╰─$PR_PROMPT "
-RPS1="${return_code}"
+RPROMPT="${return_code}"
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$PR_YELLOW%}‹"
-ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$PR_NO_COLOR%}"
+ZSH_THEME_GIT_PROMPT_PREFIX="%F{yellow}‹"
+ZSH_THEME_GIT_PROMPT_SUFFIX="› %f"
+
+}


### PR DESCRIPTION
Fixes #3425.

This clears up issues related to `eval` and the use of eager vs lazy evaulation in the `gnzh` theme. The `eval` was the one causing user-visible problems, but there's a small tangle of related issues, and this addresses them all.

The outcome of this PR is that:
* Prompt effect escapes are all lazy-evaluated at prompt time, using `%F`/`%f`
* Variables used to build the `$PROMPT` string are all eager-evaluated at theme loading time
 * Except for ones that deliberately use `$(...)` to call functions at prompt time
* Variables are all `local`-ized

This PR removes the problematic `eval` usage by switching to [normal `zsh` %F/%f prompt escapes](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Visual-effects) to avoid "eval" and the associated global variables.

There were several `local` statements that weren't having any effect, because the theme is not loaded in a function, so they were globals. This PR wraps whole thing in an anonymous function so the existing `local` statements actually work. 

But that breaks the theme, because a lot of stuff was done with lazy-evaluated `'...'` quotes, which relied on those actually being persistent global variables. So this PR switches '...' to eager "..." where needed, so stuff actually works with local variables. 

And it `local`-izes the remaining variables that are used only in prompt construction.

I've tested this on the following, exercising the git, return status, and root detection features, and it looks good.
* Mac OS X 10.9.5 with iTerm2 and Terminal.app
* Debian 7 using Konsole, `xterm`, and `urxvt`
* Cygwin/Windows 7 using mintty
Could use some more testers for `urxvt` and the console on Linux distros that were having this problem, and for RVM.