### PR TITLE
termsupport: protect title() with `emulate -L zsh` for portability

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -7,6 +7,9 @@
 # (In screen, only short_tab_title is used)
 # Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
+  emulate -L zsh
+  setopt prompt_subst
+  
   [[ "$EMACS" == *term* ]] && return
 
   # if $2 is unset use $1 as default


### PR DESCRIPTION
Adds `emulate -L zsh; setopt prompt_subst` to `title()` for portability. This prevents it from malfunctioning when `setopt prompt_subst` is off.

Fixes #4199.