### PR TITLE
[vim-interaction plugin] Escape special chars in filenames.

### DIFF
--- a/plugins/vim-interaction/vim-interaction.plugin.zsh
+++ b/plugins/vim-interaction/vim-interaction.plugin.zsh
@@ -4,17 +4,6 @@
 # Derek Wyatt (derek@{myfirstnamemylastname}.org
 # 
 
-function resolveFile
-{
-  if [ -f "$1" ]; then
-    echo $(readlink -f "$1")
-  elif [[ "${1#/}" == "$1" ]]; then
-    echo "$PWD/$1"
-  else
-    echo $1
-  fi
-}
-
 function callvim
 {
   if [[ $# == 0 ]]; then
@@ -48,13 +37,10 @@ EOH
   if [[ ${before#:} != $before && ${before%<cr>} == $before ]]; then
     before="$before<cr>"
   fi
-  local files=""
-  for f in $@
-  do
-    files="$files $(resolveFile $f)"
-  done
-  if [[ -n $files ]]; then
-    files=':args! '"$files<cr>"
+  local files
+  if [[ $# -gt 0 ]]; then
+    # absolute path of files resolving symlinks (:A) and quoting special chars (:q)
+    files=':args! '"${@:A:q}<cr>"
   fi
   cmd="$before$files$after"
   gvim --remote-send "$cmd"


### PR DESCRIPTION
This commit fixes the problem with special chars in filenames for vim-interaction plugin.
When opening a file with
```
v some\ long\ file\ name\ with\ spaces.txt
```
6 new files will be created in gvim instead of opening an existing one.