### PR TITLE
Better readability for the 'agnoster' theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -145,7 +145,7 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue black '%~'
+  prompt_segment blue white '%~'
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
I changed the current working dir color from black to white to improve readability.

This is what it looked like before:

![be4](https://cloud.githubusercontent.com/assets/5144843/9516915/393e7498-4cac-11e5-921a-69a42c4f8c1f.png)

This is what it looks like now:

![after](https://cloud.githubusercontent.com/assets/5144843/9516920/41560eca-4cac-11e5-91ba-80c0ef8b958f.png)
