### PR TITLE
history-substring-search: bind arrows in both vi and emacs keymaps

### DIFF
--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -15,9 +15,13 @@ fi
 # Bind terminal-specific up and down keys
 
 if [[ -n "$terminfo[kcuu1]" ]]; then
-  bindkey "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M vicmd "$terminfo[kcuu1]" history-substring-search-up
 fi
 if [[ -n "$terminfo[kcud1]" ]]; then
-  bindkey "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M vicmd "$terminfo[kcud1]" history-substring-search-down
 fi
 


### PR DESCRIPTION
This binds the arrow keys in both the `emacs` and `viins` keymaps so up arrow will "work" in both emacs and vi mode, and regardless of whether the `vi-mode` plugin is loaded before or after this.

Partially fixes #2735

Note that the arrow keys still won't work in vi mode if the `vi-mode` plugin is loaded until #4191 is also merged, because the widgets in `vi-mode` are preventing terminfo mappings from working.