### PR TITLE
Implement and use a standard, cross-platform open command

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -15,6 +15,22 @@ function take() {
   cd $1
 }
 
+function open_command() {
+  local open_cmd
+
+  # define the open command
+  case "$OSTYPE" in
+    darwin*)  open_cmd="open" ;;
+    cygwin*)  open_cmd="cygstart" ;;
+    linux*)   open_cmd="xdg-open" ;;
+    *)        echo "Platform $OSTYPE not supported"
+              return 1
+              ;;
+  esac
+
+  nohup $open_cmd "$@" &>/dev/null
+}
+
 #
 # Get the value of an alias.
 #

--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -5,7 +5,7 @@ if [ $commands[fasd] ]; then # check if fasd is installed
   fi
   source "$fasd_cache"
   unset fasd_cache
-  alias v='f -e vim'
-  alias o='a -e open'
-fi
 
+  alias v='f -e vim'
+  alias o='a -e open_command'
+fi

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -2,14 +2,6 @@
 
 function frontend() {
 
-  # get the open command
-  local open_cmd
-  if [[ $(uname -s) == 'Darwin' ]]; then
-    open_cmd='open'
-  else
-    open_cmd='xdg-open'
-  fi
-
   # no keyword provided, simply show how call methods
   if [[ $# -le 1 ]]; then
     echo "Please provide a search-content and a search-term for app.\nEx:\nfrontend <search-content> <search-term>\n"
@@ -113,7 +105,7 @@ function frontend() {
 
   echo "$url"
 
-  $open_cmd "$url"
+  open_command "$url"
 
 }
 

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -11,13 +11,6 @@
 # Usage: jira           # opens a new issue
 #        jira ABC-123   # Opens an existing issue
 open_jira_issue () {
-  local open_cmd
-  if [[ "$OSTYPE" = darwin* ]]; then
-    open_cmd='open'
-  else
-    open_cmd='xdg-open'
-  fi
-
   if [ -f .jira-url ]; then
     jira_url=$(cat .jira-url)
   elif [ -f ~/.jira-url ]; then
@@ -39,7 +32,7 @@ open_jira_issue () {
 
   if [ -z "$1" ]; then
     echo "Opening new issue"
-    $open_cmd "${jira_url}/secure/CreateIssue!default.jspa"
+    open_command "${jira_url}/secure/CreateIssue!default.jspa"
   elif [[ "$1" = "assigned" || "$1" = "reported" ]]; then
     jira_query $@
   else 
@@ -52,9 +45,9 @@ open_jira_issue () {
     fi
     
     if [[ "x$JIRA_RAPID_BOARD" = "xtrue" ]]; then
-      $open_cmd  "$jira_url/issues/$jira_prefix$1$addcomment"
+      open_command  "$jira_url/issues/$jira_prefix$1$addcomment"
     else
-      $open_cmd  "$jira_url/browse/$jira_prefix$1$addcomment"
+      open_command  "$jira_url/browse/$jira_prefix$1$addcomment"
     fi
   fi
 }
@@ -90,7 +83,7 @@ jira_query () {
         return 1
     fi
     echo "Browsing issues ${verb} ${preposition} ${jira_name}"
-    $open_cmd "${jira_url}/secure/IssueNavigator.jspa?reset=true&jqlQuery=${lookup}+%3D+%22${jira_name}%22+AND+resolution+%3D+unresolved+ORDER+BY+priority+DESC%2C+created+ASC"
+    open_command "${jira_url}/secure/IssueNavigator.jspa?reset=true&jqlQuery=${lookup}+%3D+%22${jira_name}%22+AND+resolution+%3D+unresolved+ORDER+BY+priority+DESC%2C+created+ASC"
 }
 
 alias jira='open_jira_issue'

--- a/plugins/lighthouse/lighthouse.plugin.zsh
+++ b/plugins/lighthouse/lighthouse.plugin.zsh
@@ -9,7 +9,7 @@ open_lighthouse_ticket () {
   else
     lighthouse_url=$(cat .lighthouse-url);
     echo "Opening ticket #$1";
-    `open $lighthouse_url/tickets/$1`;
+    open_command "$lighthouse_url/tickets/$1";
   fi
 }
 

--- a/plugins/node/node.plugin.zsh
+++ b/plugins/node/node.plugin.zsh
@@ -1,13 +1,5 @@
 # Open the node api for your current version to the optional section.
 # TODO: Make the section part easier to use.
 function node-docs {
-  # get the open command
-  local open_cmd
-  if [[ "$OSTYPE" = darwin* ]]; then
-    open_cmd='open'
-  else
-    open_cmd='xdg-open'
-  fi
-
-  $open_cmd "http://nodejs.org/docs/$(node --version)/api/all.html#all_$1"
+  open_command "http://nodejs.org/docs/$(node --version)/api/all.html#all_$1"
 }

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -14,16 +14,6 @@ function web_search() {
     github      "https://github.com/search?q="
   )
 
-  # define the open command
-  case "$OSTYPE" in
-    darwin*)  open_cmd="open" ;;
-    cygwin*)  open_cmd="cygstart" ;;
-    linux*)   open_cmd="xdg-open" ;;
-    *)        echo "Platform $OSTYPE not supported"
-              return 1
-              ;;
-  esac
-
   # check whether the search engine is supported
   if [[ -z "$urls[$1]" ]]; then
     echo "Search engine $1 not supported."
@@ -41,7 +31,7 @@ function web_search() {
     url="${(j://:)${(s:/:)urls[$1]}[1,2]}"
   fi
 
-  nohup $open_cmd "$url" &>/dev/null
+  open_command "$url"
 }
 
 


### PR DESCRIPTION
This PR implements an oh-my-zsh standard open function that is cross-platform and easy to use for all plugins and users as well to create their aliases.

The function is called `open_command` and it uses the `$OSTYPE` value to decide which command to run. 

This PR also changes those plugins that used old logic so that we have consistent, non-duplicate code throughout the project codebase. Plugins changed: `fasd`, `frontend-search`, `jira`, `lighthouse`, `node` and `web-search`.

These other plugins also have open commands but are OSX specific, so there's no need to use a cross-platform open command: `atom`, `bwana`, `marked2`, `osx`, `textmate` and `xcode`.

Fixes #1478.
Fixes #2988.
Fixes #3920.