### PR TITLE
installer: use timestamped backups to preserve all old zshrcs

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -58,6 +58,30 @@ main() {
     exit 1
   }
 
+  # Keep most recent old .zshrc at .zshrc.pre-oh-my-zsh, and older ones
+  # with datestamp of installation that moved them aside, so we never actually
+  # destroy a user's original zshrc
+  printf "${BLUE}Looking for an existing zsh config...${NORMAL}\n"
+  # Must use this exact name so uninstall.sh can find it
+  OLD_ZSHRC=~/.zshrc.pre-oh-my-zsh
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+    if [ -e "$OLD_ZSHRC" ]; then
+      TIMESTAMP="$(date +%Y-%m-%d_%H-%M-%S)"
+      OLD_OLD_ZSHRC="${OLD_ZSHRC}-${TIMESTAMP}"
+      if [ -e "$OLD_OLD_ZSHRC" ]; then
+        echo "Error: $OLD_OLD_ZSHRC exists" >&2
+        echo "Just re-run this again in a couple seconds" &>2
+        exit 1
+      fi
+      mv "$OLD_ZSHRC" "${OLD_OLD_ZSHRC}"
+      # intentional omitted newline
+      printf "${YELLOW}Found old ~/.zshrc.pre-oh-my-zsh.${NORMAL} "
+      printf "${GREEN}Backing up to ${OLD_OLD_ZSHRC}${NORMAL}\n"
+    fi
+    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ${OLD_ZSHRC}${NORMAL}\n"
+    mv ~/.zshrc "$OLD_ZSHRC";
+  fi
+
   # The Windows (MSYS) Git is not compatible with normal use on cygwin
   if [ "$OSTYPE" = cygwin ]; then
     if git --version | grep msysgit > /dev/null; then

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -23,11 +23,8 @@ if [ -e "$ZSHRC_ORIG" ]; then
   fi
 
   mv "$ZSHRC_ORIG" ~/.zshrc;
-
-  source ~/.zshrc;
 else
-  if hash chsh >/dev/null 2>&1
-  then
+  if hash chsh >/dev/null 2>&1; then
     echo "Switching back to bash"
     chsh -s /bin/bash
   else

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -6,24 +6,23 @@ then
 fi
 
 echo "Removing ~/.oh-my-zsh"
-if [ -d ~/.oh-my-zsh ]
-then
+if [ -d ~/.oh-my-zsh ]; then
   rm -rf ~/.oh-my-zsh
 fi
 
 echo "Looking for original zsh config..."
-if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]
-then
-  echo "Found ~/.zshrc.pre-oh-my-zsh -- Restoring to ~/.zshrc";
+ZSHRC_ORIG=~/.zshrc.pre-oh-my-zsh
+if [ -e "$ZSHRC_ORIG" ]; then
+  echo "Found $ZSHRC_ORIG -- Restoring to ~/.zshrc";
 
-  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]
-  then
-    ZSHRC_SAVE=".zshrc.omz-uninstalled-`date +%Y%m%d%H%M%S`";
-    echo "Found ~/.zshrc -- Renaming to ~/${ZSHRC_SAVE}";
-    mv ~/.zshrc ~/${ZSHRC_SAVE};
+  if [ -e ~/.zshrc ]; then
+    TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+    ZSHRC_SAVE=~/.zshrc.omz-uninstalled-$TIMESTAMP;
+    echo "Found ~/.zshrc -- Renaming to ${ZSHRC_SAVE}";
+    mv ~/.zshrc ${ZSHRC_SAVE};
   fi
 
-  mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
+  mv "$ZSHRC_ORIG" ~/.zshrc;
 
   source ~/.zshrc;
 else


### PR DESCRIPTION
The installer backs up `~/.zshrc` to `~/.zshrc.pre-oh-my-zsh`. But it doesn't back up `~/.zshrc.pre-oh-my-zsh` if it exists, so if you run the installer multiple times, it can destroy your original `~/.zshrc`. We should probably avoid destroying any original user data where at all possible.

This PR add timestamped backups of the old `~/.zshrc.pre-oh-my-zsh` files, so no matter how many times you run the installer, you can still find your original `~/.zshrc` contents, unless you manually delete them yourself.

Fixes #4390 
Fixes #2499 
