### PR TITLE
Remove redundant semicolon

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -6,7 +6,7 @@
 # ------------------------------------------------------------------------------
 
 function tab() {
-  local command="cd \\\"$PWD\\\"; clear; "
+  local command="cd \\\"$PWD\\\"; clear"
   (( $# > 0 )) && command="${command}; $*"
 
   the_app=$(


### PR DESCRIPTION
Remove redundant semicolon to make tab() works better in iTerm 2.
