### PR TITLE
Fixed an edge case for grep - install breaks on Linux

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -44,7 +44,7 @@ mv -f ~/.zshrc-omztemp ~/.zshrc
 TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
 if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
-    chsh -s $(grep /zsh$ /etc/shells | tail -1)
+    chsh -s $(grep --color=never /zsh$ /etc/shells | tail -1)
 fi
 unset TEST_CURRENT_SHELL
 


### PR DESCRIPTION
Users may have an option set for grep to use color.
This was inserting escape characters in "/usr/bin/zsh"