### PR TITLE
Fix Atom Plugin for Linux Users

### DIFF
--- a/plugins/atom/README.md
+++ b/plugins/atom/README.md
@@ -1,6 +1,8 @@
 ## atom
 
-Plugin for Atom, a cross platform text and code editor, available for Linux, Mac OS X, and Windows.
+This plugin makes "at" a useful function for invoking the Atom Editor.
+
+Originally by Github user [aforty](https://github.com/aforty) for OSX, modified to alias 'at' to 'atom' for Linux, since atom already works on the terminal for Linux, and calling 'at' in a non-OSX environment should still work.
 
 ### Requirements
 
@@ -10,8 +12,12 @@ Plugin for Atom, a cross platform text and code editor, available for Linux, Mac
 
  * If `at` command is called without an argument, launch Atom
 
- * If `at` is passed a directory, `cd` to it and open it in Atom
+ * If `at` is passed a directory, open it in Atom
 
  * If `at` is passed a file, open it in Atom
 
- * if `att` command is called, it is equivalent to `at .`, opening the current folder in Atom
+### Examples
+
+ * Open the current dir in atom: `at .`
+ * Open another dir in atom: `at path/to/folder`
+ * Open a file: `at filename.extension`

--- a/plugins/atom/atom.plugin.zsh
+++ b/plugins/atom/atom.plugin.zsh
@@ -1,14 +1,22 @@
-local _atom_paths > /dev/null 2>&1
-_atom_paths=(
-    "$HOME/Applications/Atom.app"
-    "/Applications/Atom.app"
-)
+# Gets OS Type
+unamestr=$(uname -s)
 
-for _atom_path in $_atom_paths; do
-    if [[ -a $_atom_path ]]; then
-        alias at="open -a '$_atom_path'"
-        break
-    fi
-done
+# If OSX
+if [[ "$unamestr" == 'Darwin' ]]; then
+    local _atom_paths > /dev/null 2>&1
+    _atom_paths=(
+        "$HOME/Applications/Atom.app"
+        "/Applications/Atom.app"
+    )
 
-alias att='at .'
+    for _atom_path in $_atom_paths; do
+        if [[ -a $_atom_path ]]; then
+            alias at="open -a '$_atom_path'"
+            break
+        fi
+    done
+# If Linux
+elif [[ "$unamestr" == 'Linux' ]]; then
+    # Alerts the user if 'atom' is not a found command.
+    type atom >/dev/null 2>&1 && alias at="atom" || { echo >&2 "You have enabled the atom oh-my-zsh plugin on Linux, but atom is not a recognized command. Please make sure you have it installed before using this plugin."; }
+fi


### PR DESCRIPTION
This is a small scripting edit to the atom plugin to fix compatibility with Linux systems, so `at` works correctly instead of throwing a useless error.

Also slightly clarified readme for the plugin.