### PR TITLE
Add new plugin js-repl for javascript REPL

### DIFF
--- a/plugins/js-repl/js-repl.plugin.zsh
+++ b/plugins/js-repl/js-repl.plugin.zsh
@@ -1,0 +1,5 @@
+if [[ "$OSTYPE" = darwin* ]] ; then
+    # https://trac.webkit.org/wiki/JSC
+    # jsc (or JavaScriptCore) is a Safari JavaScript REPL
+    alias jsc="/System/Library/Frameworks/JavaScriptCore.framework/Versions/Current/Resources/jsc"
+fi


### PR DESCRIPTION
only has safari on OS X
