### PR TITLE
Fix fbterm autostart

### DIFF
--- a/plugins/fbterm/fbterm.plugin.zsh
+++ b/plugins/fbterm/fbterm.plugin.zsh
@@ -1,6 +1,8 @@
 # start fbterm automatically in /dev/tty*
 
-if [[ $(tty|grep -o '/dev/tty') = /dev/tty ]] ; then
-	fbterm
-	exit
+if (( ${+commands[fbterm]} )); then
+	if [[ "$TTY" = /dev/tty* ]] ; then
+		fbterm
+		exit
+	fi
 fi

--- a/plugins/fbterm/fbterm.plugin.zsh
+++ b/plugins/fbterm/fbterm.plugin.zsh
@@ -2,7 +2,6 @@
 
 if (( ${+commands[fbterm]} )); then
 	if [[ "$TTY" = /dev/tty* ]] ; then
-		fbterm
-		exit
+		fbterm && exit
 	fi
 fi


### PR DESCRIPTION
This PR modifies the fbterm plugin in the following ways:

- Checks if `fbterm` is installed.
- Only exits if `fbterm` finished correctly, _i.e._ with exit code equal to 0.

~~This presupposes that `fbterm` will start without and error. There's currently no mechanism to test if fbterm will start correctly  (see [fbterm#73](https://code.google.com/p/fbterm/issues/detail?id=73)). This means that if `fbterm` fails, the shell session will be closed, due to how `exec` works.~~

~~Maybe a better solution is to get rid of the `exit` statement, which will make the `fbterm` error visible. On the other hand, if `fbterm` starts correctly, once the user logs out of it the first shell session will be open.~~

Now it will only exit if `fbterm` finishes correctly. Remains to be checked that if `fbterm` encounters an error it will have a non-zero exit code.

Related: https://github.com/robbyrussell/oh-my-zsh/pull/1598#issuecomment-125107789

cc @adben @wzhd @zasdfgbnm