### PR TITLE
agnoster: speed up git prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -78,7 +78,7 @@ prompt_git() {
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
     dirty=$(parse_git_dirty)
-    ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
+    ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git rev-parse --short HEAD 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment yellow black
     else


### PR DESCRIPTION
Problem

On detached-refs, the git prompt is very slow because it uses a command
to output all refs, which takes 32s on the twitter internal git repo.

Solution

Use git-rev-parse instead of git-show-ref to only output the head ref.
Runtime drops to 0.03 seconds.

Note

Interestingly, git-rev-parse isn't slow without the --head arguement so
I'll probably be cooking up a patch for the git team to speed this up
eventually, but it's still pointless to sigpipe git as it walks the
filesystem.