### PR TITLE
reduce rbenv plugin load time by 150ms by removing additional brew call

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -2,14 +2,11 @@ _homebrew-installed() {
   type brew &> /dev/null
 }
 
-_rbenv-from-homebrew-installed() {
-  brew --prefix rbenv &> /dev/null
-}
-
 FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
-if _homebrew-installed && _rbenv-from-homebrew-installed ; then
-    rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
+if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null); then
+    rbenvdirs=($rbenv_homebrew_path "${rbenvdirs[@]}")
+    unset rbenv_homebrew_path
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
The existing rbenv plugin code calls the same `brew --prefix` twice: once for detecting if rbenv is installed via brew, and again to get the path. This inlines the call so we only need to call it once. The call is expensive -- about 150ms each time on my mac. 

```zsh
 ~/.oh-my-zsh > @ rbenv_plugin_load_performance $ repeat 10 /usr/bin/time zsh -i -c exit
        0.31 real         0.21 user         0.10 sys
        0.32 real         0.22 user         0.10 sys
        0.31 real         0.21 user         0.10 sys
        0.30 real         0.21 user         0.10 sys
        0.31 real         0.21 user         0.10 sys
        0.31 real         0.22 user         0.10 sys
        0.31 real         0.21 user         0.10 sys
        0.32 real         0.22 user         0.10 sys
        0.31 real         0.21 user         0.10 sys
        0.31 real         0.21 user         0.10 sys
 ~/.oh-my-zsh > @ rbenv_plugin_load_performance $ git co master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
 ~/.oh-my-zsh > @ master $ git rev-parse head
a207a38d634cc10441636bc4359cd8a18c502dea
 ~/.oh-my-zsh > @ master $ repeat 10 /usr/bin/time zsh -i -c exit
        0.46 real         0.33 user         0.13 sys
        0.48 real         0.35 user         0.13 sys
        0.49 real         0.36 user         0.13 sys
        0.48 real         0.35 user         0.13 sys
        0.48 real         0.35 user         0.13 sys
        0.47 real         0.34 user         0.13 sys
        0.50 real         0.36 user         0.14 sys
        0.49 real         0.35 user         0.13 sys
        0.49 real         0.36 user         0.13 sys
        0.47 real         0.33 user         0.13 sys
```

A 1/3 reduction in load time, with no side effects.

We can save yet another 150ms if let the user hard-code configure a path instead of calling `brew` at all, but at that point you may want to skip the plugin entirely.