### PR TITLE
Fix incorrect PATH setting with system-wide rbenv

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -10,7 +10,7 @@ if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null)
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do
-  if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then
+  if [ -d $rbenvdir -a $FOUND_RBENV -eq 0 ] ; then
     FOUND_RBENV=1
     if [[ $RBENV_ROOT = '' ]]; then
       RBENV_ROOT=$rbenvdir


### PR DESCRIPTION
When using system-wide rbenv (as in provided by vendor packages like in Ubuntu or
FreeBSD), PATH is not set to the correct ruby binary.
This leads to being unable to use rubies installed with rbenv (and stick with the
system-wide ruby installed, if any).
This patch correct this behaviour, setting the correct PATH.

Fixing #3275 

Before patching: :(
![wrong](https://cloud.githubusercontent.com/assets/530992/10047436/76fa50e6-620e-11e5-8d16-2b109321803a.png)

After patching: :)
![correct](https://cloud.githubusercontent.com/assets/530992/10047453/8e068ade-620e-11e5-8917-d98f36aa2e9e.png)
