### PR TITLE
Fix invalid test expression.

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -24,7 +24,7 @@ _homebrew-installed() {
 }
 
 _chruby-from-homebrew-installed() {
-  [ -r $(brew --prefix chruby)] &> /dev/null
+  [ -r $(brew --prefix chruby) ] &> /dev/null
 }
 
 _ruby-build_installed() {


### PR DESCRIPTION
Homebrew installed chruby couldn't be found due to erroneous test expression. This PR fixes said issue.