### PR TITLE
Add URL encode/decode functions to core lib

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -73,3 +73,134 @@ function env_default() {
     env | grep -q "^$1=" && return 0 
     export "$1=$2"       && return 3
 }
+
+# Required for $langinfo
+zmodload zsh/langinfo
+
+# URL-encode a string
+#
+# Encodes a string using RFC 2396 URL-encoding (%-escaped).
+# See: https://www.ietf.org/rfc/rfc2396.txt
+#
+# By default, reserved characters and unreserved "mark" characters are
+# not escaped by this function. This allows the common usage of passing
+# an entire URL in, and encoding just special characters in it, with 
+# the expectation that reserved and mark characters are used appropriately.
+# The -r and -m options turn on escaping of the reserved and mark characters,
+# respectively, which allows arbitrary strings to be fully escaped for
+# embedding inside URLs, where reserved characters might be misinterpreted.
+#
+# Prints the encoded string on stdout.
+# Returns nonzero if encoding failed.
+#
+# Usage:
+#  omz_urlencode [-r] [-m] <string>
+#  
+#    -r causes reserved characters (;/?:@&=+$,) to be escaped
+#
+#    -m causes "mark" characters (_.!~*''()-) to be escaped
+#
+#    -P causes spaces to be encoded as '%20' instead of '+'
+function omz_urlencode() {
+  emulate -L zsh
+  zparseopts -D -E -a opts r m P
+
+  local in_str=$1
+  local url_str=""
+  local spaces_as_plus
+  if [[ -z $opts[(r)-P] ]]; then spaces_as_plus=1; fi
+  local str="$in_str"
+
+  # URLs must use UTF-8 encoding; convert str to UTF-8 if required
+  local encoding=$langinfo[CODESET]
+  local safe_encodings
+  safe_encodings=(UTF-8 utf8 US-ASCII)
+  if [[ -z ${safe_encodings[(r)$encoding]} ]]; then
+    str=$(echo -E "$str" | iconv -f $encoding -t UTF-8)
+    if [[ $? != 0 ]]; then
+      echo "Error converting string from $encoding to UTF-8" >&2
+      return 1
+    fi
+  fi
+
+  # Use LC_CTYPE=C to process text byte-by-byte
+  local i byte ord LC_ALL=C
+  export LC_ALL
+  local reserved=';/?:@&=+$,'
+  local mark='_.!~*''()-'
+  local dont_escape="[A-Za-z0-9"
+  if [[ -z $opts[(r)-r] ]]; then
+    dont_escape+=$reserved
+  fi
+  # $mark must be last because of the "-"
+  if [[ -z $opts[(r)-m] ]]; then
+    dont_escape+=$mark
+  fi
+  dont_escape+="]"
+
+  # Implemented to use a single printf call and avoid subshells in the loop,
+  # for performance (primarily on Windows).
+  local url_str=""
+  for (( i = 1; i <= ${#str}; ++i )); do
+    byte="$str[i]"
+    if [[ "$byte" =~ "$dont_escape" ]]; then
+      url_str+="$byte"
+    else
+      if [[ "$byte" == " " && -n $spaces_as_plus ]]; then
+        url_str+="+"
+      else
+        ord=$(( [##16] #byte ))
+        url_str+="%$ord"
+      fi
+    fi
+  done
+  echo -E "$url_str"
+}
+
+# URL-decode a string
+#
+# Decodes a RFC 2396 URL-encoded (%-escaped) string.
+# This decodes the '+' and '%' escapes in the input string, and leaves 
+# other characters unchanged. Does not enforce that the input is a 
+# valid URL-encoded string. This is a convenience to allow callers to
+# pass in a full URL or similar strings and decode them for human
+# presentation.
+#
+# Outputs the encoded string on stdout.
+# Returns nonzero if encoding failed.
+#
+# Usage:
+#   omz_urldecode <urlstring>  - prints decoded string followed by a newline
+function omz_urldecode {
+  emulate -L zsh
+  local encoded_url=$1
+
+  # Work bytewise, since URLs escape UTF-8 octets
+  local caller_encoding=$langinfo[CODESET]
+  local LC_ALL=C
+  export LC_ALL
+  
+  # Change + back to ' '
+  local tmp=${encoded_url:gs/+/ /}
+  # Protect other escapes to pass through the printf unchanged
+  tmp=${tmp:gs/\\/\\\\/}
+  # Handle %-escapes by turning them into `\xXX` printf escapes
+  tmp=${tmp:gs/%/\\x/}
+  local decoded
+  eval "decoded=\$'$tmp'"
+
+  # Now we have a UTF-8 encoded string in the variable. We need to re-encode
+  # it if caller is in a non-UTF-8 locale.
+  local safe_encodings
+  safe_encodings=(UTF-8 utf8 US-ASCII)
+  if [[ -z ${safe_encodings[(r)$caller_encoding]} ]]; then
+    decoded=$(echo -E "$decoded" | iconv -f UTF-8 -t $caller_encoding)
+    if [[ $? != 0 ]]; then
+      echo "Error converting string from UTF-8 to $caller_encoding" >&2
+      return 1
+    fi
+  fi
+
+  echo -E "$decoded"
+}
+

--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,16 +1,17 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
 #
 function svn_prompt_info() {
+  local _DISPLAY
   if in_svn; then
     if [ "x$SVN_SHOW_BRANCH" = "xtrue" ]; then
       unset SVN_SHOW_BRANCH
       _DISPLAY=$(svn_get_branch_name)
     else
       _DISPLAY=$(svn_get_repo_name)
+      _DISPLAY=$(omz_urldecode "${_DISPLAY}")
     fi
     echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$(svn_dirty_pwd)$ZSH_PROMPT_BASE_COLOR"
-    unset _DISPLAY
   fi
 }
 
@@ -30,7 +31,7 @@ function svn_get_repo_name() {
 }
 
 function svn_get_branch_name() {
-  _DISPLAY=$(
+  local _DISPLAY=$(
     svn info 2> /dev/null | \
       awk -F/ \
       '/^URL:/ { \
@@ -49,7 +50,6 @@ function svn_get_branch_name() {
   else
     echo $_DISPLAY
   fi
-  unset _DISPLAY
 }
 
 function svn_get_rev_nr() {
@@ -60,7 +60,7 @@ function svn_get_rev_nr() {
 
 function svn_dirty_choose() {
   if in_svn; then
-    root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
+    local root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
     if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1
@@ -77,7 +77,7 @@ function svn_dirty() {
 
 function svn_dirty_choose_pwd () {
   if in_svn; then
-    root=$PWD
+    local root=$PWD
     if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1


### PR DESCRIPTION
OMZ isn't a web-oriented tool per se, but there are several places where URLs are used in it: reporting pwd to terminal applications, working with `svn` repo URLs, and so on. URL encoding and decoding of strings comes in to play there. This is nontrivial, so it would be nice to have functions for it available in the core library, so plugins and other code can use them. Could be useful for users building their own scripts and working on the command line, too, since a lot of development work is web stuff.

This PR adds `omz_urlencode()` and `omz_urldecode()` functions to `lib.functions.zsh`. Their implementations are pure native `zsh`, for performance and consistency across platforms. (Well, except for a call to `iconv` when needed for non-UTF-8 locales.) They provide:
* A pretty full implementation of RFC 2396, handling all the character classes
* Handling of locale's character set
* Safe with respect to literal '\' and '%' in encoded strings
* Options to encode "mark" and "reserved" characters a %-escapes
* Minimal subshell calls, to avoid performance overhead, especially on Windows/Cygwin
* No external dependencies except `iconv` for non-UTF-8

If this PR is accepted, then the single-use urlencode and urldecode functions in pending PRs #3582 and #4128 can be changed to use these central implementations. I'm not making that switch part of this PR because I don't want to intertwine them until it's determined which PRs will be accepted.

There is an existing `urlencode`/`urldecode` implementation in the `urltools` plugin. But that's not suitable for use by core OMZ code or other plugins, because it would introduce core -> plugin or plugin -> plugin dependencies. They don't have options to control encoding of mark or reserved characters. Plus, those implementations rely on a variety of external components, and some of the definitions appear to be incomplete or inconsistent with each other, and don't have locale handling. Having a single native `zsh` implementation would ensure the same behavior on all systems and make things easier to debug.

Fixes #2233

UPDATE: These same functions are now included in #3582. If it is merged, this PR is no longer needed.