### PR TITLE
chucknorris: check for fortune/strfile dependency

### DIFF
--- a/plugins/chucknorris/chucknorris.plugin.zsh
+++ b/plugins/chucknorris/chucknorris.plugin.zsh
@@ -1,6 +1,12 @@
-if [ ! -f $ZSH/plugins/chucknorris/fortunes/chucknorris.dat ]; then
-    strfile $ZSH/plugins/chucknorris/fortunes/chucknorris $ZSH/plugins/chucknorris/fortunes/chucknorris.dat
-fi
+() {
+  # Automatically generate or update Chuck's compiled fortune data file
+  local fdir=$ZSH/plugins/chucknorris/fortunes
+  if [[ ! -f $fdir/chucknorris.dat ]] || [[ $fdir/chucknorris.dat -ot $fdir/chucknorris ]]; then
+    strfile $fdir/chucknorris $fdir/chucknorris.dat
+  fi
 
-alias chuck="fortune -a $ZSH/plugins/chucknorris/fortunes"
-alias chuck_cow="chuck | cowthink"
+  # Aliases
+  alias chuck="fortune -a $fdir"
+  alias chuck_cow="chuck | cowthink"
+}
+

--- a/plugins/chucknorris/chucknorris.plugin.zsh
+++ b/plugins/chucknorris/chucknorris.plugin.zsh
@@ -1,11 +1,28 @@
+# chucknorris: Chuck Norris fortunes
+
 # Automatically generate or update Chuck's compiled fortune data file
-DIR=${0:h}/fortunes
+# $0 must be used outside a local function. This variable name is unlikly to collide.
+CHUCKNORRIS_PLUGIN_DIR=${0:h}
+
+() {
+local DIR=$CHUCKNORRIS_PLUGIN_DIR/fortunes
 if [[ ! -f $DIR/chucknorris.dat ]] || [[ $DIR/chucknorris.dat -ot $DIR/chucknorris ]]; then
-  strfile $DIR/chucknorris $DIR/chucknorris.dat
+  # For some reason, Cygwin puts strfile in /usr/sbin, which is not on the path by default
+  local strfile=strfile
+  if ! which strfile &>/dev/null && [[ -f /usr/sbin/strfile ]]; then
+    strfile=/usr/sbin/strfile
+  fi
+  if which $strfile &> /dev/null; then
+    $strfile $DIR/chucknorris $DIR/chucknorris.dat >/dev/null
+  else
+    echo "[oh-my-zsh] chucknorris depends on strfile, which is not installed" >&2
+    echo "[oh-my-zsh] strfile is often provided as part of the 'fortune' package" >&2
+  fi
 fi
 
 # Aliases
 alias chuck="fortune -a $DIR"
 alias chuck_cow="chuck | cowthink"
+}
 
-unset DIR
+unset CHUCKNORRIS_PLUGIN_DIR

--- a/plugins/chucknorris/chucknorris.plugin.zsh
+++ b/plugins/chucknorris/chucknorris.plugin.zsh
@@ -1,12 +1,11 @@
-() {
-  # Automatically generate or update Chuck's compiled fortune data file
-  local fdir=$ZSH/plugins/chucknorris/fortunes
-  if [[ ! -f $fdir/chucknorris.dat ]] || [[ $fdir/chucknorris.dat -ot $fdir/chucknorris ]]; then
-    strfile $fdir/chucknorris $fdir/chucknorris.dat
-  fi
+# Automatically generate or update Chuck's compiled fortune data file
+DIR=${0:h}/fortunes
+if [[ ! -f $DIR/chucknorris.dat ]] || [[ $DIR/chucknorris.dat -ot $DIR/chucknorris ]]; then
+  strfile $DIR/chucknorris $DIR/chucknorris.dat
+fi
 
-  # Aliases
-  alias chuck="fortune -a $fdir"
-  alias chuck_cow="chuck | cowthink"
-}
+# Aliases
+alias chuck="fortune -a $DIR"
+alias chuck_cow="chuck | cowthink"
 
+unset DIR


### PR DESCRIPTION
Fixes #4112
Fixes #4334
Depends on #3611 

This plugin depends on fortune and strfile, which is part of fortune. But that's not immediately obvious to many users, per #4112.

This PR has chucknorris check for `strfile` when it needs it, and if not found, issue a more helpful error message that suggests a "fortune" package, and doesn't attempt to use strfile to update the fortunes dir. Still puts the aliases in place, since they'll produce more obvious error messages if used when `fortune` is not installed.

Also handles Cygwin installing `strfile` to `/usr/sbin`, which is not on the path by default, by directly checking for `/usr/sbin/strfile` if the plain `strfile` command is not found.

Adds an anonymous function for hygiene, to avoid clobbering the global `$DIR` variable, and uses a less-likely-to-collide `$CHUCKNORRIS_PLUGIN_DIR` temporary global for where it needs to access `$0` outside the anonymous function.

CC @maff, since you're the original chucknorris plugin author.
