### PR TITLE
Add a missing rbenv location

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -7,7 +7,7 @@ _rbenv-from-homebrew-installed() {
 }
 
 FOUND_RBENV=0
-rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
+rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/usr/bin/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
 if _homebrew-installed && _rbenv-from-homebrew-installed ; then
     rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
 fi


### PR DESCRIPTION
The [AUR package](https://aur.archlinux.org/packages/rbenv) for rbenv puts it in `/usr/bin/rbenv`, which is currently missing from the search paths.