### PR TITLE
Fix RBENV_ROOT

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -4,10 +4,6 @@ _homebrew-installed() {
 
 FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
-if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null); then
-    rbenvdirs=($rbenv_homebrew_path "${rbenvdirs[@]}")
-    unset rbenv_homebrew_path
-fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do
   if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then


### PR DESCRIPTION
Targets OSX-only users who install rbenv with homebrew.
With rbenv plugin enabled, oh-my-zsh was erroneously setting RBENV_ROOT to
brew --prefix rbenv.

Before:
% echo $RBENV_ROOT
/usr/local/opt/rbenv

After:
% echo $RBENV_ROOT
/Users/michele/.rbenv

Thus, rubies gets installed in the correct directory (~/.rbenv/versions)

Solves #3808 #3093
