### PR TITLE
Rand-quote plugin overflows stack when site is unreachable

### DIFF
--- a/plugins/rand-quote/rand-quote.plugin.zsh
+++ b/plugins/rand-quote/rand-quote.plugin.zsh
@@ -18,8 +18,8 @@ if [[ -x `which curl` ]]; then
         W=$(echo "$Q" | sed -e 's/.*\/quotes\///g' -e 's/<.*//g' -e 's/.*">//g')
         if [ "$W" -a "$TXT" ]; then
           echo "${WHO_COLOR}${W}${COLON_COLOR}: ${TEXT_COLOR}“${TXT}”${END_COLOR}"
-        else
-          quote
+        # else
+        #   quote
         fi
     }
     #quote

--- a/plugins/rand-quote/rand-quote.plugin.zsh
+++ b/plugins/rand-quote/rand-quote.plugin.zsh
@@ -18,8 +18,6 @@ if [[ -x `which curl` ]]; then
         W=$(echo "$Q" | sed -e 's/.*\/quotes\///g' -e 's/<.*//g' -e 's/.*">//g')
         if [ "$W" -a "$TXT" ]; then
           echo "${WHO_COLOR}${W}${COLON_COLOR}: ${TEXT_COLOR}“${TXT}”${END_COLOR}"
-        # else
-        #   quote
         fi
     }
     #quote


### PR DESCRIPTION
This plugin was designed so that if there is any failure, it simply calls itself recursively. Which means that if you were working offline, and `quote` was called in your `.zshrc`, you would be unable to open a new terminal session.

I fixed this by allowing the plugin to output nothing if a quote could not be fetched.