### PR TITLE
Revert commit a28dbc8 ("Move custon *.zsh file sourcing up ...")

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -29,11 +29,6 @@ for config_file ($ZSH/lib/*.zsh); do
   source $config_file
 done
 
-# Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)); do
-  source $config_file
-done
-unset config_file
 
 is_plugin() {
   local base_dir=$1
@@ -76,6 +71,12 @@ for plugin ($plugins); do
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
+
+# Load all of your custom configurations from custom/
+for config_file ($ZSH_CUSTOM/*.zsh(N)); do
+  source $config_file
+done
+unset config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]; then


### PR DESCRIPTION
PR #3617 moved the loading of custom scripts up, just before loading core lib files. This broke backwards compatibility, so we should revert it before we come up with a long-term solution.

Fixes #4072.
Related #3282, #3617.

This reverts commit a28dbc83937cbe624ec726199b4bbe7b65b2b2a0.

/cc @robbyrussell 