### PR TITLE
chruby: donʼt try to execute .sh files before loading

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -45,11 +45,11 @@ _source_from_omz_settings() {
     zstyle -s :omz:plugins:chruby path _chruby_path
     zstyle -s :omz:plugins:chruby auto _chruby_auto
 
-    if ${_chruby_path} && [[ -r ${_chruby_path} ]]; then
+    if [[ -r ${_chruby_path} ]]; then
         source ${_chruby_path}
     fi
 
-    if ${_chruby_auto} && [[ -r ${_chruby_auto} ]]; then
+    if [[ -r ${_chruby_auto} ]]; then
         source ${_chruby_auto}
     fi
 }


### PR DESCRIPTION
Iʼm not quite sure why this was here in the first place, but it was causing these errors for me:

```
_source_from_omz_settings:4: permission denied: /usr/share/chruby/chruby.sh
_source_from_omz_settings:8: permission denied: /usr/share/chruby/auto.sh
```

As far as I can tell, it should be enough to just check if the file exists and is readable?