### PR TITLE
Fix git-prompt plugin

### DIFF
--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -1,32 +1,34 @@
 # ZSH Git Prompt Plugin from:
 # http://github.com/olivierverdier/zsh-git-prompt
-#
-export __GIT_PROMPT_DIR=$ZSH/plugins/git-prompt
+
+export __GIT_PROMPT_DIR=${0:A:h}
+
+export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_USE_PYTHON:-"python"}
+
+# Initialize colors.
+autoload -U colors
+colors
 
 # Allow for functions in the prompt.
 setopt PROMPT_SUBST
 
-## Enable auto-execution of functions.
-typeset -ga preexec_functions
-typeset -ga precmd_functions
-typeset -ga chpwd_functions
+autoload -U add-zsh-hook
 
-# Append git functions needed for prompt.
-preexec_functions+='preexec_update_git_vars'
-precmd_functions+='precmd_update_git_vars'
-chpwd_functions+='chpwd_update_git_vars'
+add-zsh-hook chpwd chpwd_update_git_vars
+add-zsh-hook preexec preexec_update_git_vars
+add-zsh-hook precmd precmd_update_git_vars
 
 ## Function definitions
 function preexec_update_git_vars() {
     case "$2" in
-        git*)
+        git*|hub*|gh*|stg*)
         __EXECUTED_GIT_COMMAND=1
         ;;
     esac
 }
 
 function precmd_update_git_vars() {
-    if [ -n "$__EXECUTED_GIT_COMMAND" ]; then
+    if [ -n "$__EXECUTED_GIT_COMMAND" ] || [ ! -n "$ZSH_THEME_GIT_PROMPT_CACHE" ]; then
         update_current_git_vars
         unset __EXECUTED_GIT_COMMAND
     fi
@@ -39,19 +41,68 @@ function chpwd_update_git_vars() {
 function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
 
-    local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
-    _GIT_STATUS=`python ${gitstatus}`
-    __CURRENT_GIT_STATUS=("${(f)_GIT_STATUS}")
+    if [[ "$GIT_PROMPT_EXECUTABLE" == "python" ]]; then
+        local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
+        _GIT_STATUS=`python ${gitstatus} 2>/dev/null`
+    fi
+    if [[ "$GIT_PROMPT_EXECUTABLE" == "haskell" ]]; then
+        local gitstatus="$__GIT_PROMPT_DIR/dist/build/gitstatus/gitstatus"
+        _GIT_STATUS=`${gitstatus}`
+    fi
+     __CURRENT_GIT_STATUS=("${(@s: :)_GIT_STATUS}")
+	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
+	GIT_AHEAD=$__CURRENT_GIT_STATUS[2]
+	GIT_BEHIND=$__CURRENT_GIT_STATUS[3]
+	GIT_STAGED=$__CURRENT_GIT_STATUS[4]
+	GIT_CONFLICTS=$__CURRENT_GIT_STATUS[5]
+	GIT_CHANGED=$__CURRENT_GIT_STATUS[6]
+	GIT_UNTRACKED=$__CURRENT_GIT_STATUS[7]
 }
 
-function prompt_git_info() {
+
+git_super_status() {
+	precmd_update_git_vars
     if [ -n "$__CURRENT_GIT_STATUS" ]; then
-        echo "(%{${fg[red]}%}$__CURRENT_GIT_STATUS[1]%{${fg[default]}%}$__CURRENT_GIT_STATUS[2]%{${fg[magenta]}%}$__CURRENT_GIT_STATUS[3]%{${fg[default]}%})"
-    fi
+	  STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
+	  if [ "$GIT_BEHIND" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_BEHIND$GIT_BEHIND%{${reset_color}%}"
+	  fi
+	  if [ "$GIT_AHEAD" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_AHEAD$GIT_AHEAD%{${reset_color}%}"
+	  fi
+	  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_SEPARATOR"
+	  if [ "$GIT_STAGED" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_STAGED$GIT_STAGED%{${reset_color}%}"
+	  fi
+	  if [ "$GIT_CONFLICTS" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CONFLICTS$GIT_CONFLICTS%{${reset_color}%}"
+	  fi
+	  if [ "$GIT_CHANGED" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CHANGED$GIT_CHANGED%{${reset_color}%}"
+	  fi
+	  if [ "$GIT_UNTRACKED" -ne "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED%{${reset_color}%}"
+	  fi
+	  if [ "$GIT_CHANGED" -eq "0" ] && [ "$GIT_CONFLICTS" -eq "0" ] && [ "$GIT_STAGED" -eq "0" ] && [ "$GIT_UNTRACKED" -eq "0" ]; then
+		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
+	  fi
+	  STATUS="$STATUS%{${reset_color}%}$ZSH_THEME_GIT_PROMPT_SUFFIX"
+	  echo "$STATUS"
+	fi
 }
+
+# Default values for the appearance of the prompt. Configure at will.
+ZSH_THEME_GIT_PROMPT_PREFIX="("
+ZSH_THEME_GIT_PROMPT_SUFFIX=")"
+ZSH_THEME_GIT_PROMPT_SEPARATOR="|"
+ZSH_THEME_GIT_PROMPT_BRANCH="%{$fg_bold[magenta]%}"
+ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[red]%}%{●%G%}"
+ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
+ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
+ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%G%}"
+ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%G%}"
+ZSH_THEME_GIT_PROMPT_UNTRACKED="%{…%G%}"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}%{✔%G%}"
 
 # Set the prompt.
-#PROMPT='%B%m%~%b$(prompt_git_info) %# '
-# for a right prompt:
-#RPROMPT='%b$(prompt_git_info)'
-RPROMPT='$(prompt_git_info)'
+RPROMPT='$(git_super_status)'

--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -1,24 +1,13 @@
 # ZSH Git Prompt Plugin from:
 # http://github.com/olivierverdier/zsh-git-prompt
 
-export __GIT_PROMPT_DIR=${0:A:h}
+__GIT_PROMPT_DIR="${0:A:h}"
 
-export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_USE_PYTHON:-"python"}
+## Hook function definitions
+function chpwd_update_git_vars() {
+    update_current_git_vars
+}
 
-# Initialize colors.
-autoload -U colors
-colors
-
-# Allow for functions in the prompt.
-setopt PROMPT_SUBST
-
-autoload -U add-zsh-hook
-
-add-zsh-hook chpwd chpwd_update_git_vars
-add-zsh-hook preexec preexec_update_git_vars
-add-zsh-hook precmd precmd_update_git_vars
-
-## Function definitions
 function preexec_update_git_vars() {
     case "$2" in
         git*|hub*|gh*|stg*)
@@ -34,64 +23,59 @@ function precmd_update_git_vars() {
     fi
 }
 
-function chpwd_update_git_vars() {
-    update_current_git_vars
-}
+chpwd_functions+=(chpwd_update_git_vars)
+precmd_functions+=(precmd_update_git_vars)
+preexec_functions+=(preexec_update_git_vars)
 
+
+## Function definitions
 function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
 
-    if [[ "$GIT_PROMPT_EXECUTABLE" == "python" ]]; then
-        local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
-        _GIT_STATUS=`python ${gitstatus} 2>/dev/null`
-    fi
-    if [[ "$GIT_PROMPT_EXECUTABLE" == "haskell" ]]; then
-        local gitstatus="$__GIT_PROMPT_DIR/dist/build/gitstatus/gitstatus"
-        _GIT_STATUS=`${gitstatus}`
-    fi
+    local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
+    _GIT_STATUS=$(python ${gitstatus} 2>/dev/null)
      __CURRENT_GIT_STATUS=("${(@s: :)_GIT_STATUS}")
-	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
-	GIT_AHEAD=$__CURRENT_GIT_STATUS[2]
-	GIT_BEHIND=$__CURRENT_GIT_STATUS[3]
-	GIT_STAGED=$__CURRENT_GIT_STATUS[4]
-	GIT_CONFLICTS=$__CURRENT_GIT_STATUS[5]
-	GIT_CHANGED=$__CURRENT_GIT_STATUS[6]
-	GIT_UNTRACKED=$__CURRENT_GIT_STATUS[7]
+    GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
+    GIT_AHEAD=$__CURRENT_GIT_STATUS[2]
+    GIT_BEHIND=$__CURRENT_GIT_STATUS[3]
+    GIT_STAGED=$__CURRENT_GIT_STATUS[4]
+    GIT_CONFLICTS=$__CURRENT_GIT_STATUS[5]
+    GIT_CHANGED=$__CURRENT_GIT_STATUS[6]
+    GIT_UNTRACKED=$__CURRENT_GIT_STATUS[7]
 }
-
 
 git_super_status() {
-	precmd_update_git_vars
+    precmd_update_git_vars
     if [ -n "$__CURRENT_GIT_STATUS" ]; then
-	  STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
-	  if [ "$GIT_BEHIND" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_BEHIND$GIT_BEHIND%{${reset_color}%}"
-	  fi
-	  if [ "$GIT_AHEAD" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_AHEAD$GIT_AHEAD%{${reset_color}%}"
-	  fi
-	  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_SEPARATOR"
-	  if [ "$GIT_STAGED" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_STAGED$GIT_STAGED%{${reset_color}%}"
-	  fi
-	  if [ "$GIT_CONFLICTS" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CONFLICTS$GIT_CONFLICTS%{${reset_color}%}"
-	  fi
-	  if [ "$GIT_CHANGED" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CHANGED$GIT_CHANGED%{${reset_color}%}"
-	  fi
-	  if [ "$GIT_UNTRACKED" -ne "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED%{${reset_color}%}"
-	  fi
-	  if [ "$GIT_CHANGED" -eq "0" ] && [ "$GIT_CONFLICTS" -eq "0" ] && [ "$GIT_STAGED" -eq "0" ] && [ "$GIT_UNTRACKED" -eq "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
-	  fi
-	  STATUS="$STATUS%{${reset_color}%}$ZSH_THEME_GIT_PROMPT_SUFFIX"
-	  echo "$STATUS"
-	fi
+      STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
+      if [ "$GIT_BEHIND" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_BEHIND$GIT_BEHIND%{${reset_color}%}"
+      fi
+      if [ "$GIT_AHEAD" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_AHEAD$GIT_AHEAD%{${reset_color}%}"
+      fi
+      STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_SEPARATOR"
+      if [ "$GIT_STAGED" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_STAGED$GIT_STAGED%{${reset_color}%}"
+      fi
+      if [ "$GIT_CONFLICTS" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CONFLICTS$GIT_CONFLICTS%{${reset_color}%}"
+      fi
+      if [ "$GIT_CHANGED" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CHANGED$GIT_CHANGED%{${reset_color}%}"
+      fi
+      if [ "$GIT_UNTRACKED" -ne "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED%{${reset_color}%}"
+      fi
+      if [ "$GIT_CHANGED" -eq "0" ] && [ "$GIT_CONFLICTS" -eq "0" ] && [ "$GIT_STAGED" -eq "0" ] && [ "$GIT_UNTRACKED" -eq "0" ]; then
+          STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
+      fi
+      STATUS="$STATUS%{${reset_color}%}$ZSH_THEME_GIT_PROMPT_SUFFIX"
+      echo "$STATUS"
+    fi
 }
 
-# Default values for the appearance of the prompt. Configure at will.
+# Default values for the appearance of the prompt.
 ZSH_THEME_GIT_PROMPT_PREFIX="("
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"
 ZSH_THEME_GIT_PROMPT_SEPARATOR="|"

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -1,82 +1,65 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+from __future__ import print_function
+
+# change this symbol to whatever you prefer
+prehash = ':'
+
 from subprocess import Popen, PIPE
-import re
 
-# change those symbols to whatever you prefer
-symbols = {
-    'ahead of': '↑',
-    'behind': '↓',
-    'staged': '♦',
-    'changed': '‣',
-    'untracked': '…',
-    'clean': '⚡',
-    'unmerged': '≠',
-    'sha1': ':'
-}
+import sys
+gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
+branch, error = gitsym.communicate()
 
-output, error = Popen(
-    ['git', 'status'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
+error_string = error.decode('utf-8')
 
-if error:
-    import sys
-    sys.exit(0)
-lines = output.splitlines()
+if 'fatal: Not a git repository' in error_string:
+	sys.exit(0)
 
-behead_re = re.compile(
-    r"^# Your branch is (ahead of|behind) '(.*)' by (\d+) commit")
-diverge_re = re.compile(r"^# and have (\d+) and (\d+) different")
+branch = branch.decode("utf-8").strip()[11:]
 
-status = ''
-staged = re.compile(r'^# Changes to be committed:$', re.MULTILINE)
-changed = re.compile(r'^# Changed but not updated:$', re.MULTILINE)
-untracked = re.compile(r'^# Untracked files:$', re.MULTILINE)
-unmerged = re.compile(r'^# Unmerged paths:$', re.MULTILINE)
+res, err = Popen(['git','diff','--name-status'], stdout=PIPE, stderr=PIPE).communicate()
+err_string = err.decode('utf-8')
+if 'fatal' in err_string:
+	sys.exit(0)
+changed_files = [namestat[0] for namestat in res.decode("utf-8").splitlines()]
+staged_files = [namestat[0] for namestat in Popen(['git','diff', '--staged','--name-status'], stdout=PIPE).communicate()[0].splitlines()]
+nb_changed = len(changed_files) - changed_files.count('U')
+nb_U = staged_files.count('U')
+nb_staged = len(staged_files) - nb_U
+staged = str(nb_staged)
+conflicts = str(nb_U)
+changed = str(nb_changed)
+nb_untracked = len([0 for status in Popen(['git','status','--porcelain',],stdout=PIPE).communicate()[0].decode("utf-8").splitlines() if status.startswith('??')])
+untracked = str(nb_untracked)
 
+ahead, behind = 0,0
 
-def execute(*command):
-    out, err = Popen(stdout=PIPE, stderr=PIPE, *command).communicate()
-    if not err:
-        nb = len(out.splitlines())
-    else:
-        nb = '?'
-    return nb
-
-if staged.search(output):
-    nb = execute(
-        ['git', 'diff', '--staged', '--name-only', '--diff-filter=ACDMRT'])
-    status += '%s%s' % (symbols['staged'], nb)
-if unmerged.search(output):
-    nb = execute(['git', 'diff', '--staged', '--name-only', '--diff-filter=U'])
-    status += '%s%s' % (symbols['unmerged'], nb)
-if changed.search(output):
-    nb = execute(['git', 'diff', '--name-only', '--diff-filter=ACDMRT'])
-    status += '%s%s' % (symbols['changed'], nb)
-if untracked.search(output):
-    status += symbols['untracked']
-if status == '':
-    status = symbols['clean']
-
-remote = ''
-
-bline = lines[0]
-if bline.find('Not currently on any branch') != -1:
-    branch = symbols['sha1'] + Popen([
-        'git',
-        'rev-parse',
-        '--short',
-        'HEAD'], stdout=PIPE).communicate()[0][:-1]
+if not branch: # not on any branch
+	branch = prehash + Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode("utf-8")[:-1]
 else:
-    branch = bline.split(' ')[-1]
-    bstatusline = lines[1]
-    match = behead_re.match(bstatusline)
-    if match:
-        remote = symbols[match.groups()[0]]
-        remote += match.groups()[2]
-    elif lines[2:]:
-        div_match = diverge_re.match(lines[2])
-        if div_match:
-            remote = "{behind}{1}{ahead of}{0}".format(
-                *div_match.groups(), **symbols)
+	remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
+	if remote_name:
+		merge_name = Popen(['git','config','branch.%s.merge' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
+		if remote_name == '.': # local
+			remote_ref = merge_name
+		else:
+			remote_ref = 'refs/remotes/%s/%s' % (remote_name, merge_name[11:])
+		revgit = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
+		revlist = revgit.communicate()[0]
+		if revgit.poll(): # fallback to local
+			revlist = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
+		behead = revlist.decode("utf-8").splitlines()
+		ahead = len([x for x in behead if x[0]=='>'])
+		behind = len(behead) - ahead
 
-print('\n'.join([branch, remote, status]))
+out = ' '.join([
+	branch,
+	str(ahead),
+	str(behind),
+	staged,
+	conflicts,
+	changed,
+	untracked,
+	])
+print(out, end='')
+

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 # change this symbol to whatever you prefer
 prehash = ':'
 
+import subprocess
 from subprocess import Popen, PIPE
 
 import sys
@@ -13,53 +14,56 @@ branch, error = gitsym.communicate()
 error_string = error.decode('utf-8')
 
 if 'fatal: Not a git repository' in error_string:
-	sys.exit(0)
+    sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]
 
-res, err = Popen(['git','diff','--name-status'], stdout=PIPE, stderr=PIPE).communicate()
-err_string = err.decode('utf-8')
-if 'fatal' in err_string:
-	sys.exit(0)
-changed_files = [namestat[0] for namestat in res.decode("utf-8").splitlines()]
-staged_files = [namestat[0] for namestat in Popen(['git','diff', '--staged','--name-status'], stdout=PIPE).communicate()[0].splitlines()]
-nb_changed = len(changed_files) - changed_files.count('U')
-nb_U = staged_files.count('U')
-nb_staged = len(staged_files) - nb_U
-staged = str(nb_staged)
-conflicts = str(nb_U)
-changed = str(nb_changed)
-nb_untracked = len([0 for status in Popen(['git','status','--porcelain',],stdout=PIPE).communicate()[0].decode("utf-8").splitlines() if status.startswith('??')])
-untracked = str(nb_untracked)
+# Get git status (staged, change, conflicts and untracked)
+try:
+    res = subprocess.check_output(['git', 'status', '--porcelain'])
+except subprocess.CalledProcessError:
+    sys.exit(0)
+status = [(st[0], st[1], st[2:]) for st in res.splitlines()]
+untracked, staged, changed, conflicts = [], [], [], []
+for st in status:
+    if st[0] == '?' and st[1] == '?':
+        untracked.append(st)
+    else:
+        if st[1] == 'M':
+            changed.append(st)
+        if st[0] == 'U':
+            conflicts.append(st)
+        elif st[0] != ' ':
+            staged.append(st)
 
 ahead, behind = 0,0
 
 if not branch: # not on any branch
-	branch = prehash + Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode("utf-8")[:-1]
+    branch = prehash + Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode("utf-8")[:-1]
 else:
-	remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
-	if remote_name:
-		merge_name = Popen(['git','config','branch.%s.merge' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
-		if remote_name == '.': # local
-			remote_ref = merge_name
-		else:
-			remote_ref = 'refs/remotes/%s/%s' % (remote_name, merge_name[11:])
-		revgit = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
-		revlist = revgit.communicate()[0]
-		if revgit.poll(): # fallback to local
-			revlist = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
-		behead = revlist.decode("utf-8").splitlines()
-		ahead = len([x for x in behead if x[0]=='>'])
-		behind = len(behead) - ahead
+    remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
+    if remote_name:
+        merge_name = Popen(['git','config','branch.%s.merge' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
+        if remote_name == '.': # local
+            remote_ref = merge_name
+        else:
+            remote_ref = 'refs/remotes/%s/%s' % (remote_name, merge_name[11:])
+        revgit = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
+        revlist = revgit.communicate()[0]
+        if revgit.poll(): # fallback to local
+            revlist = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
+        behead = revlist.decode("utf-8").splitlines()
+        ahead = len([x for x in behead if x[0]=='>'])
+        behind = len(behead) - ahead
 
 out = ' '.join([
-	branch,
-	str(ahead),
-	str(behind),
-	staged,
-	conflicts,
-	changed,
-	untracked,
-	])
+    branch,
+    str(ahead),
+    str(behind),
+    str(len(staged)),
+    str(len(conflicts)),
+    str(len(changed)),
+    str(len(untracked)),
+])
 print(out, end='')
 

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -5,25 +5,40 @@ from __future__ import print_function
 prehash = ':'
 
 import sys
-import subprocess
 from subprocess import Popen, PIPE
 
-branch, error = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE).communicate()
 
-if 'fatal: Not a git repository' in error.decode('utf-8'):
-    sys.exit(0)
+# `git status --porcelain -b` can collect all information
+# branch, remote_branch, untracked, staged, changed, conflicts, ahead, behind
+po = Popen(['git', 'status', '--porcelain', '-b'], stdout=PIPE, stderr=PIPE)
+stdout, sterr = po.communicate()
+if po.returncode != 0:
+    sys.exit(0)  # Not a git repository
 
-branch = branch.decode("utf-8").strip()[11:]
-
-# Get git status (staged, change, conflicts and untracked)
-try:
-    res = subprocess.check_output(['git', 'status', '--porcelain'])
-except subprocess.CalledProcessError:
-    sys.exit(0)
-status = [(st[0], st[1], st[2:]) for st in res.splitlines()]
+# collect git status information
 untracked, staged, changed, conflicts = [], [], [], []
+ahead, behind = 0, 0
+status = [(line[0], line[1], line[2:]) for line in stdout.splitlines()]
 for st in status:
-    if st[0] == '?' and st[1] == '?':
+    if st[0] == '#' and st[1] == '#':
+        if len(st[2].strip().split('...')) == 1:
+            branch = st[2].strip()
+        else:
+            # current and remote branch info
+            branch, rest = st[2].strip().split('...')
+            if len(rest.split(' ')) == 1:
+                # remote_branch = rest.split(' ')[0]
+                pass
+            else:
+                # ahead or behind
+                divergence = ' '.join(rest.split(' ')[1:])
+                divergence = divergence.lstrip('[').rstrip(']')
+                for div in divergence.split(', '):
+                    if 'ahead' in div:
+                        ahead = int(div[len('ahead '):].strip())
+                    elif 'behind' in div:
+                        behind = int(div[len('behind '):].strip())
+    elif st[0] == '?' and st[1] == '?':
         untracked.append(st)
     else:
         if st[1] == 'M':
@@ -32,26 +47,6 @@ for st in status:
             conflicts.append(st)
         elif st[0] != ' ':
             staged.append(st)
-
-ahead, behind = 0,0
-
-if not branch: # not on any branch
-    branch = prehash + Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode("utf-8")[:-1]
-else:
-    remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
-    if remote_name:
-        merge_name = Popen(['git','config','branch.%s.merge' % branch], stdout=PIPE).communicate()[0].decode("utf-8").strip()
-        if remote_name == '.': # local
-            remote_ref = merge_name
-        else:
-            remote_ref = 'refs/remotes/%s/%s' % (remote_name, merge_name[11:])
-        revgit = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
-        revlist = revgit.communicate()[0]
-        if revgit.poll(): # fallback to local
-            revlist = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
-        behead = revlist.decode("utf-8").splitlines()
-        ahead = len([x for x in behead if x[0]=='>'])
-        behind = len(behead) - ahead
 
 out = ' '.join([
     branch,

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -4,16 +4,13 @@ from __future__ import print_function
 # change this symbol to whatever you prefer
 prehash = ':'
 
+import sys
 import subprocess
 from subprocess import Popen, PIPE
 
-import sys
-gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
-branch, error = gitsym.communicate()
+branch, error = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE).communicate()
 
-error_string = error.decode('utf-8')
-
-if 'fatal: Not a git repository' in error_string:
+if 'fatal: Not a git repository' in error.decode('utf-8'):
     sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 prehash = ':'
 
 import sys
+import re
+import subprocess
 from subprocess import Popen, PIPE
 
 
@@ -21,8 +23,13 @@ ahead, behind = 0, 0
 status = [(line[0], line[1], line[2:]) for line in stdout.decode('utf-8').splitlines()]
 for st in status:
     if st[0] == '#' and st[1] == '#':
-        if len(st[2].strip().split('...')) == 1:
+        if re.search('Initial commit on', st[2]):
+            branch = st[2].split(' ')[-1]
+        elif len(st[2].strip().split('...')) == 1:
             branch = st[2].strip()
+            if branch == 'HEAD (no branch)':
+                cmd = ['git', 'log', '-1', '--format="%h"']
+                branch = subprocess.check_output(cmd).strip().strip('"')
         else:
             # current and remote branch info
             branch, rest = st[2].strip().split('...')

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-# change this symbol to whatever you prefer
-prehash = ':'
-
 import sys
 import re
-import subprocess
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_output
 
 
-# `git status --porcelain -b` can collect all information
+# `git status --porcelain --branch` can collect all information
 # branch, remote_branch, untracked, staged, changed, conflicts, ahead, behind
-po = Popen(['git', 'status', '--porcelain', '-b'], stdout=PIPE, stderr=PIPE)
+po = Popen(['git', 'status', '--porcelain', '--branch'], stdout=PIPE, stderr=PIPE)
 stdout, sterr = po.communicate()
 if po.returncode != 0:
     sys.exit(0)  # Not a git repository
@@ -25,11 +21,10 @@ for st in status:
     if st[0] == '#' and st[1] == '#':
         if re.search('Initial commit on', st[2]):
             branch = st[2].split(' ')[-1]
+        elif re.search('no branch', st[2]):
+            branch = check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').strip()
         elif len(st[2].strip().split('...')) == 1:
             branch = st[2].strip()
-            if branch == 'HEAD (no branch)':
-                cmd = ['git', 'log', '-1', '--format="%h"']
-                branch = subprocess.check_output(cmd).strip().strip('"')
         else:
             # current and remote branch info
             branch, rest = st[2].strip().split('...')

--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -18,7 +18,7 @@ if po.returncode != 0:
 # collect git status information
 untracked, staged, changed, conflicts = [], [], [], []
 ahead, behind = 0, 0
-status = [(line[0], line[1], line[2:]) for line in stdout.splitlines()]
+status = [(line[0], line[1], line[2:]) for line in stdout.decode('utf-8').splitlines()]
 for st in status:
     if st[0] == '#' and st[1] == '#':
         if len(st[2].strip().split('...')) == 1:
@@ -58,4 +58,3 @@ out = ' '.join([
     str(len(untracked)),
 ])
 print(out, end='')
-


### PR DESCRIPTION
This PR pulls in the latest version from olivierverdier/zsh-git-prompt and adds the following modifications:

- Single call\* to `git status --porcelain -b`, thanks to @wkentaro (https://github.com/olivierverdier/zsh-git-prompt/pull/65, https://github.com/mcornella/oh-my-zsh/pull/2)
  This avoids using up to 4 calls to git, while also fixing the problem with locales other than English (fixes #3460):
  ```
$ export LC_ALL=fr_FR.UTF-8
$ git status
Sur la branche dev
Votre branche est en avance sur 'origin/dev' de 5 commits.
  (utilisez "git push" pour publier vos commits locaux)
Fichiers non suivis:
  (utilisez "git add <fichier>..." pour inclure dans ce qui sera validé)

	asdf

aucune modification ajoutée à la validation mais des fichiers non suivis sont présents (utilisez "git add" pour les suivre)
$ git status --porcelain
?? asdf
```

- Uses `*_functions+=()` syntax instead of `add-zsh-hook`.

- Removes unnecessary stuff from the zsh file which is only needed on the upstream project.

- Cleans up the syntax in gitstatus.py. 

_\* If HEAD is in detached mode, a second call to `git rev-parse` is made to get the short SHA1._

Closes #3222.