### PR TITLE
Add missing command completion for `vagrant`

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -35,6 +35,8 @@ _box_arguments=(
     'add:NAME URI Add a box to the system'
     'help:COMMAND Describe subcommands or one specific subcommand'
     'list:Lists all installed boxes'
+    'update:NAME Updates the box if outdated'
+    'outdated:NAME Check if a box is outdated'
     'remove:NAME Remove a box from the system'
     'repackage:NAME Repackage an installed box into a `.box` file.'
 )


### PR DESCRIPTION
Fixes the issue addressed in #4130.

( Fixes #4130 )
