### PR TITLE
Refactor frontend-search plugin

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -1,83 +1,60 @@
-## Rationale ##
+## Introduction ##
 
-> Searches for your Frontend contents more easier
-
-
-## Instalation ##
+> Searches for your frontend web development made easier
 
 
-Open your `.zshrc` file and load `frontend-search` plugin
+## Installation ##
 
-```bash
-...
-plugins=( <your-plugins-list>... frontend-search)
-...
+Open your `~/.zshrc` file and enable the `frontend-search` plugin:
+
+```zsh
+
+plugins=( ... frontend-search)
+
 ```
 
 
-## Commands ##
+## Usage ##
 
-All command searches are accept only in formats
+You can use the frontend-search plugin in these two forms:
 
-* `frontend <search-content> <search-term>`
-* `<search-content> <search-term>`
+* `frontend <context> <term> [more terms if you want]`
+* `<context> <term> [more terms if you want]`
 
-For more informations, please run help command (are similars)
+For example, these two are equivalent:
 
-* `frontend -h`
-* `frontend --help`
-* `frontend help`
+```zsh
+$ frontend angularjs dependency injection
+$ angularjs dependency injection
+```
 
-The search content are
+Available search contexts are:
 
-* `jquery <api.jquery.com>`
-* `mdn <developer.mozilla.org>`
-* `compass <compass-style.org>`
-* `html5please <html5please.com>`
-* `caniuse <caniuse.com>`
-* `aurajs <aurajs.com>`
-* `dartlang <api.dartlang.org/apidocs/channels/stable/dartdoc-viewer>`
-* `lodash <search>`
-* `qunit <api.qunitjs.com>`
-* `fontello <fontello.com>`
-* `bootsnipp <bootsnipp.com>`
-* `cssflow <cssflow.com>`
-* `codepen <codepen.io>`
-* `unheap <www.unheap.com>`
-* `bem <google.com/search?as_q=<search-term>&as_sitesearch=bem.info>`
-* `smacss <google.com/search?as_q=<search-term>&as_sitesearch=smacss.com>`
-* `angularjs <google.com/search?as_q=<search-term>&as_sitesearch=angularjs.org>`
-* `reactjs <google.com/search?as_q=<search-term>&as_sitesearch=facebook.github.io/react>`
-* `emberjs <emberjs.com>`
-* `stackoverflow <stackoverflow.com>`
-* `npmjs <npmjs.com>`
+| context       | URL                                                                      |
+|---------------|--------------------------------------------------------------------------|
+| angularjs     | `https://google.com/search?as_sitesearch=angularjs.org&as_q=`            |
+| aurajs        | `http://aurajs.com/api/#stq=`                                            |
+| bem           | `https://google.com/search?as_sitesearch=bem.info&as_q=`                 |
+| bootsnipp     | `http://bootsnipp.com/search?q=`                                         |
+| caniuse       | `http://caniuse.com/#search=`                                            |
+| codepen       | `http://codepen.io/search?q=`                                            |
+| compass       | `http://compass-style.org/search?q=`                                     |
+| cssflow       | `http://www.cssflow.com/search?q=`                                       |
+| dartlang      | `https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:`  |
+| emberjs       | `http://emberjs.com/api/#stp=1&stq=`                                     |
+| fontello      | `http://fontello.com/#search=`                                           |
+| html5please   | `http://html5please.com/#`                                               |
+| jquery        | `https://api.jquery.com/?s=`                                             |
+| lodash        | `https://devdocs.io/lodash/index#`                                       |
+| mdn           | `https://developer.mozilla.org/search?q=`                                |
+| npmjs         | `https://www.npmjs.com/search?q=`                                        |
+| qunit         | `https://api.qunitjs.com/?s=`                                            |
+| reactjs       | `https://google.com/search?as_sitesearch=facebook.github.io/react&as_q=` |
+| smacss        | `https://google.com/search?as_sitesearch=smacss.com&as_q=`               |
+| stackoverflow | `http://stackoverflow.com/search?q=`                                     |
+| unheap        | `http://www.unheap.com/?s=`                                              |
 
-
-## Aliases ##
-
-There are a few aliases presented as well:
-
-* `jquery` A shorthand for `frontend jquery`
-* `mdn` A shorthand for `frontend mdn`
-* `compass` A shorthand for `frontend compass`
-* `html5please` A shorthand for `frontend html5please`
-* `caniuse` A shorthand for `frontend caniuse`
-* `aurajs` A shorthand for `frontend aurajs`
-* `dartlang` A shorthand for `frontend dartlang`
-* `lodash` A shorthand for `frontend lodash`
-* `qunit` A shorthand for `frontend qunit`
-* `fontello` A shorthand for `frontend fontello`
-* `bootsnipp` A shorthand for `frontend bootsnipp`
-* `cssflow` A shorthand for `frontend cssflow`
-* `codepen` A shorthand for `frontend codepen`
-* `unheap` A shorthand for `frontend unheap`
-* `bem` A shorthand for `frontend bem`
-* `smacss` A shorthand for `frontend smacss`
-* `angularjs` A shorthand for `frontend angularjs`
-* `reactjs` A shorthand for `frontend reactjs`
-* `emberjs` A shorthand for `frontend emberjs`
-* `stackoverflow` A shorthand for `frontend stackoverflow`
-* `npmjs` A shorthand for `frontend npmjs`
+If you want to have another context, open an Issue and tell us!
 
 
 ## Author
@@ -86,5 +63,3 @@ There are a few aliases presented as well:
 + <https://plus.google.com/+WilsonMendes>
 + <https://twitter.com/willmendesneto>
 + <http://github.com/willmendesneto>
-
-New features comming soon.

--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -17,9 +17,16 @@ plugins=( <your-plugins-list>... frontend-search)
 
 ## Commands ##
 
-All command searches are accept only in format
+All command searches are accept only in formats
 
 * `frontend <search-content> <search-term>`
+* `<search-content> <search-term>`
+
+For more informations, please run help command (are similars)
+
+* `frontend -h`
+* `frontend --help`
+* `frontend help`
 
 The search content are
 

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -1,6 +1,33 @@
 # frontend from terminal
 
 function frontend() {
+  emulate -L zsh
+
+  # define search content URLS
+  typeset -A urls
+  urls=(
+    angularjs      'https://google.com/search?as_sitesearch=angularjs.org&as_q='
+    aurajs         'http://aurajs.com/api/#stq='
+    bem            'https://google.com/search?as_sitesearch=bem.info&as_q='
+    bootsnipp      'http://bootsnipp.com/search?q='
+    caniuse        'http://caniuse.com/#search='
+    codepen        'http://codepen.io/search?q='
+    compass        'http://compass-style.org/search?q='
+    cssflow        'http://www.cssflow.com/search?q='
+    dartlang       'https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:'
+    emberjs        'http://emberjs.com/api/#stp=1&stq='
+    fontello       'http://fontello.com/#search='
+    html5please    'http://html5please.com/#'
+    jquery         'https://api.jquery.com/?s='
+    lodash         'https://devdocs.io/lodash/index#'
+    mdn            'https://developer.mozilla.org/search?q='
+    npmjs          'https://www.npmjs.com/search?q='
+    qunit          'https://api.qunitjs.com/?s='
+    reactjs        'https://google.com/search?as_sitesearch=facebook.github.io/react&as_q='
+    smacss         'https://google.com/search?as_sitesearch=smacss.com&as_q='
+    stackoverflow  'http://stackoverflow.com/search?q='
+    unheap         'http://www.unheap.com/?s='
+  )
 
   # no keyword provided, simply show how call methods
   if [[ $# -le 1 ]]; then
@@ -9,7 +36,7 @@ function frontend() {
   fi
 
   # check whether the search engine is supported
-  if [[ ! $1 =~ '(jquery|mdn|compass|html5please|caniuse|aurajs|dartlang|qunit|fontello|bootsnipp|cssflow|codepen|unheap|bem|smacss|angularjs|reactjs|emberjs|stackoverflow|npmjs)' ]];
+  if [[ -z "$urls[$1]" ]]; then
   then
     echo "Search valid search content $1 not supported."
     echo "Valid contents: (formats 'frontend <search-content>' or '<search-content>')"
@@ -39,73 +66,10 @@ function frontend() {
     return 1
   fi
 
-  local url="http://"
-  local query=""
-
-  case "$1" in
-    "jquery")
-      url="${url}api.jquery.com"
-      url="${url}/?s=$2" ;;
-    "mdn")
-      url="${url}developer.mozilla.org"
-      url="${url}/search?q=$2" ;;
-    "compass")
-      url="${url}compass-style.org"
-      url="${url}/search?q=$2" ;;
-    "html5please")
-      url="${url}html5please.com"
-      url="${url}/#$2" ;;
-    "caniuse")
-      url="${url}caniuse.com"
-      url="${url}/#search=$2" ;;
-    "aurajs")
-      url="${url}aurajs.com"
-      url="${url}/api/#stq=$2" ;;
-    "dartlang")
-      url="${url}api.dartlang.org/apidocs/channels/stable/dartdoc-viewer"
-      url="${url}/dart-$2" ;;
-    "qunit")
-      url="${url}api.qunitjs.com"
-      url="${url}/?s=$2" ;;
-    "fontello")
-      url="${url}fontello.com"
-      url="${url}/#search=$2" ;;
-    "bootsnipp")
-      url="${url}bootsnipp.com"
-      url="${url}/search?q=$2" ;;
-    "cssflow")
-      url="${url}cssflow.com"
-      url="${url}/search?q=$2" ;;
-    "codepen")
-      url="${url}codepen.io"
-      url="${url}/search?q=$2" ;;
-    "unheap")
-      url="${url}www.unheap.com"
-      url="${url}/?s=$2" ;;
-    "bem")
-      url="${url}google.com"
-      url="${url}/search?as_q=$2&as_sitesearch=bem.info" ;;
-    "smacss")
-      url="${url}google.com"
-      url="${url}/search?as_q=$2&as_sitesearch=smacss.com" ;;
-    "angularjs")
-      url="${url}google.com"
-      url="${url}/search?as_q=$2&as_sitesearch=angularjs.org" ;;
-    "reactjs")
-      url="${url}google.com"
-      url="${url}/search?as_q=$2&as_sitesearch=facebook.github.io/react" ;;
-    "emberjs")
-      url="${url}emberjs.com"
-      url="${url}/api/#stq=$2&stp=1" ;;
-    "stackoverflow")
-      url="${url}stackoverflow.com"
-      url="${url}/search?q=$2" ;;
-    "npmjs")
-      url="${url}www.npmjs.com"
-      url="${url}/search?q=$2" ;;
-    *) echo "INVALID PARAM!"
-       return ;;
-  esac
+  # build search url:
+  # join arguments passed with '+', then append to search engine URL
+  # TODO substitute for proper urlencode method
+  url="${urls[$1]}${(j:+:)@[2,-1]}"
 
   echo "$url"
 

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -1,9 +1,7 @@
-# frontend from terminal
-
 function frontend() {
   emulate -L zsh
 
-  # define search content URLS
+  # define search context URLS
   typeset -A urls
   urls=(
     angularjs      'https://google.com/search?as_sitesearch=angularjs.org&as_q='
@@ -29,74 +27,45 @@ function frontend() {
     unheap         'http://www.unheap.com/?s='
   )
 
-  # show help for commands list
-  if [[ $1 =~ '(help|--help|-h)' ]]
+  # show help for command list
+  if [[ $# -lt 2 ]]
   then
-      echo "Usage:"
-      echo "\n\tfrontend <search-content>\n\t<search-content>\n\tfrontend <search-content> <search-term>"
-      echo ""
-      echo "Where <search-content> is one of:"
-      echo "jquery, mdn, compass, html5please, caniuse, aurajs, dartlang, qunit, fontello,"
-      echo "bootsnipp, cssflow, codepen, unheap, bem, smacss, angularjs, reactjs, emberjs"
-      echo "help"
-      echo ""
-      echo "Where <search-term> is a term to search in allowed repositories"
-      echo ""
-      echo "frontend --help       show plugin help"
-      echo "frontend -h           show plugin help"
-      echo ""
-      echo "It is allowed to directly access all search contents."
-      echo ""
+      print -P "Usage: frontend %Ucontext%u %Uterm%u [...%Umore%u] (or just: %Ucontext%u %Uterm%u [...%Umore%u])"
+      print -P ""
+      print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
+      print -P "and %Ucontext%u is one of the following:"
+      print -P ""
+      print -P "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compass, cssflow,"
+      print -P "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,"
+      print -P "  qunit, reactjs, smacss, stackoverflow, unheap"
+      print -P ""
+      print -P "For example: frontend npmjs mocha (or just: npmjs mocha)."
+      print -P ""
       return 1
   fi
 
-  # no keyword provided, simply show how call methods
-  if [[ $# -le 1 ]]
-  then
-    echo "Please provide a search-content and a search-term for app.\nEx:\nfrontend <search-content> <search-term>\n"
-    return 1
-  fi
-
-  # check whether the search engine is supported
+  # check whether the search context is supported
   if [[ -z "$urls[$1]" ]]
   then
-    echo "Search valid search content $1 not supported."
-    echo "Valid contents: (formats 'frontend <search-content>' or '<search-content>')"
-    echo "* jquery"
-    echo "* mdn"
-    echo "* compass"
-    echo "* html5please"
-    echo "* caniuse"
-    echo "* aurajs"
-    echo "* dartlang"
-    echo "* lodash"
-    echo "* qunit"
-    echo "* fontello"
-    echo "* bootsnipp"
-    echo "* cssflow"
-    echo "* codepen"
-    echo "* unheap"
-    echo "* bem"
-    echo "* smacss"
-    echo "* angularjs"
-    echo "* reactjs"
-    echo "* emberjs"
-    echo "* stackoverflow"
-    echo "* npmjs"
+    echo "Search context \"$1\" currently not supported."
     echo ""
-
+    echo "Valid contexts are:"
+    echo ""
+    echo "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compass, cssflow, "
+    echo "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,  "
+    echo "  qunit, reactjs, smacss, stackoverflow, unheap"
+    echo ""
     return 1
   fi
 
   # build search url:
-  # join arguments passed with '+', then append to search engine URL
+  # join arguments passed with '+', then append to search context URL
   # TODO substitute for proper urlencode method
   url="${urls[$1]}${(j:+:)@[2,-1]}"
 
-  echo "$url"
+  echo "Opening $url ..."
 
   open_command "$url"
-
 }
 
 # javascript

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -1,3 +1,25 @@
+alias angularjs='frontend angularjs'
+alias aurajs='frontend aurajs'
+alias bem='frontend bem'
+alias bootsnipp='frontend bootsnipp'
+alias caniuse='frontend caniuse'
+alias codepen='frontend codepen'
+alias compass='frontend compass'
+alias cssflow='frontend cssflow'
+alias dartlang='frontend dartlang'
+alias emberjs='frontend emberjs'
+alias fontello='frontend fontello'
+alias html5please='frontend html5please'
+alias jquery='frontend jquery'
+alias lodash='frontend lodash'
+alias mdn='frontend mdn'
+alias npmjs='frontend npmjs'
+alias qunit='frontend qunit'
+alias reactjs='frontend reactjs'
+alias smacss='frontend smacss'
+alias stackoverflow='frontend stackoverflow'
+alias unheap='frontend unheap'
+
 function frontend() {
   emulate -L zsh
 
@@ -67,44 +89,3 @@ function frontend() {
 
   open_command "$url"
 }
-
-# javascript
-alias jquery='frontend jquery'
-alias mdn='frontend mdn'
-
-# pre processors frameworks
-alias compassdoc='frontend compass'
-
-# important links
-alias html5please='frontend html5please'
-alias caniuse='frontend caniuse'
-
-# components and libraries
-alias aurajs='frontend aurajs'
-alias dartlang='frontend dartlang'
-alias lodash='frontend lodash'
-
-#tests
-alias qunit='frontend qunit'
-
-#fonts
-alias fontello='frontend fontello'
-
-# snippets
-alias bootsnipp='frontend bootsnipp'
-alias cssflow='frontend cssflow'
-alias codepen='frontend codepen'
-alias unheap='frontend unheap'
-
-# css architecture
-alias bem='frontend bem'
-alias smacss='frontend smacss'
-
-# frameworks
-alias angularjs='frontend angularjs'
-alias reactjs='frontend reactjs'
-alias emberjs='frontend emberjs'
-
-# search websites
-alias stackoverflow='frontend stackoverflow'
-alias npmjs='frontend npmjs'

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -29,14 +29,36 @@ function frontend() {
     unheap         'http://www.unheap.com/?s='
   )
 
+  # show help for commands list
+  if [[ $1 =~ '(help|--help|-h)' ]]
+  then
+      echo "Usage:"
+      echo "\n\tfrontend <search-content>\n\t<search-content>\n\tfrontend <search-content> <search-term>"
+      echo ""
+      echo "Where <search-content> is one of:"
+      echo "jquery, mdn, compass, html5please, caniuse, aurajs, dartlang, qunit, fontello,"
+      echo "bootsnipp, cssflow, codepen, unheap, bem, smacss, angularjs, reactjs, emberjs"
+      echo "help"
+      echo ""
+      echo "Where <search-term> is a term to search in allowed repositories"
+      echo ""
+      echo "frontend --help       show plugin help"
+      echo "frontend -h           show plugin help"
+      echo ""
+      echo "It is allowed to directly access all search contents."
+      echo ""
+      return 1
+  fi
+
   # no keyword provided, simply show how call methods
-  if [[ $# -le 1 ]]; then
+  if [[ $# -le 1 ]]
+  then
     echo "Please provide a search-content and a search-term for app.\nEx:\nfrontend <search-content> <search-term>\n"
     return 1
   fi
 
   # check whether the search engine is supported
-  if [[ -z "$urls[$1]" ]]; then
+  if [[ -z "$urls[$1]" ]]
   then
     echo "Search valid search content $1 not supported."
     echo "Valid contents: (formats 'frontend <search-content>' or '<search-content>')"


### PR DESCRIPTION
This PR refactors and cleans up the frontend-search plugin, and improves the documentation.

The changes include:

- Use of an associative array to define the necessary URLs.
  This makes it trivial to add another search context: just append a new entry to the `urls` array, add the alias and update the help messages .
- Uses all arguments passed instead of just the second, to enable for multiword queries.
  Now `frontend <context> multiple words or a whole phrase` will also work.
- Clarifies the README and removes duplicate information.
- Includes a better help message adapting it from PR #2930.  
  This is how it looks:
  ![frontend help screenshot](https://cloud.githubusercontent.com/assets/1441704/9585834/8b58e2ca-5019-11e5-8ff5-73aae5fcc1f2.png)

Fixes #2930

/cc @willmendesneto