### PR TITLE
history-substring-search: bind arrows in both vi and emacs keymaps (post-#4190 upstream update)

### DIFF
--- a/plugins/history-substring-search/README.markdown
+++ b/plugins/history-substring-search/README.markdown
@@ -1,7 +1,0 @@
-To activate this script, please include it the `plugins` variable within `~/.zshrc`
-
-  `plugins=(git history-substring-search)`
-
-See the "history-substring-search.zsh" file for more information:
-
-  `sed -n '2,/^$/s/^#//p' history-substring-search.zsh | more`

--- a/plugins/history-substring-search/README.md
+++ b/plugins/history-substring-search/README.md
@@ -1,0 +1,149 @@
+zsh-history-substring-search
+==============================================================================
+
+This is a clean-room implementation of the [Fish shell][1]'s history search
+feature, where you can type in any part of any previously entered command
+and press the UP and DOWN arrow keys to cycle through the matching commands.
+You can also use K and J in VI mode or ^P and ^N in EMACS mode for the same.
+
+[1]: http://fishshell.com
+[2]: http://www.zsh.org/mla/users/2009/msg00818.html
+[3]: http://sourceforge.net/projects/fizsh/
+[4]: https://github.com/robbyrussell/oh-my-zsh/pull/215
+[5]: https://github.com/zsh-users/zsh-history-substring-search
+[6]: https://github.com/zsh-users/zsh-syntax-highlighting
+
+------------------------------------------------------------------------------
+Requirements
+------------------------------------------------------------------------------
+
+* [ZSH](http://zsh.sourceforge.net) 4.3 or newer
+
+------------------------------------------------------------------------------
+Usage
+------------------------------------------------------------------------------
+
+1.  Load this script into your interactive ZSH session:
+
+        % source zsh-history-substring-search.zsh
+
+    If you want to use [zsh-syntax-highlighting][6] along with this script,
+    then make sure that you load it *before* you load this script:
+
+        % source zsh-syntax-highlighting.zsh
+        % source zsh-history-substring-search.zsh
+
+2.  Bind keyboard shortcuts to this script's functions:
+
+        # bind UP and DOWN arrow keys
+        zmodload zsh/terminfo
+        bindkey "$terminfo[kcuu1]" history-substring-search-up
+        bindkey "$terminfo[kcud1]" history-substring-search-down
+
+        # bind UP and DOWN arrow keys (compatibility fallback
+        # for Ubuntu 12.04, Fedora 21, and MacOSX 10.9 users)
+        bindkey '^[[A' history-substring-search-up
+        bindkey '^[[B' history-substring-search-down
+
+        # bind P and N for EMACS mode
+        bindkey -M emacs '^P' history-substring-search-up
+        bindkey -M emacs '^N' history-substring-search-down
+
+        # bind k and j for VI mode
+        bindkey -M vicmd 'k' history-substring-search-up
+        bindkey -M vicmd 'j' history-substring-search-down
+
+3.  Type any part of any previous command and then:
+
+    * Press the UP arrow key to select the nearest command that (1) contains
+      your query and (2) is older than the current command in the command
+      history.
+
+    * Press the DOWN arrow key to select the nearest command that (1)
+      contains your query and (2) is newer than the current command in the
+      command history.
+
+    * Press ^U (the Control and U keys simultaneously) to abort the search.
+
+4.  If a matching command spans more than one line of text, press the LEFT
+    arrow key to move the cursor away from the end of the command, and then:
+
+    * Press the UP arrow key to move the cursor to the line above.  When the
+      cursor reaches the first line of the command, pressing the UP arrow
+      key again will cause this script to perform another search.
+
+    * Press the DOWN arrow key to move the cursor to the line below.  When
+      the cursor reaches the last line of the command, pressing the DOWN
+      arrow key again will cause this script to perform another search.
+
+------------------------------------------------------------------------------
+Configuration
+------------------------------------------------------------------------------
+
+This script defines the following global variables. You may override their
+default values only after having loaded this script into your ZSH session.
+
+* HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND is a global variable that defines
+  how the query should be highlighted inside a matching command. Its default
+  value causes this script to highlight using bold, white text on a magenta
+  background. See the "Character Highlighting" section in the zshzle(1) man
+  page to learn about the kinds of values you may assign to this variable.
+
+* HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND is a global variable that
+  defines how the query should be highlighted when no commands in the
+  history match it. Its default value causes this script to highlight using
+  bold, white text on a red background. See the "Character Highlighting"
+  section in the zshzle(1) man page to learn about the kinds of values you
+  may assign to this variable.
+
+* HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS is a global variable that defines
+  how the command history will be searched for your query. Its default value
+  causes this script to perform a case-insensitive search. See the "Globbing
+  Flags" section in the zshexpn(1) man page to learn about the kinds of
+  values you may assign to this variable.
+
+To always receive _unique_ search results, use `setopt HIST_IGNORE_ALL_DUPS`.
+Alternatively, use `setopt HIST_FIND_NO_DUPS` which makes this plugin skip
+duplicate _adjacent_ search results as you cycle through them---however, this
+does not guarantee that search results are unique: if your search results were
+"Dog", "Dog", "HotDog", "Dog", then cycling them gives "Dog", "HotDog", "Dog".
+Notice that the "Dog" search result appeared twice as you cycled through them!
+If you wish to avoid this limitation, then use `setopt HIST_IGNORE_ALL_DUPS`.
+
+------------------------------------------------------------------------------
+History
+------------------------------------------------------------------------------
+
+This script was originally written by [Peter Stephenson][2], who published it
+to the ZSH users mailing list (thereby making it public domain) in September
+2009. It was later revised by Guido van Steen and released under the BSD
+license (see below) as part of [the fizsh project][3] in January 2011.
+
+It was later extracted from fizsh release 1.0.1, refactored heavily, and
+repackaged as both an [oh-my-zsh plugin][4] and as an independently loadable
+[ZSH script][5] by Suraj N. Kurapati in 2011.
+
+It was [further developed][4] by Guido van Steen, Suraj N. Kurapati, Sorin
+Ionescu, and Vincent Guerci in 2011.
+
+------------------------------------------------------------------------------
+Oh My Zsh Distribution Notes
+------------------------------------------------------------------------------
+
+What you are looking at now is Oh My Zsh's repackaging of zsh-history-substring-search 
+as an OMZ module inside the Oh My Zsh distribution.
+
+The upstream repo, zsh-users/zsh-history-substring-search, can be found on GitHub at 
+https://github.com/zsh-users/zsh-history-substring-search.
+
+This downstream copy was last updated from the following upstream commit:
+
+  SHA:          c4a83561a12b898ff7145856d0e6ae50757e28ba
+  Commit date:  2015-04-26 20:17:10 -0700
+
+Everything above this section is a copy of the original upstream's README, so things
+may differ slightly when you're using this inside OMZ. In particular, you do not
+need to set up key bindings for the up and down arrows yourself in `~/.zshrc`; the OMZ 
+plugin does that for you. You may still want to set up additional emacs- or vi-specific
+bindings as mentioned above.
+

--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -1,6 +1,6 @@
-# This file integrates the history-substring-search script into oh-my-zsh.
+# This file integrates the zsh-history-substring-search script into oh-my-zsh.
 
-source "$ZSH/plugins/history-substring-search/history-substring-search.zsh"
+source "${0:r:r}.zsh"
 
 if test "$CASE_SENSITIVE" = true; then
   unset HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS
@@ -10,3 +10,14 @@ if test "$DISABLE_COLOR" = true; then
   unset HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND
   unset HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
 fi
+
+
+# Bind terminal-specific up and down keys
+
+if [[ -n "$terminfo[kcuu1]" ]]; then
+  bindkey "$terminfo[kcuu1]" history-substring-search-up
+fi
+if [[ -n "$terminfo[kcud1]" ]]; then
+  bindkey "$terminfo[kcud1]" history-substring-search-down
+fi
+

--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -13,11 +13,14 @@ fi
 
 
 # Bind terminal-specific up and down keys
-
+# Bind in both emacs and vi modes so it works in both, and is not
+# sensitive to whether this is loaded before or after the vi-mode plugin
 if [[ -n "$terminfo[kcuu1]" ]]; then
-  bindkey "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
 fi
 if [[ -n "$terminfo[kcud1]" ]]; then
-  bindkey "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
+  bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
 fi
 

--- a/plugins/history-substring-search/history-substring-search.zsh
+++ b/plugins/history-substring-search/history-substring-search.zsh
@@ -1,95 +1,4 @@
 #!/usr/bin/env zsh
-#
-# This is a clean-room implementation of the Fish[1] shell's history search
-# feature, where you can type in any part of any previously entered command
-# and press the UP and DOWN arrow keys to cycle through the matching commands.
-#
-#-----------------------------------------------------------------------------
-# Usage
-#-----------------------------------------------------------------------------
-#
-# 1. Load this script into your interactive ZSH session:
-#
-#       % source history-substring-search.zsh
-#
-#    If you want to use the zsh-syntax-highlighting[6] script along with this
-#    script, then make sure that you load it *before* you load this script:
-#
-#       % source zsh-syntax-highlighting.zsh
-#       % source history-substring-search.zsh
-#
-# 2. Type any part of any previous command and then:
-#
-#     * Press the UP arrow key to select the nearest command that (1) contains
-#       your query and (2) is older than the current command in the command
-#       history.
-#
-#     * Press the DOWN arrow key to select the nearest command that (1)
-#       contains your query and (2) is newer than the current command in the
-#       command history.
-#
-#     * Press ^U (the Control and U keys simultaneously) to abort the search.
-#
-# 3. If a matching command spans more than one line of text, press the LEFT
-#    arrow key to move the cursor away from the end of the command, and then:
-#
-#     * Press the UP arrow key to move the cursor to the line above.  When the
-#       cursor reaches the first line of the command, pressing the UP arrow
-#       key again will cause this script to perform another search.
-#
-#     * Press the DOWN arrow key to move the cursor to the line below.  When
-#       the cursor reaches the last line of the command, pressing the DOWN
-#       arrow key again will cause this script to perform another search.
-#
-#-----------------------------------------------------------------------------
-# Configuration
-#-----------------------------------------------------------------------------
-#
-# This script defines the following global variables. You may override their
-# default values only after having loaded this script into your ZSH session.
-#
-# * HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND is a global variable that defines
-#   how the query should be highlighted inside a matching command. Its default
-#   value causes this script to highlight using bold, white text on a magenta
-#   background. See the "Character Highlighting" section in the zshzle(1) man
-#   page to learn about the kinds of values you may assign to this variable.
-#
-# * HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND is a global variable that
-#   defines how the query should be highlighted when no commands in the
-#   history match it. Its default value causes this script to highlight using
-#   bold, white text on a red background. See the "Character Highlighting"
-#   section in the zshzle(1) man page to learn about the kinds of values you
-#   may assign to this variable.
-#
-# * HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS is a global variable that defines
-#   how the command history will be searched for your query. Its default value
-#   causes this script to perform a case-insensitive search. See the "Globbing
-#   Flags" section in the zshexpn(1) man page to learn about the kinds of
-#   values you may assign to this variable.
-#
-#-----------------------------------------------------------------------------
-# History
-#-----------------------------------------------------------------------------
-#
-# This script was originally written by Peter Stephenson[2], who published it
-# to the ZSH users mailing list (thereby making it public domain) in September
-# 2009. It was later revised by Guido van Steen and released under the BSD
-# license (see below) as part of the fizsh[3] project in January 2011.
-#
-# It was later extracted from fizsh[3] release 1.0.1, refactored heavily, and
-# repackaged as both an oh-my-zsh plugin[4] and as an independently loadable
-# ZSH script[5] by Suraj N. Kurapati in 2011.
-#
-# It was further developed[4] by Guido van Steen, Suraj N. Kurapati, Sorin
-# Ionescu, and Vincent Guerci in 2011.
-#
-# [1]: http://fishshell.com
-# [2]: http://www.zsh.org/mla/users/2009/msg00818.html
-# [3]: http://sourceforge.net/projects/fizsh/
-# [4]: https://github.com/robbyrussell/oh-my-zsh/pull/215
-# [5]: https://github.com/sunaku/zsh-history-substring-search
-# [6]: https://github.com/nicoulaj/zsh-syntax-highlighting
-#
 ##############################################################################
 #
 # Copyright (c) 2009 Peter Stephenson
@@ -163,14 +72,6 @@ function history-substring-search-down() {
 zle -N history-substring-search-up
 zle -N history-substring-search-down
 
-zmodload zsh/terminfo
-if [[ -n "$terminfo[kcuu1]" ]]; then
-  bindkey "$terminfo[kcuu1]" history-substring-search-up
-fi
-if [[ -n "$terminfo[kcud1]" ]]; then
-  bindkey "$terminfo[kcud1]" history-substring-search-down
-fi
-
 #-----------------------------------------------------------------------------
 # implementation details
 #-----------------------------------------------------------------------------
@@ -185,32 +86,20 @@ zmodload -F zsh/parameter
 #
 if [[ $+functions[_zsh_highlight] -eq 0 ]]; then
   #
-  # Dummy implementation of _zsh_highlight()
-  # that simply removes existing highlights
+  # Dummy implementation of _zsh_highlight() that
+  # simply removes any existing highlights when the
+  # user inserts printable characters into $BUFFER.
   #
   function _zsh_highlight() {
-    region_highlight=()
-  }
-
-  #
-  # Remove existing highlights when the user
-  # inserts printable characters into $BUFFER
-  #
-  function ordinary-key-press() {
     if [[ $KEYS == [[:print:]] ]]; then
       region_highlight=()
     fi
-    zle .self-insert
   }
-  zle -N self-insert ordinary-key-press
 
   #
-  # Override ZLE widgets to invoke _zsh_highlight()
+  # The following snippet was taken from the zsh-syntax-highlighting project:
   #
-  # https://github.com/nicoulaj/zsh-syntax-highlighting/blob/
-  # bb7fcb79fad797a40077bebaf6f4e4a93c9d8163/zsh-syntax-highlighting.zsh#L121
-  #
-  #--------------8<-------------------8<-------------------8<-----------------
+  # https://github.com/zsh-users/zsh-syntax-highlighting/blob/56b134f5d62ae3d4e66c7f52bd0cc2595f9b305b/zsh-syntax-highlighting.zsh#L126-161
   #
   # Copyright (c) 2010-2011 zsh-syntax-highlighting contributors
   # All rights reserved.
@@ -241,50 +130,53 @@ if [[ $+functions[_zsh_highlight] -eq 0 ]]; then
   # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
   # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  #
+  #--------------8<-------------------8<-------------------8<-----------------
+  # Rebind all ZLE widgets to make them invoke _zsh_highlights.
+  _zsh_highlight_bind_widgets()
+  {
+    # Load ZSH module zsh/zleparameter, needed to override user defined widgets.
+    zmodload zsh/zleparameter 2>/dev/null || {
+      echo 'zsh-syntax-highlighting: failed loading zsh/zleparameter.' >&2
+      return 1
+    }
 
-  # Load ZSH module zsh/zleparameter, needed to override user defined widgets.
-  zmodload zsh/zleparameter 2>/dev/null || {
-    echo 'zsh-syntax-highlighting: failed loading zsh/zleparameter, exiting.' >&2
-    return -1
-  }
+    # Override ZLE widgets to make them invoke _zsh_highlight.
+    local cur_widget
+    for cur_widget in ${${(f)"$(builtin zle -la)"}:#(.*|_*|orig-*|run-help|which-command|beep|yank*)}; do
+      case $widgets[$cur_widget] in
 
-  # Override ZLE widgets to make them invoke _zsh_highlight.
-  for event in ${${(f)"$(zle -la)"}:#(_*|orig-*|.run-help|.which-command)}; do
-    if [[ "$widgets[$event]" == completion:* ]]; then
-      eval "zle -C orig-$event ${${${widgets[$event]}#*:}/:/ } ; $event() { builtin zle orig-$event && _zsh_highlight } ; zle -N $event"
-    else
-      case $event in
-        accept-and-menu-complete)
-          eval "$event() { builtin zle .$event && _zsh_highlight } ; zle -N $event"
-          ;;
+        # Already rebound event: do nothing.
+        user:$cur_widget|user:_zsh_highlight_widget_*);;
 
-        # The following widgets should NOT remove any previously
-        # applied highlighting. Therefore we do not remap them.
-        .forward-char|.backward-char|.up-line-or-history|.down-line-or-history)
-          ;;
+        # User defined widget: override and rebind old one with prefix "orig-".
+        user:*) eval "zle -N orig-$cur_widget ${widgets[$cur_widget]#*:}; \
+                      _zsh_highlight_widget_$cur_widget() { builtin zle orig-$cur_widget -- \"\$@\" && _zsh_highlight }; \
+                      zle -N $cur_widget _zsh_highlight_widget_$cur_widget";;
 
-        .*)
-          clean_event=$event[2,${#event}] # Remove the leading dot in the event name
-          case ${widgets[$clean_event]-} in
-            (completion|user):*)
-              ;;
-            *)
-              eval "$clean_event() { builtin zle $event && _zsh_highlight } ; zle -N $clean_event"
-              ;;
-          esac
-          ;;
-        *)
-          ;;
+        # Completion widget: override and rebind old one with prefix "orig-".
+        completion:*) eval "zle -C orig-$cur_widget ${${widgets[$cur_widget]#*:}/:/ }; \
+                            _zsh_highlight_widget_$cur_widget() { builtin zle orig-$cur_widget -- \"\$@\" && _zsh_highlight }; \
+                            zle -N $cur_widget _zsh_highlight_widget_$cur_widget";;
+
+        # Builtin widget: override and make it call the builtin ".widget".
+        builtin) eval "_zsh_highlight_widget_$cur_widget() { builtin zle .$cur_widget -- \"\$@\" && _zsh_highlight }; \
+                       zle -N $cur_widget _zsh_highlight_widget_$cur_widget";;
+
+        # Default: unhandled case.
+        *) echo "zsh-syntax-highlighting: unhandled ZLE widget '$cur_widget'" >&2 ;;
       esac
-    fi
-  done
-  unset event clean_event
+    done
+  }
   #-------------->8------------------->8------------------->8-----------------
+
+  _zsh_highlight_bind_widgets
 fi
 
 function _history-substring-search-begin() {
   setopt localoptions extendedglob
-  _history_substring_search_move_cursor_eol=false
+
+  _history_substring_search_refresh_display=
   _history_substring_search_query_highlight=
 
   #
@@ -308,12 +200,10 @@ function _history-substring-search-begin() {
     #
     # Find all occurrences of the search query in the history file.
     #
-    # (k) turns it an array of line numbers.
+    # (k) returns the "keys" (history index numbers) instead of the values
+    # (Oa) reverses the order, because (R) returns results reversed.
     #
-    # (on) seems to remove duplicates, which are default
-    #      options. They can be turned off by (ON).
-    #
-    _history_substring_search_matches=(${(kon)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
+    _history_substring_search_matches=(${(kOa)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
 
     #
     # Define the range of values that $_history_substring_search_match_index
@@ -351,10 +241,13 @@ function _history-substring-search-begin() {
 
 function _history-substring-search-end() {
   setopt localoptions extendedglob
+
   _history_substring_search_result=$BUFFER
 
-  # move the cursor to the end of the command line
-  if [[ $_history_substring_search_move_cursor_eol == true ]]; then
+  # the search was succesful so display the result properly by clearing away
+  # existing highlights and moving the cursor to the end of the result buffer
+  if [[ $_history_substring_search_refresh_display -eq 1 ]]; then
+    region_highlight=()
     CURSOR=${#BUFFER}
   fi
 
@@ -379,7 +272,7 @@ function _history-substring-search-end() {
   # read -k -t 200 && zle -U $REPLY
 
   # Exit successfully from the history-substring-search-* widgets.
-  true
+  return 0
 }
 
 function _history-substring-search-up-buffer() {
@@ -405,10 +298,10 @@ function _history-substring-search-up-buffer() {
 
   if [[ $#buflines -gt 1 && $CURSOR -ne $#BUFFER && $#xlbuflines -ne 1 ]]; then
     zle up-line-or-history
-    return true
+    return 0
   fi
 
-  false
+  return 1
 }
 
 function _history-substring-search-down-buffer() {
@@ -434,10 +327,10 @@ function _history-substring-search-down-buffer() {
 
   if [[ $#buflines -gt 1 && $CURSOR -ne $#BUFFER && $#xrbuflines -ne 1 ]]; then
     zle down-line-or-history
-    return true
+    return 0
   fi
 
-  false
+  return 1
 }
 
 function _history-substring-search-up-history() {
@@ -453,13 +346,13 @@ function _history-substring-search-up-history() {
 
     # going up from somewhere below the top of history
     else
-      zle up-history
+      zle up-line-or-history
     fi
 
-    return true
+    return 0
   fi
 
-  false
+  return 1
 }
 
 function _history-substring-search-down-history() {
@@ -472,21 +365,31 @@ function _history-substring-search-down-history() {
     # going down from the absolute top of history
     if [[ $HISTNO -eq 1 && -z $BUFFER ]]; then
       BUFFER=${history[1]}
-      _history_substring_search_move_cursor_eol=true
+      _history_substring_search_refresh_display=1
 
     # going down from somewhere above the bottom of history
     else
-      zle down-history
+      zle down-line-or-history
     fi
 
-    return true
+    return 0
   fi
 
-  false
+  return 1
+}
+
+function _history-substring-search-not-found() {
+  #
+  # Nothing matched the search query, so put it back into the $BUFFER while
+  # highlighting it accordingly so the user can revise it and search again.
+  #
+  _history_substring_search_old_buffer=$BUFFER
+  BUFFER=$_history_substring_search_query
+  _history_substring_search_query_highlight=$HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
 }
 
 function _history-substring-search-up-search() {
-  _history_substring_search_move_cursor_eol=true
+  _history_substring_search_refresh_display=1
 
   #
   # Highlight matches during history-substring-up-search:
@@ -542,9 +445,7 @@ function _history-substring-search-up-search() {
     #    to highlight the current buffer.
     #
     (( _history_substring_search_match_index-- ))
-    _history_substring_search_old_buffer=$BUFFER
-    BUFFER=$_history_substring_search_query
-    _history_substring_search_query_highlight=$HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
+    _history-substring-search-not-found
 
   elif [[ $_history_substring_search_match_index -eq $_history_substring_search_matches_count_plus ]]; then
     #
@@ -561,11 +462,30 @@ function _history-substring-search-up-search() {
     (( _history_substring_search_match_index-- ))
     BUFFER=$_history_substring_search_old_buffer
     _history_substring_search_query_highlight=$HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND
+
+  else
+    #
+    # We are at the beginning of history and there are no further matches.
+    #
+    _history-substring-search-not-found
+    return
+  fi
+
+  #
+  # When HIST_FIND_NO_DUPS is set, meaning that only unique command lines from
+  # history should be matched, make sure the new and old results are different.
+  # But when HIST_IGNORE_ALL_DUPS is set, ZSH already ensures a unique history.
+  #
+  if [[ ! -o HIST_IGNORE_ALL_DUPS && -o HIST_FIND_NO_DUPS && $BUFFER == $_history_substring_search_result ]]; then
+    #
+    # Repeat the current search so that a different (unique) match is found.
+    #
+    _history-substring-search-up-search
   fi
 }
 
 function _history-substring-search-down-search() {
-  _history_substring_search_move_cursor_eol=true
+  _history_substring_search_refresh_display=1
 
   #
   # Highlight matches during history-substring-up-search:
@@ -622,9 +542,7 @@ function _history-substring-search-down-search() {
     #    to highlight the current buffer.
     #
     (( _history_substring_search_match_index++ ))
-    _history_substring_search_old_buffer=$BUFFER
-    BUFFER=$_history_substring_search_query
-    _history_substring_search_query_highlight=$HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
+    _history-substring-search-not-found
 
   elif [[ $_history_substring_search_match_index -eq 0 ]]; then
     #
@@ -641,6 +559,25 @@ function _history-substring-search-down-search() {
     (( _history_substring_search_match_index++ ))
     BUFFER=$_history_substring_search_old_buffer
     _history_substring_search_query_highlight=$HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND
+
+  else
+    #
+    # We are at the end of history and there are no further matches.
+    #
+    _history-substring-search-not-found
+    return
+  fi
+
+  #
+  # When HIST_FIND_NO_DUPS is set, meaning that only unique command lines from
+  # history should be matched, make sure the new and old results are different.
+  # But when HIST_IGNORE_ALL_DUPS is set, ZSH already ensures a unique history.
+  #
+  if [[ ! -o HIST_IGNORE_ALL_DUPS && -o HIST_FIND_NO_DUPS && $BUFFER == $_history_substring_search_result ]]; then
+    #
+    # Repeat the current search so that a different (unique) match is found.
+    #
+    _history-substring-search-down-search
   fi
 }
 

--- a/plugins/history-substring-search/update-from-upstream.zsh
+++ b/plugins/history-substring-search/update-from-upstream.zsh
@@ -76,10 +76,12 @@ cat >> $plugin_basename.plugin.zsh <<EOF
 # Bind terminal-specific up and down keys
 
 if [[ -n "\$terminfo[kcuu1]" ]]; then
-  bindkey "\$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M emacs "\$terminfo[kcuu1]" history-substring-search-up
+  bindkey -M viins "\$terminfo[kcuu1]" history-substring-search-up
 fi
 if [[ -n "\$terminfo[kcud1]" ]]; then
-  bindkey "\$terminfo[kcud1]" history-substring-search-down
+  bindkey -M emacs "\$terminfo[kcud1]" history-substring-search-down
+  bindkey -M viins "\$terminfo[kcud1]" history-substring-search-down
 fi
 
 EOF

--- a/plugins/history-substring-search/update-from-upstream.zsh
+++ b/plugins/history-substring-search/update-from-upstream.zsh
@@ -1,0 +1,94 @@
+#!/usr/bin/env zsh
+#
+# update-from-upstream.zsh
+#
+# This script updates the Oh My Zsh version of the zsh-history-substring-search
+# plugin from the independent upstream repo. This is to be run by OMZ developers
+# when they want to pull in new changes from upstream to OMZ. It is not run
+# during normal use of the plugin.
+#
+# The official upstream repo is zsh-users/zsh-history-substring-search
+# https://github.com/zsh-users/zsh-history-substring-search
+#
+# This is a zsh script, not a function. Call it with `zsh update-from-upstream.zsh`
+# from the command line, running it from within the plugin directory.
+#
+# You can set the environment variable REPO_PATH to point it at an upstream
+# repo you have already prepared. Otherwise, it will do a clean checkout of
+# upstream's HEAD to a temporary local repo and use that.
+
+
+# Just bail on any error so we don't have to do extra checking.
+# This is a developer-use script, so terse output like that should
+# be fine.
+set -e
+
+
+UPSTREAM_BASE=zsh-history-substring-search
+UPSTREAM_REPO=zsh-users/$UPSTREAM_BASE
+need_repo_cleanup=false
+upstream_github_url="https://github.com/$UPSTREAM_REPO"
+
+if [[ -z "$UPSTREAM_REPO_PATH" ]]; then
+  # Do a clean checkout
+  my_tempdir=$(mktemp -d -t omz-update-histsubstrsrch)
+  UPSTREAM_REPO_PATH="$my_tempdir/$UPSTREAM_BASE"
+  git clone "$upstream_github_url" "$UPSTREAM_REPO_PATH"
+  need_repo_cleanup=true
+  print "Checked out upstream repo to $UPSTREAM_REPO_PATH"
+else
+	print "Using existing zsh-history-substring-search repo at $UPSTREAM_REPO_PATH"
+fi
+
+upstream="$UPSTREAM_REPO_PATH"
+
+# Figure out what we're pulling in
+upstream_sha=$(cd $upstream && git rev-parse HEAD)
+upstream_commit_date=$(cd $upstream && git log  -1 --pretty=format:%ci)
+print "upstream SHA:         $upstream_sha"
+print "upstream commit date: $upstream_commit_date"
+print
+
+# Copy the files over, using the OMZ plugin's names where needed
+cp -v "$upstream"/* .
+mv zsh-history-substring-search.plugin.zsh history-substring-search.plugin.zsh
+mv zsh-history-substring-search.zsh history-substring-search.zsh
+
+if [[ $need_repo_cleanup == true ]]; then
+	print "Removing temporary repo at $my_tempdir"
+	rm -rf "$my_tempdir"
+fi
+
+# Do OMZ-specific edits
+
+print
+print "Updating files with OMZ-specific stuff"
+
+# Tack OMZ-specific notes on to readme
+thin_line="------------------------------------------------------------------------------"
+cat >> README.md <<EOF
+
+$thin_line
+Oh My Zsh Notes
+$thin_line
+
+This is Oh My Zsh's repackaging of zsh-history-substring-search as an OMZ module
+inside the Oh My Zsh distribution.
+
+The upstream repo, $UPSTREAM_REPO, can be found on GitHub at $upstream_github_url.
+
+This downstream copy was last updated from the following upstream commit:
+
+  SHA:          $upstream_sha
+  Commit date:  $upstream_commit_date
+
+Everything above this section is a copy of the original upstream's README, so things
+may differ slightly when you're using this inside OMZ. In particular, you do not
+need to set up key bindings yourself in \`~/.zshrc\`; the OMZ plugin does that for
+you.
+
+EOF
+
+print
+print "Done OK"
+

--- a/plugins/history-substring-search/update-from-upstream.zsh
+++ b/plugins/history-substring-search/update-from-upstream.zsh
@@ -24,20 +24,21 @@
 set -e
 
 
-UPSTREAM_BASE=zsh-history-substring-search
-UPSTREAM_REPO=zsh-users/$UPSTREAM_BASE
+upstream_basename=zsh-history-substring-search
+plugin_basename=history-substring-search
+UPSTREAM_REPO=zsh-users/$upstream_basename
 need_repo_cleanup=false
 upstream_github_url="https://github.com/$UPSTREAM_REPO"
 
 if [[ -z "$UPSTREAM_REPO_PATH" ]]; then
   # Do a clean checkout
   my_tempdir=$(mktemp -d -t omz-update-histsubstrsrch)
-  UPSTREAM_REPO_PATH="$my_tempdir/$UPSTREAM_BASE"
+  UPSTREAM_REPO_PATH="$my_tempdir/$upstream_basename"
   git clone "$upstream_github_url" "$UPSTREAM_REPO_PATH"
   need_repo_cleanup=true
   print "Checked out upstream repo to $UPSTREAM_REPO_PATH"
 else
-	print "Using existing zsh-history-substring-search repo at $UPSTREAM_REPO_PATH"
+	print "Using existing $upstream_basename repo at $UPSTREAM_REPO_PATH"
 fi
 
 upstream="$UPSTREAM_REPO_PATH"
@@ -45,14 +46,16 @@ upstream="$UPSTREAM_REPO_PATH"
 # Figure out what we're pulling in
 upstream_sha=$(cd $upstream && git rev-parse HEAD)
 upstream_commit_date=$(cd $upstream && git log  -1 --pretty=format:%ci)
+upstream_just_date=${${=upstream_commit_date}[1]}
 print "upstream SHA:         $upstream_sha"
-print "upstream commit date: $upstream_commit_date"
+print "upstream commit time: $upstream_commit_date"
+print "upstream commit date: $upstream_just_date"
 print
 
 # Copy the files over, using the OMZ plugin's names where needed
 cp -v "$upstream"/* .
-mv zsh-history-substring-search.plugin.zsh history-substring-search.plugin.zsh
-mv zsh-history-substring-search.zsh history-substring-search.zsh
+mv -v zsh-history-substring-search.zsh $plugin_basename.zsh
+mv -v zsh-history-substring-search.plugin.zsh $plugin_basename.plugin.zsh
 
 if [[ $need_repo_cleanup == true ]]; then
 	print "Removing temporary repo at $my_tempdir"
@@ -63,19 +66,38 @@ fi
 
 print
 print "Updating files with OMZ-specific stuff"
+print
+
+# OMZ binds the keys as part of the plugin loading
+
+cat >> $plugin_basename.plugin.zsh <<EOF
+
+
+# Bind terminal-specific up and down keys
+
+if [[ -n "\$terminfo[kcuu1]" ]]; then
+  bindkey "\$terminfo[kcuu1]" history-substring-search-up
+fi
+if [[ -n "\$terminfo[kcud1]" ]]; then
+  bindkey "\$terminfo[kcud1]" history-substring-search-down
+fi
+
+EOF
 
 # Tack OMZ-specific notes on to readme
+
 thin_line="------------------------------------------------------------------------------"
 cat >> README.md <<EOF
 
 $thin_line
-Oh My Zsh Notes
+Oh My Zsh Distribution Notes
 $thin_line
 
-This is Oh My Zsh's repackaging of zsh-history-substring-search as an OMZ module
-inside the Oh My Zsh distribution.
+What you are looking at now is Oh My Zsh's repackaging of zsh-history-substring-search 
+as an OMZ module inside the Oh My Zsh distribution.
 
-The upstream repo, $UPSTREAM_REPO, can be found on GitHub at $upstream_github_url.
+The upstream repo, $UPSTREAM_REPO, can be found on GitHub at 
+$upstream_github_url.
 
 This downstream copy was last updated from the following upstream commit:
 
@@ -84,11 +106,22 @@ This downstream copy was last updated from the following upstream commit:
 
 Everything above this section is a copy of the original upstream's README, so things
 may differ slightly when you're using this inside OMZ. In particular, you do not
-need to set up key bindings yourself in \`~/.zshrc\`; the OMZ plugin does that for
-you.
+need to set up key bindings for the up and down arrows yourself in \`~/.zshrc\`; the OMZ 
+plugin does that for you. You may still want to set up additional emacs- or vi-specific
+bindings as mentioned above.
 
 EOF
 
-print
-print "Done OK"
+# Announce success and generate git commit messages
+
+cat <<EOF
+Done OK
+
+Now you can check the results and commit like this:
+
+  git add *
+  git commit -m "history-substring-search: update to upstream version $upstream_just_date" \\
+      -m "Updates OMZ's copy to commit $upstream_sha from $UPSTREAM_REPO"
+
+EOF
 


### PR DESCRIPTION
This is a version of #4192 that can be used if #4190 (harmonizing history-substring-search with upstream) gets merged in. It's a nontrivial merge, so I put in a separate PR, so people could see how it would work with the upstream-pulling mechanism.

Depends on #4190 (and includes its commits).
Closes #4192.
Partially fixes #2735.

### Description  ###

This binds the arrow keys in both the `emacs` and `viins` keymaps so up arrow will "work" in both emacs and vi mode, and regardless of whether the `vi-mode` plugin is loaded before or after this.

Note that the arrow keys still won't work in vi mode if the `vi-mode` plugin is loaded until #4191 is also merged, because the widgets in `vi-mode` are preventing terminfo mappings from working.
