### PR TITLE
Fix chpwd clobbering in dirhistory and last-working-dir

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -49,7 +49,9 @@ function push_future() {
 }
 
 # Called by zsh when directory changes
-function chpwd() {
+typeset -ga chpwd_functions
+chpwd_functions+='chpwd_dirhistory'
+function chpwd_dirhistory() {
   push_past $PWD
   # If DIRHISTORY_CD is not set...
   if [[ -z "${DIRHISTORY_CD+x}" ]]; then

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -49,8 +49,7 @@ function push_future() {
 }
 
 # Called by zsh when directory changes
-typeset -ga chpwd_functions
-chpwd_functions+='chpwd_dirhistory'
+chpwd_functions+=(chpwd_dirhistory)
 function chpwd_dirhistory() {
   push_past $PWD
   # If DIRHISTORY_CD is not set...

--- a/plugins/dirpersist/dirpersist.plugin.zsh
+++ b/plugins/dirpersist/dirpersist.plugin.zsh
@@ -11,8 +11,7 @@ if [[ -f ${dirstack_file} ]] && [[ ${#dirstack[*]} -eq 0 ]] ; then
   [[ -d $dirstack[1] ]] && cd $dirstack[1] && cd $OLDPWD
 fi
 
-typeset -ga chpwd_functions
-chpwd_functions+='chpwd_dirpersist'
+chpwd_functions+=(chpwd_dirpersist)
 chpwd_dirpersist() {
   if (( $DIRSTACKSIZE <= 0 )) || [[ -z $dirstack_file ]]; then return; fi
   local -ax my_stack

--- a/plugins/dirpersist/dirpersist.plugin.zsh
+++ b/plugins/dirpersist/dirpersist.plugin.zsh
@@ -11,7 +11,9 @@ if [[ -f ${dirstack_file} ]] && [[ ${#dirstack[*]} -eq 0 ]] ; then
   [[ -d $dirstack[1] ]] && cd $dirstack[1] && cd $OLDPWD
 fi
 
-chpwd() {
+typeset -ga chpwd_functions
+chpwd_functions+='chpwd_dirpersist'
+chpwd_dirpersist() {
   if (( $DIRSTACKSIZE <= 0 )) || [[ -z $dirstack_file ]]; then return; fi
   local -ax my_stack
   my_stack=( ${PWD} ${dirstack} )

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -8,7 +8,9 @@ mkdir -p $ZSH_CACHE_DIR
 cache_file="$ZSH_CACHE_DIR/last-working-dir"
 
 # Updates the last directory once directory is changed.
-function chpwd() {
+typeset -ga chpwd_functions
+chpwd_functions+='chpwd_last_working_dir'
+function chpwd_last_working_dir() {
   # Use >| in case noclobber is set to avoid "file exists" error
 	pwd >| "$cache_file"
 }

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -8,8 +8,7 @@ mkdir -p $ZSH_CACHE_DIR
 cache_file="$ZSH_CACHE_DIR/last-working-dir"
 
 # Updates the last directory once directory is changed.
-typeset -ga chpwd_functions
-chpwd_functions+='chpwd_last_working_dir'
+chpwd_functions+=(chpwd_last_working_dir)
 function chpwd_last_working_dir() {
   # Use >| in case noclobber is set to avoid "file exists" error
 	pwd >| "$cache_file"


### PR DESCRIPTION
dirhistory and last-working-dir clobber each other's chpwd functions when used together. This PR changes them both to append to chpwd_functions instead of clobbering chpwd