### PR TITLE
Updating Vundle.vim url and path

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -1,13 +1,12 @@
 function vundle-init () {
-  if [ ! -d ~/.vim/bundle/vundle/ ]
-  then
-    mkdir -p ~/.vim/bundle/vundle/
+  if [[ ! -d ~/.vim/bundle/Vundle.vim/ ]]; then
+    mkdir -p ~/.vim/bundle/Vundle.vim/
   fi
 
-  if [ ! -d ~/.vim/bundle/vundle/.git ] && [ ! -f ~/.vim/bundle/vundle/.git ]
-  then
-    git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
-    echo "\n\tRead about vim configuration for vundle at https://github.com/gmarik/vundle\n"
+  if [[ ! -d ~/.vim/bundle/Vundle.vim/.git ]] && [[ ! -f ~/.vim/bundle/Vundle.vim/.git ]]; then
+    git clone http://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+    echo "\n\tIn order to use the vundle commands, you will need to configure your .vimrc file."
+    echo "\tRead more about how to configure vundle at https://github.com/VundleVim/Vundle.vim\n"
   fi
 }
 


### PR DESCRIPTION
Per the Vundle.vim README, the new Github url is https://github.com/VundleVim/Vundle.vim. Moreover, the README states that the Vundle.vim repo should be cloned to `~/.vim/bundle/Vundle.vim`. For more info, check out [the Vundle.vim README](https://github.com/VundleVim/Vundle.vim).