### PR TITLE
golang: improve go doc completion

### DIFF
--- a/plugins/golang/golang.plugin.zsh
+++ b/plugins/golang/golang.plugin.zsh
@@ -54,23 +54,37 @@ __go_tool_complete() {
     '-installsuffix[suffix to add to package directory]:suffix'
     '-tags[list of build tags to consider satisfied]:tags'
   )
-  __go_list() {
-      local expl importpaths
-      declare -a importpaths
-      importpaths=($(go list ${words[$CURRENT]}... 2>/dev/null))
-      _wanted importpaths expl 'import paths' compadd "$@" - "${importpaths[@]}"
+  __go_packages() {
+      _path_files -W "$(go env GOROOT)/src" -/
+      _path_files -W "$(go env GOPATH)/src" -/
+  }
+  __go_identifiers() {
+      compadd $(godoc -templates $ZSH/plugins/golang/templates ${words[-2]} 2> /dev/null)
   }
   case ${words[2]} in
-  clean|doc)
-      _arguments -s -w : '*:importpaths:__go_list'
+  doc)
+    _arguments -s -w \
+      "-c[symbol matching honors case (paths not affected)]" \
+      "-cmd[show symbols with package docs even if package is a command]" \
+      "-u[show unexported symbols as well as exported]" \
+      "2:importpaths:__go_packages" \
+      ":next identifiers:__go_identifiers"
+      ;;
+  clean)
+    _arguments -s -w \
+      "-i[remove the corresponding installed archive or binary (what 'go install' would create)]" \
+      "-n[print the remove commands it would execute, but not run them]" \
+      "-r[apply recursively to all the dependencies of the packages named by the import paths]" \
+      "-x[print remove commands as it executes them]" \
+      "*:importpaths:__go_packages"
       ;;
   fix|fmt|list|vet)
-      _alternative ':importpaths:__go_list' ':files:_path_files -g "*.go"'
+      _alternative ':importpaths:__go_packages' ':files:_path_files -g "*.go"'
       ;;
   install)
       _arguments -s -w : ${build_flags[@]} \
         "-v[show package names]" \
-        '*:importpaths:__go_list'
+        '*:importpaths:__go_packages'
       ;;
   get)
       _arguments -s -w : \
@@ -81,7 +95,7 @@ __go_tool_complete() {
         ${build_flags[@]} \
         "-v[show package names]" \
         "-o[output file]:file:_files" \
-        "*:args:{ _alternative ':importpaths:__go_list' ':files:_path_files -g \"*.go\"' }"
+        "*:args:{ _alternative ':importpaths:__go_packages' ':files:_path_files -g \"*.go\"' }"
       ;;
   test)
       _arguments -s -w : \
@@ -103,7 +117,7 @@ __go_tool_complete() {
         "-cpuprofile[write CPU profile to file]:file:_files" \
         "-memprofile[write heap profile to file]:file:_files" \
         "-memprofilerate[set heap profiling rate]:number" \
-        "*:args:{ _alternative ':importpaths:__go_list' ':files:_path_files -g \"*.go\"' }"
+        "*:args:{ _alternative ':importpaths:__go_packages' ':files:_path_files -g \"*.go\"' }"
       ;;
   help)
       _values "${commands[@]}" \

--- a/plugins/golang/golang.plugin.zsh
+++ b/plugins/golang/golang.plugin.zsh
@@ -55,8 +55,13 @@ __go_tool_complete() {
     '-tags[list of build tags to consider satisfied]:tags'
   )
   __go_packages() {
-      _path_files -W "$(go env GOROOT)/src" -/
-      _path_files -W "$(go env GOPATH)/src" -/
+      local gopaths
+      declare -a gopaths
+      gopaths=("${(s/:/)$(go env GOPATH)}")
+      gopaths+=("$(go env GOROOT)")
+      for p in $gopaths; do
+        _path_files -W "$p/src" -/
+      done
   }
   __go_identifiers() {
       compadd $(godoc -templates $ZSH/plugins/golang/templates ${words[-2]} 2> /dev/null)

--- a/plugins/golang/templates/package.txt
+++ b/plugins/golang/templates/package.txt
@@ -1,0 +1,29 @@
+{{with .PDoc}}{{/*
+
+Constants 
+---------------------------------------
+
+*/}}{{with .Consts}}{{range .}}{{range .Names}}{{.}} {{end}}{{end}}{{end}}{{/*
+
+Variables
+---------------------------------------
+
+*/}}{{with .Vars}}{{range .}}{{range .Names}}{{.}} {{end}}{{end}}{{end}}{{/*
+
+Functions
+---------------------------------------
+
+*/}}{{with .Funcs}}{{range .}}{{ .Name }} {{end}}{{end}}{{/*
+
+Types
+---------------------------------------
+
+*/}}{{with .Types}}{{range .}}{{ $TypeName := .Name }}{{ $TypeName }} {{/*
+
+*/}}{{range .Methods}}{{ $TypeName }}.{{.Name}} {{end}}{{/*
+
+*/}}{{range .Funcs}}{{.Name}} {{end}}{{/*
+
+*/}}{{range .Consts}}{{range .Names}}{{.}} {{end}}{{end}}{{/*
+
+*/}}{{range .Vars}}{{range .Names}}{{.}} {{end}}{{end}}{{end}}{{end}}{{end}}


### PR DESCRIPTION
Using `_path_files` for completing the package names makes the completion significantly faster.
Also, `godoc` is used to complete exported package identifiers.

![](http://i.imgur.com/ChfXG1q.gif)