### PR TITLE
gnu-utils: add findutils (find,xargs,locate)

### DIFF
--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -29,7 +29,10 @@ if [[ -x "${commands[gwhoami]}" ]]; then
     'gunexpand' 'guniq' 'gunlink' 'guptime' 'gusers' 'gvdir' 'gwc' 'gwho'
     'gwhoami' 'gyes')
 
-    # Not part of coreutils, installed separately.
+    # findutils
+    gcmds+=('gfind' 'gxargs' 'glocate')
+
+    # Not part of either coreutils or findutils, installed separately.
     gcmds+=('gsed' 'gtar' 'gtime')
 
     for gcmd in "${gcmds[@]}"; do


### PR DESCRIPTION
findutils (gfind, gxargs, glocate) are installed with Homebrew,
```sh
$ brew install findutils
```