### PR TITLE
not in the path gradlew support

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -82,7 +82,11 @@ _gradlew_tasks () {
   if [ in_gradle ]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
-     gradlew tasks --all | grep "^[ ]*[a-zA-Z0-9:]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
+      cmd=gradlew
+      if ! type "gradlew" > /dev/null; then
+        cmd=./gradlew
+      fi
+      $cmd tasks --all | grep "^[ ]*[a-zA-Z0-9:]*\ -\ " | sed "s/ - .*$//" | sed "s/[\ ]*//" > .gradletasknamecache
     fi
     compadd -X "==== Gradlew Tasks ====" `cat .gradletasknamecache`
   fi


### PR DESCRIPTION
Hello,

as I do not put the "." in the path variable, my gradle wrapper (gradlew) cannot be run using the command "gradlew". As I assume it could affect other people, I propose this pull request to take into account the gradle wrapper of the current directory