### PR TITLE
Also accept any forms of yes as an answer to the "do you want to update?" prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -43,7 +43,7 @@ then
     else
       echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
       read line
-      if [ "$line" = Y ] || [ "$line" = y ] || [ -z "$line" ]; then
+      if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
         _upgrade_zsh
       else
         _update_zsh_update


### PR DESCRIPTION
When getting asked whether you want to update your zsh and you type in "yes" oh-my-zsh doesn't accepts this as an valid answer.
```
[Oh My Zsh] Would you like to check for updates?
Type Y to update oh-my-zsh: yes
```
This kind of sucks from a user experience point of view because the software was not doing what I expected it to do.

This patch allows oh-my-zsh to accept any forms of `Yes`, `Y`, `y`, `yes` as a valid answer.