### PR TITLE
fixing missing variable expansion for terminal title to be set

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -46,7 +46,7 @@ function omz_termsupport_preexec {
   local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
 
-  title '$CMD' '%100>...>$LINE%<<'
+  title "$CMD" "%100>...>$LINE%<<"
 }
 
 precmd_functions+=(omz_termsupport_precmd)


### PR DESCRIPTION
changing some single quotes to double quotes, because with single quotes the variable does not get expanded and the terminal title ends up being '$LINE' instead of the actual command run. With double quotes the variable expansion takes place as desired.