### PR TITLE
Fix xcode plugin

### DIFF
--- a/plugins/xcode/README.md
+++ b/plugins/xcode/README.md
@@ -4,7 +4,7 @@
 
 This plugin provides a few utilities that can help you on your daily use of Xcode and iOS development.
 
-To start using it, add the `xcode` plugin to your `plugins` array:
+To start using it, add the `xcode` plugin to your `plugins` array in `~/.zshrc`:
 
 ```zsh
 plugins=(... xcode)
@@ -24,12 +24,61 @@ plugins=(... xcode)
 
 ## Functions
 
-- **`xc`**:
-  Open one of the `.xcworkspace` and `.xcodeproj` files that it can find in the current working directory.
-  Returns 1 if it didn't find any relevant files.
+###  `xc`
 
-- **`simulator`**:
-  Open the iOS Simulator from your command line, dependant on whichever is the active developer directory for Xcode.
+Opens the current directory in Xcode as an Xcode project. This will open one of the `.xcworkspace` and `.xcodeproj` files that it can find in the current working directory.
+Returns 1 if it didn't find any relevant files.
 
-- **`xcselv`**:
-  Select different Xcode by version. Example: `xcselv 6.2`
+###  `simulator`
+
+Opens the iOS Simulator from your command line, dependent on whichever is the active developer directory for Xcode. (That is, it respects the `xcsel` setting.)
+
+### `xcselv`
+
+Selects different Xcode installations by version name. This is like `xcsel`, except it takes just a version name as an argument instead of the full path to the Xcode installation. Uses the naming conventions described below.
+
+* `xcselv <version>` selects a version
+ * Example: `xcselv 6.2`
+* `xcselv default` selects the default unversioned `Applications/Xcode.app`
+* `xcselv` with no argument lists the available Xcode versions in a human-readable format
+* `xcselv -l` lists the installed Xcode versions
+* `xcselv -L` lists the installed Xcode versions in a short version-name-only format
+* `xcselv -p` prints info about the active Xcode version
+* `xcselv -h` prints a help message
+
+The option parsing for `xcselv` is naive. Options may not be combined, and only the first option is recognized.
+
+## Multiple Xcode Versions
+
+The `xcselv` command provides support for switching between different Xcode installations using just a version number. Different Xcode versions are identified by file naming conventions.
+
+### Versioned Xcode Naming Conventions
+
+Apple does not seem to explicitly define or provide tooling support for a naming convention or other organizational mechanism for managing versioned Xcode installations. Apple seems to have released beta versions with both `Xcode<version>.app` and `Xcode-<version>.app` style names in the past, and both styles show up in forum and blog discussions.
+
+We've adopted the following naming convention:
+
+* Versioned Xcode installations are identified by the name `Xcode-<version>` or `Xcode<version>`.
+* The `-` separating `"Xcode"` and the version name is optional, and may be replaced by a space.
+* The versioned name may be applied to the `Xcode.app` itself, or a subdirectory underneath `Applications/` containing it.
+* You cannot version both the `Xcode.app` filename itself and the containing subfolder.
+* Thus, all of the following are equivalent.
+ * `Applications/Xcode-<version>.app`
+ * `Applications/Xcode-<version>/Xcode.app`
+ * `Applications/Xcode<version>.app`
+ * `Applications/Xcode <version>.app`
+ * `Applications/Xcode <version>/Xcode.app`
+* Both the system `/Applications/` and user `$HOME/Applications/` directories are searched.
+ * The user's `$HOME/Applications/` takes precedence over `/Applications` for a given version.
+ * If multiple naming variants within the same `Applications/` folder indicate the same version (for example, `Xcode-3.2.1.app`, `Xcode3.2.1.app`, and `Xcode-3.2.1/Xcode.app`), the precedence order is unspecified and implementation-dependent.
+* The `<version>` may be any string that is valid in a filename.
+* The special version name `"default"` refers to the "default" unversioned Xcode at `Applications/Xcode.app` (in either `/Applications/` or `$HOME/Applications/`).
+* Version names may not start with ``"-"`` or whitespace.
+
+The restrictions on the naming convention may need to be tightened in the future. In particular, if there are other well-known applications whose names begin with the string `"Xcode"`, the strings allowed for `<version>` may need to be restricted to avoid colliding with other applications. If there's evidence that one of these naming techniques is strongly favored either in practice or by Apple, we may tighten the naming convention to favor it.
+
+## Caveats
+
+Using `xcsel` or `xcselv` to select an Xcode that is installed under your `$HOME` may break things for other users, depending on your system setup. We let you do this anyway because some people run OS X as effectively single-user, or have open permissions so this will work. You could also use `$DEVELOPER_DIR` as an alternative to `xcsel` that is scoped to the current user or session, instead of a global setting.
+
+This does not verify that the version name in the Xcode filename matches the actual version of that binary. It is the user's responsibility to get the names right.

--- a/plugins/xcode/README.md
+++ b/plugins/xcode/README.md
@@ -1,0 +1,31 @@
+# Xcode
+
+## Description
+
+This plugin provides a few utilities that can help you on your daily use of Xcode and iOS development.
+
+To start using it, add the `xcode` plugin to your `plugins` array:
+
+```zsh
+plugins=(... xcode)
+```
+
+
+## Aliases
+
+| Alias | Description                           | Command                                        |
+|-------|---------------------------------------|------------------------------------------------|
+| xcsel | Change active developer directory     | sudo xcode-select --switch                     |
+| xcp   | Show currently active dev. directory  | xcode-select --print-path                      |
+| xcb   | Build Xcode projects and workspaces   | xcodebuild                                     |
+| xcdd  | Purge all temporary build information | rm -rf ~/Library/Developer/Xcode/DerivedData/* |
+
+
+## Functions
+
+- **`xc`**:
+  Open one of the `.xcworkspace` and `.xcodeproj` files that it can find in the current working directory.
+  Returns 1 if it didn't find any relevant files.
+
+- **`simulator`**:
+  Open the iOS Simulator from your command line, dependant on whichever is the active developer directory for Xcode.

--- a/plugins/xcode/README.md
+++ b/plugins/xcode/README.md
@@ -13,12 +13,13 @@ plugins=(... xcode)
 
 ## Aliases
 
-| Alias | Description                           | Command                                        |
-|-------|---------------------------------------|------------------------------------------------|
-| xcsel | Change active developer directory     | sudo xcode-select --switch                     |
-| xcp   | Show currently active dev. directory  | xcode-select --print-path                      |
-| xcb   | Build Xcode projects and workspaces   | xcodebuild                                     |
-| xcdd  | Purge all temporary build information | rm -rf ~/Library/Developer/Xcode/DerivedData/* |
+| Alias | Description                              | Command                                        |
+|-------|------------------------------------------|------------------------------------------------|
+| xcb   | Build Xcode projects and workspaces      | xcodebuild                                     |
+| xcdd  | Purge all temporary build information    | rm -rf ~/Library/Developer/Xcode/DerivedData/* |
+| xcp   | Show currently selected Xcode directory  | xcode-select --print-path                      |
+| xcsel | Select different Xcode directory by path | sudo xcode-select --switch                     |
+
 
 
 ## Functions
@@ -29,3 +30,6 @@ plugins=(... xcode)
 
 - **`simulator`**:
   Open the iOS Simulator from your command line, dependant on whichever is the active developer directory for Xcode.
+
+- **`xcselv`**:
+  Select different Xcode by version. Example: `xcselv 6.2`

--- a/plugins/xcode/_xcselv
+++ b/plugins/xcode/_xcselv
@@ -1,0 +1,19 @@
+#compdef xcselv
+#autoload
+
+function _xcselv_compl_list_versions() {
+  _omz_xcode_list_versions short
+}
+
+_arguments \
+  '(-l -L -p)-h[prints a help message]' \
+  '(-L -p -h)-l[lists installed Xcode versions]' \
+  '(-l -p -h)-L[lists installed Xcode versions (long form)]' \
+  '(-h -l -L)-p[prints active Xcode version]' \
+  && ret=0
+
+local _xcode_versions
+_xcode_versions=($(_xcselv_compl_list_versions))
+_describe -t _xcode_versions 'version' _xcode_versions
+
+return 1

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -17,8 +17,15 @@ alias xcb='xcodebuild'
 alias xcp='xcode-select --print-path'
 alias xcdd='rm -rf ~/Library/Developer/Xcode/DerivedData/*'
 
-if [[ -d $(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone\ Simulator.app ]]; then
-  alias simulator='open $(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone\ Simulator.app'
-else
-  alias simulator='open $(xcode-select -p)/Applications/iOS\ Simulator.app'
-fi
+function simulator {
+  local devfolder
+  devfolder="$(xcode-select -p)"
+
+  # Xcode ≤ 5.x
+  if [[ -d "${devfolder}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app" ]]; then
+    open "${devfolder}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"
+  # Xcode ≥ 6.x
+  else
+    open "${devfolder}/Applications/iOS Simulator.app"
+  fi
+}

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -2,8 +2,10 @@
 function xc {
   local xcode_proj
   xcode_proj=(*.{xcworkspace,xcodeproj}(N))
+
   if [[ ${#xcode_proj} -eq 0 ]]; then
     echo "No xcworkspace/xcodeproj file found in the current directory."
+    return 1
   else
     echo "Found ${xcode_proj[1]}"
     open "${xcode_proj[1]}"

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -12,10 +12,7 @@ function xc {
   fi
 }
 
-function xcsel {
-  sudo xcode-select --switch "$*"
-}
-
+alias xcsel='sudo xcode-select --switch'
 alias xcb='xcodebuild'
 alias xcp='xcode-select --print-path'
 alias xcdd='rm -rf ~/Library/Developer/Xcode/DerivedData/*'

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -1,12 +1,12 @@
 #xc function courtesy of http://gist.github.com/subdigital/5420709
 function xc {
-  xcode_proj=`ls | grep "\.xc" | sort -r | head -1`
-  if [[ `echo -n $xcode_proj | wc -m` == 0 ]]
-  then
+  local xcode_proj
+  xcode_proj=(*.{xcworkspace,xcodeproj}(N))
+  if [[ ${#xcode_proj} -eq 0 ]]; then
     echo "No xcworkspace/xcodeproj file found in the current directory."
   else
-    echo "Found $xcode_proj" 
-    open "$xcode_proj" 
+    echo "Found ${xcode_proj[1]}"
+    open "${xcode_proj[1]}"
   fi
 }
 

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -22,28 +22,153 @@ function xc {
 # Uses naming convention:
 #  - different versions of Xcode are named Xcode-<version>.app or stored
 #     in a folder named Xcode-<version>
-#  - the special version name "-" refers to the "default" Xcode.app with no suffix
+#  - the special version name "default" refers to the "default" Xcode.app with no suffix
 function xcselv {
   emulate -L zsh
+  if [[ $# == 0 ]]; then
+    echo "xcselv: error: no option or argument given" >&2
+    echo "xcselv: see 'xcselv -h' for help" >&2
+    return 1
+  elif [[ $1 == "-p" ]]; then
+    _omz_xcode_print_active_version
+    return
+  elif [[ $1 == "-l" ]]; then
+    _omz_xcode_list_versions
+    return
+  elif [[ $1 == "-L" ]]; then
+    _omz_xcode_list_versions short
+    return
+  elif [[ $1 == "-h" ]]; then
+    _omz_xcode_print_xcselv_usage
+    return 0
+  elif [[ $1 == -* && $1 != "-" ]]; then
+    echo "xcselv: error: unrecognized option: $1" >&2
+    echo "xcselv: see 'xcselv -h' for help" >&2
+    return 1
+  fi
+  # Main case: "xcselv <version>" to select a version
   local version=$1
-  local apps_dirs apps_dir apps app
-  apps_dirs=( $HOME/Applications /Applications )
-  for apps_dir ($apps_dirs); do
-    if [[ $version == "-" ]]; then
-      apps=( $apps_dir/Xcode.app $apps_dir/Xcode/Xcode.app )
+  local -A xcode_versions
+  _omz_xcode_locate_versions
+  if [[ -z ${xcode_versions[$version]} ]]; then
+    echo "xcselv: error: Xcode version '$version' not found" >&2
+    return 1
+  fi
+  app="${xcode_versions[$version]}"
+  echo "selecting Xcode $version: $app"
+  xcsel "$app"
+}
+
+function _omz_xcode_print_xcselv_usage {
+  cat << EOF >&2
+Usage: 
+  xcselv <version>
+  xcselv [options]
+
+Options:
+  <version> set the active Xcode version
+  -h        print this help message and exit
+  -p        print the active Xcode version
+  -l        list installed Xcode versions (long human-readable form)
+  -L        list installed Xcode versions (short form, version names only)
+EOF
+}
+
+# Parses the Xcode version from a filename based on our conventions
+# Only meaningful when called from other _omz_xcode functions
+function _omz_xcode_parse_versioned_file {
+  local file=$1
+  local basename=${app:t}
+  local dir=${app:h}
+  local parent=${dir:t}
+  #echo "parent=$parent basename=$basename verstr=$verstr ver=$ver" >&2
+  local verstr
+  if [[ $parent == Xcode* ]]; then
+    if [[ $basename == "Xcode.app" ]]; then
+      # "Xcode-<version>/Xcode.app" format
+      verstr=$parent
     else
-      apps=( $apps_dir/Xcode-$version.app $apps_dir/Xcode-$version/Xcode.app )
+      # Both file and parent dir are versioned. Reject.
+      return 1;
     fi
+  elif [[ $basename == Xcode*.app ]]; then
+    # "Xcode-<version>.app" format
+    verstr=${basename:r}
+  else
+    # Invalid naming pattern
+    return 1;
+  fi
+
+  local ver=${verstr#Xcode}
+  ver=${ver#[- ]}
+  if [[ -z $ver ]]; then
+    # Unversioned "default" installation location
+    ver="default"
+  fi
+  print -- "$ver"
+}
+
+# Print the active version, using xcselv's notion of versions
+function _omz_xcode_print_active_version {
+  emulate -L zsh
+  local -A xcode_versions
+  local versions version active_path
+  _omz_xcode_locate_versions
+  active_path=$(xcode-select -p)
+  active_path=${active_path%%/Contents/Developer*}
+  versions=(${(kni)xcode_versions})
+  for version ($versions); do
+    if [[ "${xcode_versions[$version]}" == $active_path ]]; then
+      printf "%s (%s)\n" $version $active_path
+      return
+    fi
+  done
+  printf "%s (%s)\n" "<unknown>" $active_path
+}
+
+# Locates all the installed versions of Xcode on this system, for this
+# plugin's internal use.
+# Populates the $xcode_versions associative array variable
+# Caller should local-ize $xcode_versions with `local -A xcode_versions`
+function _omz_xcode_locate_versions {
+  emulate -L zsh
+  local -a app_dirs
+  local app_dir apps app xcode_ver
+  # In increasing precedence order:
+  app_dirs=(/Applications $HOME/Applications)
+  for app_dir ($app_dirs); do
+    apps=( $app_dir/Xcode*.app(N) $app_dir/Xcode*/Xcode.app(N) )
     for app ($apps); do
-      if [[ -e "$app" ]]; then
-        echo "selecting Xcode $version: $app"
-        xcsel "$app"
-        return
+      xcode_ver=$(_omz_xcode_parse_versioned_file $app)
+      if [[ $? != 0 ]]; then
+        continue
       fi
+      xcode_versions[$xcode_ver]=$app
     done
   done
-  echo "xcselv: Xcode version $version not found"
-  return 1
+}
+
+function _omz_xcode_list_versions {
+  emulate -L zsh
+  local -A xcode_versions
+  _omz_xcode_locate_versions
+  local width=1 width_i versions do_short=0
+  if [[ $1 == "short" ]]; then
+    do_short=1
+  fi
+  versions=(${(kni)xcode_versions})
+  for version ($versions); do
+    if [[ $#version > $width ]]; then
+      width=$#version;
+    fi
+  done
+  for version ($versions); do
+    if [[ $do_short == 1 ]]; then
+      printf "%s\n" $version
+    else
+      printf "%-${width}s -> %s\n" "$version" "${xcode_versions[$version]}"
+    fi
+  done
 }
 
 function simulator {

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -1,4 +1,10 @@
-#xc function courtesy of http://gist.github.com/subdigital/5420709
+alias xcb='xcodebuild'
+alias xcdd='rm -rf ~/Library/Developer/Xcode/DerivedData/*'
+alias xcp='xcode-select --print-path'
+alias xcsel='sudo xcode-select --switch'
+
+# original author: @subdigital
+# source: http://gist.github.com/subdigital/5420709
 function xc {
   local xcode_proj
   xcode_proj=(*.{xcworkspace,xcodeproj}(N))
@@ -11,12 +17,6 @@ function xc {
     open "${xcode_proj[1]}"
   fi
 }
-
-alias xcsel='sudo xcode-select --switch'
-alias xcb='xcodebuild'
-alias xcp='xcode-select --print-path'
-alias xcdd='rm -rf ~/Library/Developer/Xcode/DerivedData/*'
-
 
 # "XCode-SELect by Version" - select Xcode by just version number
 # Uses naming convention:

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -17,6 +17,35 @@ alias xcb='xcodebuild'
 alias xcp='xcode-select --print-path'
 alias xcdd='rm -rf ~/Library/Developer/Xcode/DerivedData/*'
 
+
+# "XCode-SELect by Version" - select Xcode by just version number
+# Uses naming convention:
+#  - different versions of Xcode are named Xcode-<version>.app or stored
+#     in a folder named Xcode-<version>
+#  - the special version name "-" refers to the "default" Xcode.app with no suffix
+function xcselv {
+  emulate -L zsh
+  local version=$1
+  local apps_dirs apps_dir apps app
+  apps_dirs=( $HOME/Applications /Applications )
+  for apps_dir ($apps_dirs); do
+    if [[ $version == "-" ]]; then
+      apps=( $apps_dir/Xcode.app $apps_dir/Xcode/Xcode.app )
+    else
+      apps=( $apps_dir/Xcode-$version.app $apps_dir/Xcode-$version/Xcode.app )
+    fi
+    for app ($apps); do
+      if [[ -e "$app" ]]; then
+        echo "selecting Xcode $version: $app"
+        xcsel "$app"
+        return
+      fi
+    done
+  done
+  echo "xcselv: Xcode version $version not found"
+  return 1
+}
+
 function simulator {
   local devfolder
   devfolder="$(xcode-select -p)"


### PR DESCRIPTION
This PR does the following:

- Fix the `xc()` function by only looking for `.xcworskpace` and `.xcodeproj` files.
  It also cleans it up by using zsh arrays and localized variables.

- Change `xcsel` function into an alias, since it doesn't do anything extraordinary and `"$*"` might have side effects.

Closes #3259, #3950.