### PR TITLE
Added fedora plugin, based on dnf/yum plugin

### DIFF
--- a/plugins/fedora/README.md
+++ b/plugins/fedora/README.md
@@ -1,0 +1,3 @@
+This is a plugin based on yum plugin, but using dnf as main frontend
+(from Fedora 22 onwards, yum is deprecated in favor of dnf).
+ 

--- a/plugins/fedora/fedora.plugin.zsh
+++ b/plugins/fedora/fedora.plugin.zsh
@@ -1,0 +1,16 @@
+## Aliases
+
+alias dnfs="dnf search"                       # search package
+alias dnfp="dnf info"                         # show package info
+alias dnfl="dnf list"                         # list packages
+alias dnfgl="dnf grouplist"                   # list package groups
+alias dnfli="dnf list installed"              # print all installed packages
+alias dnfmc="dnf makecache"                   # rebuilds the dnf package list
+
+alias dnfu="sudo dnf upgrade"                 # upgrade packages
+alias dnfi="sudo dnf install"                 # install package
+alias dnfgi="sudo dnf groupinstall"           # install package group
+alias dnfr="sudo dnf remove"                  # remove package
+alias dnfgr="sudo dnf groupremove"            # remove pagage group
+alias dnfrl="sudo dnf remove --remove-leaves" # remove package and leaves
+alias dnfc="sudo dnf clean all"               # clean cache


### PR DESCRIPTION
I've added fedora plugin.
As there are distro-specific plugin I thought to rename yum plugin, adapt to use dnf instead of yum (from Fedora 22 onwards, yum is deprecated).

