### PR TITLE
Call correct ssh-add command

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/ssh-add $HOME/.ssh/${^identities}
+  /usr/bin/env ssh-add $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from


### PR DESCRIPTION
Instead of hard-coding ssh-add you should use /usr/bin/env so it runs the correct one (for instance if you installed openssh with brew on mac the old version breaks)