### PR TITLE
Add JIRA setting to show dashboard instead of create issue

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -3,11 +3,11 @@
 #         .jira-url in the current directory takes precedence
 #
 # If you prefer the jira command to show your dashboard, set:
-#JIRA_DASHBOARD="true"
+#   JIRA_DEFAULT_ACTION="dashboard"
 # in you .zshrc
 #
 # If you use Rapid Board, set:
-#JIRA_RAPID_BOARD="true"
+#   JIRA_RAPID_BOARD="true"
 # in you .zshrc
 #
 # Setup: cd to/my/project
@@ -35,7 +35,7 @@ open_jira_issue () {
   fi
 
   if [ -z "$1" ]; then
-    if [[ "$JIRA_DASHBOARD" = "true" ]]; then
+    if [[ "$JIRA_DEFAULT_ACTION" = "dashboard" ]]; then
       open_command "${jira_url}/secure/Dashboard.jspa"
     else
       open_command "${jira_url}/secure/CreateIssue!default.jspa"

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -2,6 +2,10 @@
 #         You can also set JIRA_URL in your .zshrc or put .jira-url in your home directory
 #         .jira-url in the current directory takes precedence
 #
+# If you prefer the jira command to show your dashboard, set:
+#JIRA_DASHBOARD="true"
+# in you .zshrc
+#
 # If you use Rapid Board, set:
 #JIRA_RAPID_BOARD="true"
 # in you .zshrc
@@ -31,8 +35,11 @@ open_jira_issue () {
   fi
 
   if [ -z "$1" ]; then
-    echo "Opening new issue"
-    open_command "${jira_url}/secure/CreateIssue!default.jspa"
+    if [[ "$JIRA_DASHBOARD" = "true" ]]; then
+      open_command "${jira_url}/secure/Dashboard.jspa"
+    else
+      open_command "${jira_url}/secure/CreateIssue!default.jspa"
+    fi
   elif [[ "$1" = "assigned" || "$1" = "reported" ]]; then
     jira_query $@
   else 


### PR DESCRIPTION
My most common JIRA action is to view my dashboard, so that's what the
command `jira` should do.