### PR TITLE
virtualenvwrapper: Treat git repos as project roots again

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -30,16 +30,17 @@ if [[ "$WORKON_HOME" == "" ]]; then
 fi
 
 if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
-  # Automatically activate Git projects's virtual environments based on the
+  # Automatically activate Git projects' virtual environments based on the
   # directory name of the project. Virtual environment name can be overridden
   # by placing a .venv file in the project root with a virtualenv name in it
   function workon_cwd {
     if [ ! $WORKON_CWD ]; then
       WORKON_CWD=1
       # Check if this is a Git repo
-      PROJECT_ROOT=`pwd`
+      # Get absolute path, resolving symlinks
+      PROJECT_ROOT="${PWD:A}"
       while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" ]]; do
-        PROJECT_ROOT=`realpath $PROJECT_ROOT/..`
+        PROJECT_ROOT="${PROJECT_ROOT:h}"
       done
       if [[ "$PROJECT_ROOT" == "/" ]]; then
         PROJECT_ROOT="."
@@ -50,7 +51,7 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       elif [[ -f "$PROJECT_ROOT/.venv/bin/activate" ]];then
         ENV_NAME="$PROJECT_ROOT/.venv"
       elif [[ "$PROJECT_ROOT" != "." ]]; then
-        ENV_NAME=`basename "$PROJECT_ROOT"`
+        ENV_NAME="${PROJECT_ROOT:t}"
       else
         ENV_NAME=""
       fi


### PR DESCRIPTION
Makes `virtualenvwrapper` see git repos as project roots again, which was lost in the #3918 change.

Fixes #4110
Closes #4070 
Depends on #4106 

###  Details

In #3918, the virtualenvwrapper plugin logic was changed so that `.venv` dirs at any point created a virtualenvwrapper project root, but Git repos without a custom `.venv` were no longer treated as project roots. This was unexpected by some users, who are using non-customized Git repos as project roots. (See #4110, #4070, discussion in #4106, discussion in #3918).

This PR restores the old behavior of treating any Git repo as a project root, in addition to #3918's use of `.venv` as defining a project root. Combined with #3918, this means that the lowermost Git repo or customized `.venv` project will be treated as the project root.

There appear to be some other issues in detection of the venv name and activating venvs, but this PR does not address them. (E.g. invalid venv names are silently ignored and result in th previous venv being left activated.) This PR only undoes the loss of git repo functionality from #3918.


### Implementation

This uses `git rev-parse --show-toplevel` instead of `[[ -d $DIR/.git ]]` to detect git repos, because it is more robust. The presence of a `.git` subdir alone doesn't mean it's an actual git repo. (Try it yourself: just `mkdir .git` and see if it works as a repo.) And the `git` executable should be the source of truth about what is a git repo.

Degrades such that if `git` is not installed, then git repos will be silently ignored and not treated as project roots.

It seems like there would be an inconsistency between walking up the absolute path vs asking `git rev-parse show-toplevel` what the repo root is, in the case where you are inside a repo which has a symlink to a directory outside the repo, and you have cd'ed down through that directory. However, I tested it, and `git rev-parse show-toplevel` works the same way: it considers your absolute path. I'm not sure if this is the intended behavior for `git` wrt symlinks outside a repo, but we are consistent with it.

[Here's a test script](https://gist.github.com/apjanke/275ee69f3749ee157da5) that demonstrates the `--show-toplevel` behavior. On OS X 10.9.5, I get the following, which is consistent with this PR's code. It looks like `git` evaluates symlinks before locating the top of the repo. (I have Homebrew installed, so `/usr/local` is itself a Git repo.)

```
$ zsh ./test_rev_parse.zsh
/Users/janke/tmp/a_git_repo/a_dir/link_to_local_bin
show-toplevel: /usr/local
/Users/janke/tmp/a_git_repo/a_dir/under_tmp
fatal: Not a git repository (or any of the parent directories): .git
show-toplevel:
```

