### PR TITLE
Esc-esc toggles sudo

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -14,7 +14,11 @@
 
 sudo-command-line() {
     [[ -z $BUFFER ]] && zle up-history
-    [[ $BUFFER != sudo\ * ]] && LBUFFER="sudo $LBUFFER"
+    if [[ $BUFFER == sudo\ * ]]; then
+        LBUFFER="${LBUFFER#sudo }"
+    else
+        LBUFFER="sudo $LBUFFER"
+    fi
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]


### PR DESCRIPTION
This change improves the behaviour of the sudo plugin. By pressing esc-esc once the sudo command is added at the beginning as usual; pressing it once more removes "sudo " from the beginning of the line.