### PR TITLE
plugin symfony2 sf2.7 compatibility fix

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[a-z]+/ { print $1 }'
+   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
with symfony 2.7 command group titles are listed as commands. this commit prevents it.