### PR TITLE
Fix: Plugin knife: Add relative local path for commands which upload files

### DIFF
--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -230,12 +230,11 @@ _cookbook_versions() {
 # Searches up from current directory to find the closest folder that has a .chef folder 
 # Useful for the knife upload/from file commands 
 _chef_root () {
-  slashes=${PWD//[^\/]/}
   directory="$PWD"
-  for (( n=${#slashes}; n>0; --n ))
+  while [ $directory != '/' ]
   do
     test -e "$directory/.chef" && echo "$directory" && return
-    directory="$directory/.."
+    directory="${directory:h}"
   done
 }
 

--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -119,7 +119,19 @@ _knife() {
      _arguments '4:Subsubsubcommands:($(_chef_$words[2]_$words[3]s_remote))'
     ;;
      file)
-     _arguments '*:file or directory:_files -g "*.(rb|json)"'
+      case $words[2] in
+      environment)
+        _arguments '*:files:_path_files -g "*.(rb|json)" -W "$(_chef_root)/environments"'
+      ;;
+      node)
+        _arguments '*:files:_path_files -g "*.(rb|json)" -W "$(_chef_root)/nodes"'
+      ;;
+      role)
+        _arguments '*:files:_path_files -g "*.(rb|json)" -W "$(_chef_root)/roles"'
+      ;;
+      *)
+        _arguments '*:Subsubcommands:($(_knife_options3))'
+      esac 
     ;;
       list)
      compadd -a "$@" knife_general_flags
@@ -132,11 +144,22 @@ _knife() {
       if (( versioncomp > 0 )); then
         compadd "$@" attributes definitions files libraries providers recipes resources templates
       else
-       _arguments '*:Subsubcommands:($(_knife_options2))'
+      case $words[5] in 
+        file)
+          _arguments '*:directory:_path_files -/ -W "$(_chef_root)/data_bags" -qS \ '
+        ;;
+        *) _arguments '*:Subsubcommands:($(_knife_options2))'
+      esac
       fi
     ;; 
     knifesubcmd5) 
-      _arguments '*:Subsubcommands:($(_knife_options3))'
+      case $words[5] in 
+        file) 
+          _arguments '*:files:_path_files -g "*.json" -W "$(_chef_root)/data_bags/$words[6]"'
+        ;;
+        *) 
+          _arguments '*:Subsubcommands:($(_knife_options3))'
+      esac
    esac
 }
 
@@ -196,6 +219,18 @@ _chef_cookbooks_local() {
 # This function extracts the available cookbook versions on the chef server
 _cookbook_versions() {
   (knife cookbook show $words[4] | grep -v $words[4] | grep -v -E '\]|\[|\{|\}' | sed 's/ //g' | sed 's/"//g')
+}
+
+# Searches up from current directory to find the closest folder that has a .chef folder 
+# Useful for the knife upload/from file commands 
+_chef_root () {
+  slashes=${PWD//[^\/]/}
+  directory="$PWD"
+  for (( n=${#slashes}; n>0; --n ))
+  do
+    test -e "$directory/.chef" && echo "$directory" && return
+    directory="$directory/.."
+  done
 }
 
 _knife "$@"

--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -3,6 +3,9 @@
 # You can override the path to knife.rb and your cookbooks by setting
 # KNIFE_CONF_PATH=/path/to/my/.chef/knife.rb
 # KNIFE_COOKBOOK_PATH=/path/to/my/chef/cookbooks
+# If you want your local cookbooks path to be calculated relative to where you are then 
+# set the below option
+# KNIFE_RELATIVE_PATH=true 
 # Read around where these are used for more detail.
 
 # These flags should be available everywhere according to man knife
@@ -207,12 +210,15 @@ _chef_environments_remote() {
 
 # The chef_x_local functions use the knife config to find the paths of relevant objects x to be uploaded to the server
 _chef_cookbooks_local() {
-  
-  local knife_rb=${KNIFE_CONF_PATH:-${HOME}/.chef/knife.rb}
-  if [ -f ./.chef/knife.rb ]; then
-    knife_rb="./.chef/knife.rb"
+  if [ $KNIFE_RELATIVE_PATH ]; then 
+    local cookbook_path="$(_chef_root)/cookbooks"
+  else 
+    local knife_rb=${KNIFE_CONF_PATH:-${HOME}/.chef/knife.rb}
+    if [ -f ./.chef/knife.rb ]; then
+      knife_rb="./.chef/knife.rb"
+    fi
+    local cookbook_path=${KNIFE_COOKBOOK_PATH:-$(grep cookbook_path $knife_rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/' )}
   fi
-  local cookbook_path=${KNIFE_COOKBOOK_PATH:-$(grep cookbook_path $knife_rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/' )}
   (for i in $cookbook_path; do ls $i; done)
 }
 


### PR DESCRIPTION
Currently any of the `knife * from file` commands autocomplete by the knife plugin only look in the current directory for the relevant files. This fix searches upwards for a .chef folder and then looks in the folder relative to that folder (this is similar to the way knife itself functions). This should affect the following subcommands: 
- `knife node from file`
- `knife environment from file`
- `knife role from file`
- `knife data bag from file`

It also adds an option (`KNIFE_RELATIVE_PATH`) that lets `knife cookbook upload` work in the same way. This is useful when you have multiple local Chef orgs and can't set a path to a single cookbooks folder. 