### PR TITLE
Adds npmE alias

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -12,3 +12,6 @@ alias npmS="npm i -S "
 # Install and save to dev-dependencies in your package.json
 # npmd is used by https://github.com/dominictarr/npmd
 alias npmD="npm i -D "
+# Execute command from node_modules folder based on current directory
+# i.e npmE gulp
+alias npmE="'PATH=$(npm bin):$PATH'"

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -14,4 +14,4 @@ alias npmS="npm i -S "
 alias npmD="npm i -D "
 # Execute command from node_modules folder based on current directory
 # i.e npmE gulp
-alias npmE="'PATH=$(npm bin):$PATH'"
+alias npmE="PATH=$(npm bin):$PATH"

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -14,4 +14,4 @@ alias npmS="npm i -S "
 alias npmD="npm i -D "
 # Execute command from node_modules folder based on current directory
 # i.e npmE gulp
-alias npmE="PATH=$(npm bin):$PATH"
+alias npmE='PATH="$(npm bin)":"$PATH"'


### PR DESCRIPTION
Option to execute a command from closest ancestor node_modules folder

Example
```zsh
$ls
node_modules
other_folder
$npmE gulp
No gulpfile found
$cd other_folder
$npmE gulp
No gulpfile found
```

