### PR TITLE
fix url-quote-magic not working issue

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,10 @@
 ## Load smart urls if available
 for d in $fpath; do
 	if [[ -e "$d/url-quote-magic" ]]; then
+		if [[ -e "$d/bracketed-paste-magic" ]]; then
+			autoload -Uz bracketed-paste-magic
+			zle -N bracketed-paste bracketed-paste-magic
+		fi
 		autoload -U url-quote-magic
 		zle -N self-insert url-quote-magic
 	fi


### PR DESCRIPTION
Incompatibilites between 5.0.8 and 5.1:
bracketed-paste-magic may also be necessary in order to apply url-quote-magic.

Reference: 
https://github.com/zsh-users/zsh/blob/a9df6aaa702abf761b155cd842a7f6917be44139/Functions/Zle/url-quote-magic#L11