### PR TITLE
vi-mode: fix smkx/rmkx by removing broken line-init/finish widgets 

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,15 +1,5 @@
-# Ensures that $terminfo values are valid and updates editor information when
-# the keymap changes.
-function zle-keymap-select zle-line-init zle-line-finish {
-  # The terminal must be in application mode when ZLE is active for $terminfo
-  # values to be valid.
-  if (( ${+terminfo[smkx]} )); then
-    printf '%s' ${terminfo[smkx]}
-  fi
-  if (( ${+terminfo[rmkx]} )); then
-    printf '%s' ${terminfo[rmkx]}
-  fi
-
+# Updates editor information when the keymap changes.
+function zle-keymap-select() {
   zle reset-prompt
   zle -R
 }
@@ -19,8 +9,6 @@ TRAPWINCH() {
   zle && { zle reset-prompt; zle -R }
 }
 
-zle -N zle-line-init
-zle -N zle-line-finish
 zle -N zle-keymap-select
 zle -N edit-command-line
 


### PR DESCRIPTION
The zle-line-init and zle-line-finish definition changes introduced in #1533 were broken with
respect to `smkx`/`rmkx` because their "if" logic had fallthrough where it shouldn't,
so the mode was left in `rmkx` ("local" keypad mode) all the time. This breaks anything that uses terminfo or application ("transmit") mode escape sequences for cursor key bindings, including key bindings in some other plugins.

This PR just removes those widgets entirely, because they're now defined (correctly, I think) in `lib/keybindings.zsh` and not needed in plugins any more. (As long as the intent is to enable application cursor mode; see Caveats.)

Partially fixes #2735.

### Caveats and Regressions  ###

This fixes `vi-mode` so the terminal will be in "application cursor" aka "transmit" mode while editing the command line, instead of "local" mode.  This is how it is when OMZ is loaded but the `vi-mode` plugin is not. This allows key bindings made with the portable `terminfo` support to work.

However, users that use `vi-mode` and have hardcoded keybindings that map the cursor key sequences that a terminal sends in "local" mode are currently relying in the current broken smkx/rmkx code to keep the keypad in "local cursor" mode. Those key bindings would break.

Since terminfo supports portability to different terminals, and OMZ as a whole and other plugins seem to be moving toward using them, we may want to do this despite the breakage. This also seems to be where the zsh community as a whole is going: the zsh mailing lists seem to endorse `[sr]mkx`. And Ubuntu is shipping with an `/etc/zsh/zshrc` that enables it by default.

###   Interaction with prompt overwriting and `zle reset-prompt`   ###

I *think* the `zle reset-prompt` and `zle -R` were only needed on the `zle-keymap-select`, so they won't be missed from the other widgets (the `lib/keybindings.zsh` version doesn't use them). I've tested this out with the combination of `vi-mode` and `per-directory-history` (which introduced this initially in #1387), and it seems to be working for me. That is, with various themes I've tried, including two-line ones, it doesn't show the prompt-overwriting problem for me.


