### PR TITLE
termsupport: avoid repeated dir in window title in Terminal.app

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -23,6 +23,10 @@ function title {
 
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
+# Avoid duplication of directory in terminals with independent dir display
+if [[ $TERM_PROGRAM == Apple_Terminal ]]; then
+  ZSH_THEME_TERM_TITLE_IDLE="%n@%m"
+fi
 
 # Runs before showing the prompt
 function omz_termsupport_precmd {


### PR DESCRIPTION
Apple's Terminal.app displays the current directory in the window title bar independently. So if the dir is included in the window title, you get a redundant copy.

This PR has termsupport detect Terminal.app and remove the current directory from the default window title format.

Fixes #4213.