### PR TITLE
Fix print rvm version in amuse theme

### DIFF
--- a/themes/amuse.zsh-theme
+++ b/themes/amuse.zsh-theme
@@ -20,7 +20,7 @@ ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[green]%}?"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  RPROMPT='%{$fg_bold[red]%}‹$(~/.rvm/bin/rvm-prompt i v)›%{$reset_color%}'
+  RPROMPT='%{$fg_bold[red]%}‹$(rvm_current)›%{$reset_color%}'
 else
   if which rbenv &> /dev/null; then
     RPROMPT='%{$fg_bold[red]%}$(rbenv_version)%{$reset_color%}'


### PR DESCRIPTION
Change to print `ruby version` with `gemset name` in right prompt.
It was `<ruby-2.1.5>`
It become `<ruby-2.1.5@project-name>`