### PR TITLE
Fix aws plugin RPROMPT pollution

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -11,11 +11,16 @@ export AWS_HOME=~/.aws
 function agp {
   echo $AWS_DEFAULT_PROFILE
 }
+
 function asp {
+  local rprompt=${RPROMPT/<aws:$(agp)>/}
+
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
-  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>$RPROMPT"
+
+  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>$rprompt"
 }
+
 function aws_profiles {
   reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))
 }


### PR DESCRIPTION
Multiple calls to `asp` pollutes `RPROMPT`. E.g. calling `asp foo` then `asp bar` will set `RPROMPT` to `<aws:bar><aws:foo>`. This patch makes sure only last value is presented.