### PR TITLE
svn: decode URLs before display, to avoid breaking prompt

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,17 +1,65 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
 #
 function svn_prompt_info() {
+  local _DISPLAY
   if in_svn; then
     if [ "x$SVN_SHOW_BRANCH" = "xtrue" ]; then
       unset SVN_SHOW_BRANCH
       _DISPLAY=$(svn_get_branch_name)
     else
       _DISPLAY=$(svn_get_repo_name)
+      _DISPLAY=$(_omz_svn_urldecode "${_DISPLAY}")
     fi
     echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$(svn_dirty_pwd)$ZSH_PROMPT_BASE_COLOR"
-    unset _DISPLAY
   fi
+}
+
+# Required for $langinfo
+zmodload zsh/langinfo
+
+# Decode a RFC 2396 URL-encoded (%-escaped) string
+#
+# This decodes the '+' and '%' escapes in the input string, and leaves 
+# other characters unchanged. Does not enforce that the input is a 
+# valid URL-encoded string. This is a convenience to allow callers to
+# pass in a full URL or similar strings and decode them for human
+# presentation.
+#
+# If an error occurs during character encoding or other parts of the
+# decoding process, this outputs a message on stderr and returns a 
+# nonzero status.
+#
+# Usage:
+#   _omz_svn_urldecode <urlstring>  - prints decoded string followed by a newline
+function _omz_svn_urldecode {
+  local encoded_url=$1
+
+  # Work bytewise, since URLs escape UTF-8 octets
+  local caller_encoding=${langinfo[CODESET]}
+  local LC_ALL=C
+  export LC_ALL
+  
+  # Change + back to ' '
+  local tmp=${encoded_url:gs/+/ /}
+  # Transform other escapes to pass through the printf
+  tmp="${tmp:gs/\\/\\\\/}"
+  # Handle %-escapes by turning them into `\xXX` printf escapes
+  tmp="${tmp:gs/%/\\x/}"
+  local decoded
+  eval "decoded=\$'$tmp'"
+
+  # Now we have a UTF-8 encoded string in the variable. We need to re-encode
+  # it if caller is in a non-UTF-8 locale.
+  if [[ $caller_encoding != "UTF-8" && $caller_encoding != "utf8" ]]; then
+    decoded=$(echo "$decoded" | iconv -f UTF-8 -t "$caller_encoding")
+    if [[ $? != 0 ]]; then
+      echo "Error converting string from UTF-8 to $caller_encoding" >&2
+      return 1
+    fi
+  fi
+
+  print "$decoded"
 }
 
 
@@ -30,7 +78,7 @@ function svn_get_repo_name() {
 }
 
 function svn_get_branch_name() {
-  _DISPLAY=$(
+  local _DISPLAY=$(
     svn info 2> /dev/null | \
       awk -F/ \
       '/^URL:/ { \
@@ -49,7 +97,6 @@ function svn_get_branch_name() {
   else
     echo $_DISPLAY
   fi
-  unset _DISPLAY
 }
 
 function svn_get_rev_nr() {
@@ -60,7 +107,7 @@ function svn_get_rev_nr() {
 
 function svn_dirty_choose() {
   if in_svn; then
-    root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
+    local root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
     if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1


### PR DESCRIPTION
Subversion repos are identified by URLs, which may be %-escaped if they have reserved characters in them. Those %s will be interpreted as prompt escapes if an escaped URL fragment is included directly in the prompt. This PR has it decode the URLs before using them in the prompt.

Fixes #2233.