### PR TITLE
Add support for Docker images from custom registries

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -27,7 +27,7 @@ __docker_all_containers() {
 # output a selectable list of all docker images
 __docker_images() {
     declare -a img_cmd
-    img_cmd=($(docker images | awk 'NR>1{print $1}'))
+    img_cmd=($(docker images | awk 'NR>1{print $1}'| sed 's/:/\\:/g'))
     _describe 'images' img_cmd
 }
 


### PR DESCRIPTION
By default docker images use the official docker hub, however by prefixing the image name with a URL it is possible to push and pull images from a different registry. This URL can also contain a non standard port number e.g. `web.address:port/namespace/repo`. 

When the current docker plugin encounters such an image the _describe function it splits the images into name = `web.address` description = `port/namespace/repo`. To fix this the command that fetches the image list needs to escape the `:` with a backslash.