### PR TITLE
[plugin] adds clipboard plugin

### DIFF
--- a/plugins/clipboard/clipboard.plugin.zsh
+++ b/plugins/clipboard/clipboard.plugin.zsh
@@ -1,0 +1,23 @@
+# pbcopy is expected to be available on Mac OSX
+if type pbcopy &> /dev/null; then
+  alias copy="pbcopy"
+  alias paste="pbpaste"
+
+# xsel is expected to be available on most modern XWindows based Linux distro
+elif type xsel &> /dev/null; then
+  alias copy="xsel --clipboard --input"
+  alias paste="xsel --clipboard --output"
+
+# xclip is expected to be available on Linux distros that do not ship with xsel
+elif type xclip &> /dev/null; then
+  alias copy="xclip --selection clipboard"
+  alias paste="xclip --selection clipboard -o"
+
+else
+ echo 'No clipboard util found!'
+ echo 'Please install one of the following utils:'
+ echo '\tpbcopy'
+ echo '\txsel'
+ echo '\txclip'
+ return 1
+fi


### PR DESCRIPTION
The clipboard plugin adds a `copy` and `paste` alias that works in every environment.

## Copy and paste

``` zsh
$ echo "foo" | copy
$ paste
foo
```

## Copy from file

``` zsh
$ echo "foo" > document.txt
$ cat document.txt | copy
$ paste
foo
```

## Paste to file

``` zsh
$ echo "foo" | copy
$ paste > clipboard.txt
$ cat clipboard.txt
foo
```

## When tools are missing

``` zsh
No cliboard util found!
Please install one of the following utils:
   pbcopy
   xsel
   xclip
$
```