### PR TITLE
Update autojump plugin for latest brew installation

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -15,7 +15,7 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/local/share/autojump/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
     . /opt/local/etc/profile.d/autojump.zsh
-  elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.zsh ]; then # mac os x with brew
-    . `brew --prefix`/etc/autojump.zsh
+  elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.sh ]; then # mac os x with brew
+    . `brew --prefix`/etc/autojump.sh
   fi
 fi


### PR DESCRIPTION
It seems like there is only one file to source now, see https://github.com/Homebrew/homebrew/blob/master/Library/Formula/autojump.rb (the autojump.zsh file got removed).