### PR TITLE
Pacaur aliases in the Arch Linux plugin

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -43,6 +43,26 @@
 | yaupd        | yaourt -Sy && sudo aur                  | Update and refresh the local package and AUR databases against repositories                                         |
 | yaupd        | yaourt -Sy                              | Update and refresh the local package database against repositories                                                  |
 | yaupg        | yaourt -Syua                            | Synchronize with repositories before upgrading packages (AUR packages too) that are out of date on the local system |
+| paupg        | pacaur -Syu                             | Synchronize with repositories before upgrading packages (AUR too) that are out of date on the local system.
+| paupgd       | pacaur -Syu --devel                     | Synchronize with repositories before upgrading packages (AUR and devel too) that are out of date on the local system.
+| paupga       | pacaur -u                               | Upgrade all AUR packages
+| paupgda      | pacaur -u --devel                       | Upgrade all AUR and devel (-git, -svn, etc.) packages
+| pain         | pacaur -S                               | Install specific package(s) from the AUR
+| pains        | pacaur -U                               | Install specific package not from the repositories but from a file
+| pare         | pacaur -R                               | Remove the specified package(s), retaining its configuration(s) and required dependencies
+| parem        | pacaur -Rns                             | Remove the specified package(s), its configuration(s) and unneeded dependencies
+| parep        | pacaur -Si                              | Display information about a given package in the repositories or the AUR
+| pareps       | pacaur -Ss                              | Search for package(s) in the repositories and the AUR
+| parepsa      | pacaur -s                               | Search for package(s) in the repositories and the AUR
+| paloc        | pacaur -Qi                              | Display information about a given package in the local database
+| palocs       | pacaur -Qs                              | Search for package(s) in the local database
+| palst        | pacaur -Qe                              | List manually installed packages, even those installed from AUR
+| paupd        | pacaur -Sy && sudo abs && sudo aur      | Update and refresh the local package, ABS and AUR databases against repositories
+| paupd        | pacaur -Sy && sudo abs                  | Update and refresh the local package and ABS databases against repositories
+| paupd        | pacaur -Sy && sudo aur                  | Update and refresh the local package and AUR databases against repositories
+| paupd        | pacaur -Sy                              | Update and refresh the local package database against repositories
+| painsd       | pacaur -S --asdeps                      | Install given package(s) as dependencies of another package
+| pamir        | pacaur -Syy                             | Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
 
 | Function       | Description                                                                                                       |
 |----------------|:------------------------------------------------------------------------------------------------------------------|
@@ -60,5 +80,6 @@
  - Martin Putniorz - mputniorz@gmail.com
  - MatthR3D - matthr3d@gmail.com
  - ornicar - thibault.duplessis@gmail.com
+ - Juraj Fiala - doctorjellyface@riseup.net
 
 ---

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -6,6 +6,18 @@ if [[ -x `command -v yaourt` ]]; then
   upgrade () {
     yaourt -Syu
   }
+elif [[ -x `command -v pacaur` ]]; then
+  upgrade () {
+    pacaur -Syu
+  }
+else
+ upgrade() {
+   sudo pacman -Syu
+ }
+fi
+
+
+if [[ -x `command -v yaourt` ]]; then
   alias yaconf='yaourt -C'        # Fix all configuration files with vimdiff
   # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
   alias yaupg='yaourt -Syua'        # Synchronize with repositories before upgrading packages (AUR packages too) that are out of date on the local system.
@@ -32,11 +44,10 @@ if [[ -x `command -v yaourt` ]]; then
   fi
   alias yainsd='yaourt -S --asdeps'        # Install given package(s) as dependencies of another package
   alias yamir='yaourt -Syy'                # Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
-# If no yaourt, look for pacaur, and add useful functions and aliases to it too
-elif [[ -x `command -v pacaur` ]]; then
-  upgrade () {
-    pacaur -Syu
-  }
+fi
+
+# Look for pacaur, and add useful functions and aliases to it too
+if [[ -x `command -v pacaur` ]]; then
   alias paupg='pacaur -Syu'          # Synchronize with repositories before upgrading packages (AUR too) that are out of date on the local system.
   alias paupgd='pacaur -Syu --devel' # Synchronize with repositories before upgrading packages (AUR and devel too) that are out of date on the local system.
   alias paupga='pacaur -u'           # Upgrade all AUR packages
@@ -63,10 +74,6 @@ elif [[ -x `command -v pacaur` ]]; then
   fi
   alias painsd='pacaur -S --asdeps'        # Install given package(s) as dependencies of another package
   alias pamir='pacaur -Syy'                # Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
-else
- upgrade() {
-   sudo pacman -Syu
- }
 fi
 
 # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -32,6 +32,37 @@ if [[ -x `command -v yaourt` ]]; then
   fi
   alias yainsd='yaourt -S --asdeps'        # Install given package(s) as dependencies of another package
   alias yamir='yaourt -Syy'                # Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
+# If no yaourt, look for pacaur, and add useful functions and aliases to it too
+elif [[ -x `command -v pacaur` ]]; then
+  upgrade () {
+    pacaur -Syu
+  }
+  alias paupg='pacaur -Syu'          # Synchronize with repositories before upgrading packages (AUR too) that are out of date on the local system.
+  alias paupgd='pacaur -Syu --devel' # Synchronize with repositories before upgrading packages (AUR and devel too) that are out of date on the local system.
+  alias paupga='pacaur -u'           # Upgrade all AUR packages
+  alias paupgda='pacaur -u --devel'  # Upgrade all AUR and devel (-git, -svn, etc.) packages
+  alias pain='pacaur -S'             # Install specific package(s) from the repositories or the AUR
+  alias pains='pacaur -U'            # Install specific package not from the repositories but from a file
+  alias pare='pacaur -R'             # Remove the specified package(s), retaining its configuration(s) and required dependencies
+  alias parem='pacaur -Rns'          # Remove the specified package(s), its configuration(s) and unneeded dependencies
+  alias parep='pacaur -Si'           # Display information about a given package in the repositories or the AUR
+  alias pareps='pacaur -Ss'          # Search for package(s) in the repositories and the AUR
+  alias parepsa='pacaur -s'          # Search for package(s) in the AUR
+  alias paloc='pacaur -Qi'           # Display information about a given package in the local database
+  alias palocs='pacaur -Qs'          # Search for package(s) in the local database
+  alias palst='pacaur -Qe'           # List manually installed packages, even those installed from AUR
+  # Additional pacaur alias examples
+  if [[ -x `command -v abs` && -x `command -v aur` ]]; then
+    alias paupd='pacaur -Sy && sudo abs && sudo aur'  # Update and refresh the local package, ABS and AUR databases against repositories
+  elif [[ -x `command -v abs` ]]; then
+    alias paupd='pacaur -Sy && sudo abs'              # Update and refresh the local package and ABS databases against repositories
+  elif [[ -x `command -v aur` ]]; then
+    alias paupd='pacaur -Sy && sudo aur'              # Update and refresh the local package and AUR databases against repositories
+  else
+    alias paupd='pacaur -Sy'                          # Update and refresh the local package database against repositories
+  fi
+  alias painsd='pacaur -S --asdeps'        # Install given package(s) as dependencies of another package
+  alias pamir='pacaur -Syy'                # Force refresh of all package lists after updating /etc/pacman.d/mirrorlist
 else
  upgrade() {
    sudo pacman -Syu


### PR DESCRIPTION
[Pacaur](https://wiki.archlinux.org/index.php/Pacaur) is another AUR helper, though arguable one of the more popular ones. I (obv) use it too, and I missed aliases a lot, so I made them myself.

It's basically the same as the Yaourt/Pacman aliases. I tested every command I included. I also documented all my changes.

Hope you like it.