### PR TITLE
Add alias for "systemctl cat" and "systemctl edit"

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -1,11 +1,12 @@
 user_commands=(
   list-units is-active status show help list-unit-files
-  is-enabled list-jobs show-environment)
+  is-enabled list-jobs show-environment cat)
 
 sudo_commands=(
   start stop reload restart try-restart isolate kill
   reset-failed enable disable reenable preset mask unmask
-  link load cancel set-environment unset-environment)
+  link load cancel set-environment unset-environment
+  edit)
 
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
 for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done


### PR DESCRIPTION
I added few aliases, which I miss when managing systemd:
 * `sc-cat` -> `systemctl cat` 
 * `sc-edit` -> `sudo systemctl edit`