### PR TITLE
Fix graphical bug in cypher theme when return status is non-zero

### DIFF
--- a/themes/cypher.zsh-theme
+++ b/themes/cypher.zsh-theme
@@ -1,4 +1,4 @@
 # Based on evan's prompt
 # Shows the exit status of the last command if non-zero
 # Uses "#" instead of "»" when running with elevated privileges
-PROMPT="%m %{${fg_bold[red]}%}:: %{${fg[green]}%}%3~%(0?. . ${fg[red]}%? )%{${fg[blue]}%}»%{${reset_color}%} "
+PROMPT="%m %{${fg_bold[red]}%}:: %{${fg[green]}%}%3~%(0?. . %{${fg[red]}%}%? )%{${fg[blue]}%}»%{${reset_color}%} "


### PR DESCRIPTION
This fixes an issue in cypher's theme which occurs when the previous command's return status is non-zero and the prompt is redrawn. The ``fg[red]`` was not escaped, resulting in occasional graphical issues.

**Test**
When using cypher's theme, do any command resulting in a non-zero return status. Then try to make or edit a multi-line command. On the terminals I've tried this out on it overwrites the current line when hitting the end of a line, and when backspacing it starts to delete characters from line above the command.

It should also trigger when doing an ambiguous tab completion, where the first few characters of the command are drawn twice.