### PR TITLE
Fix completion waiting dots function

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -60,7 +60,11 @@ zstyle '*' single-ignored show
 
 if [[ $COMPLETION_WAITING_DOTS = true ]]; then
   expand-or-complete-with-dots() {
+    # toggle line-wrapping off and back on again
+    [[ -n "$terminfo[rmam]" && -n "$terminfo[smam]" ]] && echoti rmam
     print -Pn "%{%F{red}......%f%}"
+    [[ -n "$terminfo[rmam]" && -n "$terminfo[smam]" ]] && echoti smam
+
     zle expand-or-complete
     zle redisplay
   }

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -58,7 +58,7 @@ zstyle ':completion:*:*:*:users' ignored-patterns \
 # ... unless we really want to.
 zstyle '*' single-ignored show
 
-if [ "x$COMPLETION_WAITING_DOTS" = "xtrue" ]; then
+if [[ $COMPLETION_WAITING_DOTS = true ]]; then
   expand-or-complete-with-dots() {
     echo -n "\e[31m......\e[0m"
     zle expand-or-complete

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -60,7 +60,7 @@ zstyle '*' single-ignored show
 
 if [[ $COMPLETION_WAITING_DOTS = true ]]; then
   expand-or-complete-with-dots() {
-    echo -n "\e[31m......\e[0m"
+    print -Pn "%{%F{red}......%f%}"
     zle expand-or-complete
     zle redisplay
   }


### PR DESCRIPTION
### STATUS: READY

This PR solves the annoying problem of new line prompt being redrawn each when the terminal is small enough that the prompt + 5 chars being drawn don't fit the line. This is done by disabling automatic line wrapping using terminfo's `rmam` sequence.

It uses `%F{red}` as well, instead of `\e[31m` which might not be that bad for portability but it looks better and is clearer what the color is.

----

### Test

**Instructions:** you need a prompt that is sufficiently big that it occupies almost all the line space. There are 5 completion dots, so you'll need to have a prompt that is `$COLUMNS - command length - 4` minimum to trigger the new line prompt redraw. You also need to uncomment the line `COMPLETION_WAITING_DOTS=true` in your zshrc file to enable the feature.

Once that is in place, trigger the bad behavior with `command [TAB]` (it needs to be a command that hasn't been completed yet, I use `ls [TAB]`). The 5 dots will be printed and the prompt will be redrawn on the line below to accomodate for the extra 5 characters. 

After that, copy the new function definition and try to trigger the same behavior (you have to use a different command now or `exec zsh` to restart the shell). See that dots get printed but the prompt is not redrawn. 

Here's the new function definition:
```zsh
expand-or-complete-with-dots() {
    # toggle line-wrapping off and back on again
    [[ -n "$terminfo[rmam]" && -n "$terminfo[smam]" ]] && echoti rmam
    print -Pn "%F{red}......%f"
    [[ -n "$terminfo[rmam]" && -n "$terminfo[smam]" ]] && echoti smam

    zle expand-or-complete
    zle redisplay
}
```

----
### Results

**LEFT:** _without_ fix. **RIGHT:** _with_ fix.
<a href="https://asciinema.org/a/25388?autoplay=1" target="_blank"><img src="https://asciinema.org/a/25388.png" width="294"/></a> <a href="https://asciinema.org/a/25389?autoplay=1" target="_blank"><img src="https://asciinema.org/a/25389.png" width="294"/></a>

/cc @robbyrussell 