### PR TITLE
Fix gbda alias to support `color.ui = always` + exclude dev branches

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -53,7 +53,7 @@ alias gapa='git add --patch'
 
 alias gb='git branch'
 alias gba='git branch -a'
-alias gbda='git branch --merged | command grep -vE "^(\*|\s*master\s*$)" | command xargs -n 1 git branch -d'
+alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*master\s*$)" | command xargs -n 1 git branch -d'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
 alias gbr='git branch --remote'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -53,7 +53,7 @@ alias gapa='git add --patch'
 
 alias gb='git branch'
 alias gba='git branch -a'
-alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*master\s*$)" | command xargs -n 1 git branch -d'
+alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*(master|develop|dev)\s*$)" | command xargs -n 1 git branch -d'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
 alias gbr='git branch --remote'


### PR DESCRIPTION
The alias `gbda` actually doesn't work if `git config color.ui = always`.
Some invisible characters are included in branch names wich causes the following :
- master branch is not excluded
- on deletion, the output is : `error: branch 'x' not found.` And there is no deletion at all.

The `--no-color` option solves this problem.

Also, `command` seems unnecessary.

I excluded `develop` and `dev` branches to make it usable with Git Flow. Should I do this in another PR or is it ok to keep it here ?