### PR TITLE
Added mercurial library

### DIFF
--- a/lib/mercurial.zsh
+++ b/lib/mercurial.zsh
@@ -1,0 +1,32 @@
+# Michele Bologna
+#
+# Implements a hg_prompt_info function that inspect the current mercurial repo
+# (if any) and then outputs the status of the repo, in a similar way with
+# git.zsh library.
+#
+# themes should customize:
+# * ZSH_THEME_HG_PROMPT_UNTRACKED - symbol to show in prompt if untracked 
+# files are present in the mercurial repo
+# * ZSH_THEME_HG_PROMPT_ADDED - symbol to show in prompt if added files are
+# present in the mercurial repo
+# * ZSH_THEME_HG_PROMPT_MODIFIED - symbol to show in prompt if modified files
+# are present in the mercurial repo
+
+hg_prompt_info() 
+{
+	local STATUS=""
+	if $(hg id >/dev/null 2>&1); then
+		local BRANCH=$(hg branch 2>/dev/null)
+		if `hg status | grep -q "^\?"`; then
+			STATUS="$ZSH_THEME_HG_PROMPT_UNTRACKED"
+		fi
+		if `hg status | grep -q "^[A]"`; then
+			STATUS="$ZSH_THEME_HG_PROMPT_ADDED$STATUS"
+		fi
+		if `hg status | grep -q "^[M]"`; then
+			STATUS="$ZSH_THEME_HG_PROMPT_MODIFIED$STATUS"
+		fi
+		echo "$BRANCH$STATUS"
+	fi
+}
+

--- a/lib/mercurial.zsh
+++ b/lib/mercurial.zsh
@@ -17,14 +17,18 @@ hg_prompt_info()
 	local STATUS=""
 	if $(hg id >/dev/null 2>&1); then
 		local BRANCH=$(hg branch 2>/dev/null)
-		if `hg status | grep -q "^\?"`; then
+		local STATUS_OUTPUT=$(hg status)
+		if echo $STATUS_OUTPUT | grep -q "^\?"; then
 			STATUS="$ZSH_THEME_HG_PROMPT_UNTRACKED"
 		fi
-		if `hg status | grep -q "^[A]"`; then
+		if echo $STATUS_OUTPUT | grep -q "^[A]"; then
 			STATUS="$ZSH_THEME_HG_PROMPT_ADDED$STATUS"
 		fi
-		if `hg status | grep -q "^[M]"`; then
+		if echo $STATUS_OUTPUT | grep -q "^[M]"; then
 			STATUS="$ZSH_THEME_HG_PROMPT_MODIFIED$STATUS"
+		fi
+		if [ ! "$STATUS" = "" ] ; then
+			 STATUS=" $STATUS"
 		fi
 		echo "$BRANCH$STATUS"
 	fi

--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -10,7 +10,7 @@
 # Dummy implementations that return false to prevent command_not_found
 # errors with themes, that implement these functions
 # Real implementations will be used when the respective plugins are loaded
-function chruby_prompt_info hg_prompt_info pyenv_prompt_info \
+function chruby_prompt_info pyenv_prompt_info \
   rbenv_prompt_info svn_prompt_info vi_mode_prompt_info \
   virtualenv_prompt_info {
   return 1

--- a/themes/michelebologna.zsh-theme
+++ b/themes/michelebologna.zsh-theme
@@ -68,8 +68,14 @@ ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE=">"
 ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE="<"
 ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE="$red<>"
 
+ZSH_THEME_HG_PROMPT_MODIFIED="$red*"
+ZSH_THEME_HG_PROMPT_ADDED="$green+"
+ZSH_THEME_HG_PROMPT_UNTRACKED="$blue%%"
+
 PROMPT='$username_output$hostname_output:$current_dir_output%1(j. [$jobs_bg].)'
 GIT_PROMPT='$(out=$(git_prompt_info)$(git_prompt_status)$(git_remote_status);if [[ -n $out ]]; then printf %s " $white($green$out$white)$reset";fi)'
 PROMPT+="$GIT_PROMPT"
+HG_PROMPT='$(out=$(hg_prompt_info);if [[ -n $out ]]; then printf %s " $white($green$out$white)$reset";fi)'
+PROMPT+="$HG_PROMPT"
 PROMPT+=" $last_command_output%#$reset "
 RPROMPT=''


### PR DESCRIPTION
The added library parses output of the hg (mercurial) command, and outputs
the same variables (which should be customized by theme) in your prompt.
I added an example of these variables to michelebologna theme.

This patch should uniform all the behaviour of all themes regarding mercurial.
In fact, some themes implement their own hg parsing _inside_ the theme.
This should be better implemented in a library, as happens with git library.
