### PR TITLE
Uniform git prompt equal remote

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -38,7 +38,7 @@ git_remote_status() {
 
         if [ $ahead -eq 0 ] && [ $behind -eq 0 ]
         then
-          echo "$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
+          git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
         elif [ $ahead -gt 0 ] && [ $behind -eq 0 ]
         then
             git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -38,7 +38,7 @@ git_remote_status() {
 
         if [ $ahead -eq 0 ] && [ $behind -eq 0 ]
         then
-          git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
+          	git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
         elif [ $ahead -gt 0 ] && [ $behind -eq 0 ]
         then
             git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"


### PR DESCRIPTION
Uniform git prompt equal remote to all others prompts, setting the correct symbol
(if applicable) to $git_remote_status, instead of echoing it.

It also solves the problem pointed out in #3911