### PR TITLE
Fix divide by zero in emoji plugin

### DIFF
--- a/plugins/emoji/emoji.plugin.zsh
+++ b/plugins/emoji/emoji.plugin.zsh
@@ -255,7 +255,7 @@ function random_emoji() {
   if [[ -z "$group" || "$group" == "all" ]]; then
   	names=(${(k)emoji})
   else
-  	names=(${=emoji_groups[$group_name]})
+	names=(${=emoji_groups[$group]})
   fi
   local list_size=$#names
   local random_index=$(( ( RANDOM % $list_size ) + 1 ))

--- a/plugins/emoji/emoji.plugin.zsh
+++ b/plugins/emoji/emoji.plugin.zsh
@@ -76,8 +76,6 @@ emoji_skintone[6]=$'\U1F3FF'
 # These are stored in a single associative array, $emoji_groups, to avoid cluttering up the global
 # namespace, and to allow adding additional group definitions at run time.
 # The keys are the group names, and the values are whitespace-separated lists of emoji character names.
-#
-# These extra local arrays are used to allow more convenient formatting of the source code.
 
 emoji_groups[fruits]="
   tomato

--- a/plugins/emoji/emoji.plugin.zsh
+++ b/plugins/emoji/emoji.plugin.zsh
@@ -257,7 +257,8 @@ function random_emoji() {
   else
 	names=(${=emoji_groups[$group]})
   fi
-  local list_size=$#names
+  local list_size=${#names}
+  [[ $list_size -eq 0 ]] && return 1
   local random_index=$(( ( RANDOM % $list_size ) + 1 ))
   local name=${names[$random_index]}
   echo ${emoji[$name]}


### PR DESCRIPTION
- Uses the right variable name (`$group` instead of `$group_name`)
- Check that the names array has any element before attempting to pick an emoji out of it. This fixes the same problem on groups that don't exist (_e.g._ `random_emoji 404notfound`).

Fixes #4245.

/cc @robbyrussell @fallwith @apjanke 