### PR TITLE
Adds an alias to search for the rails routes that pattern match a string

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -58,6 +58,7 @@ alias rdmtc='rake db:migrate db:test:clone'
 alias rlc='rake log:clear'
 alias rn='rake notes'
 alias rr='rake routes'
+alias rrg='rake routes | grep '
 
 # legacy stuff
 alias sstat='thin --stats "/thin/stats" start'

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -58,7 +58,7 @@ alias rdmtc='rake db:migrate db:test:clone'
 alias rlc='rake log:clear'
 alias rn='rake notes'
 alias rr='rake routes'
-alias rrg='rake routes | grep '
+alias rrg='rake routes | grep'
 
 # legacy stuff
 alias sstat='thin --stats "/thin/stats" start'


### PR DESCRIPTION
Some background on the PR -

**1. Reasons behind the need of this alias**

* Often times we'd like to know what is the REST path of a certain rails resource and for that we use the command `rake routes | grep resource_name` from the command line.
* Sometimes we'd like to even know what is the URL corresponding to a specific resource action and we'd use the above command for the same.

**2. The alias that gives you the above information**

We can now cover the above mentioned use cases with the alias `rrg resource_name`. 
* Example
  * Assuming the resource name is `users`, one could benefit from this alias via `rrg users`.