### PR TITLE
tmux: reformat source, use $0 for path

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -50,7 +50,7 @@ else
 fi
 
 # Set the correct local config file to use.
-if [[ "$ZSH_TMUX_ITERM2" == "false" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]; then
+if [[ "$ZSH_TMUX_ITERM2" != "true" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]; then
   #use this when they have a ~/.tmux.conf
   export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
 else

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -9,89 +9,82 @@ alias tksv='tmux kill-server'
 alias tkss='tmux kill-session -t'
 
 # Only run if tmux is actually installed
-if which tmux &> /dev/null
-	then
-	# Configuration variables
-	#
-	# Automatically start tmux
-	[[ -n "$ZSH_TMUX_AUTOSTART" ]] || ZSH_TMUX_AUTOSTART=false
-	# Only autostart once. If set to false, tmux will attempt to
-	# autostart every time your zsh configs are reloaded.
-	[[ -n "$ZSH_TMUX_AUTOSTART_ONCE" ]] || ZSH_TMUX_AUTOSTART_ONCE=true
-	# Automatically connect to a previous session if it exists
-	[[ -n "$ZSH_TMUX_AUTOCONNECT" ]] || ZSH_TMUX_AUTOCONNECT=true
-	# Automatically close the terminal when tmux exits
-	[[ -n "$ZSH_TMUX_AUTOQUIT" ]] || ZSH_TMUX_AUTOQUIT=$ZSH_TMUX_AUTOSTART
-	# Set term to screen or screen-256color based on current terminal support
-	[[ -n "$ZSH_TMUX_FIXTERM" ]] || ZSH_TMUX_FIXTERM=true
-	# Set '-CC' option for iTerm2 tmux integration
-	[[ -n "$ZSH_TMUX_ITERM2" ]] || ZSH_TMUX_ITERM2=false
-	# The TERM to use for non-256 color terminals.
-	# Tmux states this should be screen, but you may need to change it on
-	# systems without the proper terminfo
-	[[ -n "$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITHOUT_256COLOR="screen"
-	# The TERM to use for 256 color terminals.
-	# Tmux states this should be screen-256color, but you may need to change it on
-	# systems without the proper terminfo
-	[[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
+if ! which tmux &> /dev/null; then
+  print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin."
+  return 1
+fi
+
+# Configuration variables
+#
+# Automatically start tmux
+[[ -n "$ZSH_TMUX_AUTOSTART" ]] || ZSH_TMUX_AUTOSTART=false
+# Only autostart once. If set to false, tmux will attempt to
+# autostart every time your zsh configs are reloaded.
+[[ -n "$ZSH_TMUX_AUTOSTART_ONCE" ]] || ZSH_TMUX_AUTOSTART_ONCE=true
+# Automatically connect to a previous session if it exists
+[[ -n "$ZSH_TMUX_AUTOCONNECT" ]] || ZSH_TMUX_AUTOCONNECT=true
+# Automatically close the terminal when tmux exits
+[[ -n "$ZSH_TMUX_AUTOQUIT" ]] || ZSH_TMUX_AUTOQUIT=$ZSH_TMUX_AUTOSTART
+# Set term to screen or screen-256color based on current terminal support
+[[ -n "$ZSH_TMUX_FIXTERM" ]] || ZSH_TMUX_FIXTERM=true
+# Set '-CC' option for iTerm2 tmux integration
+[[ -n "$ZSH_TMUX_ITERM2" ]] || ZSH_TMUX_ITERM2=false
+# The TERM to use for non-256 color terminals.
+# Tmux states this should be screen, but you may need to change it on
+# systems without the proper terminfo
+[[ -n "$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITHOUT_256COLOR="screen"
+# The TERM to use for 256 color terminals.
+# Tmux states this should be screen-256color, but you may need to change it on
+# systems without the proper terminfo
+[[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
 
 
-	# Get the absolute path to the current directory
-	local zsh_tmux_plugin_path="$(cd "$(dirname "$0")" && pwd)"
+# Get the absolute path to the current directory
+local zsh_tmux_plugin_path="$(cd "$(dirname "$0")" && pwd)"
 
-	# Determine if the terminal supports 256 colors
-	if [[ `tput colors` == "256" ]]
-	then
-		export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
-	else
-		export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR
-	fi
-
-	# Set the correct local config file to use.
-    if [[ "$ZSH_TMUX_ITERM2" == "false" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]
-	then
-		#use this when they have a ~/.tmux.conf
-		export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
-	else
-		#use this when they don't have a ~/.tmux.conf
-		export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.only.conf"
-	fi
-
-	# Wrapper function for tmux.
-	function _zsh_tmux_plugin_run()
-	{
-		# We have other arguments, just run them
-		if [[ -n "$@" ]]
-		then
-			\tmux $@
-		# Try to connect to an existing session.
-		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
-		then
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
-			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
-		# Just run tmux, fixing the TERM variable if requested.
-		else
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
-			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
-		fi
-	}
-
-	# Use the completions for tmux for our function
-	compdef _tmux _zsh_tmux_plugin_run
-
-	# Alias tmux to our wrapper function.
-	alias tmux=_zsh_tmux_plugin_run
-
-	# Autostart if not already in tmux and enabled.
-	if [[ ! -n "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" ]]
-	then
-		# Actually don't autostart if we already did and multiple autostarts are disabled.
-		if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]
-		then
-			export ZSH_TMUX_AUTOSTARTED=true
-			_zsh_tmux_plugin_run
-		fi
-	fi
+# Determine if the terminal supports 256 colors
+if [[ `tput colors` == "256" ]]; then
+  export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
 else
-	print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin."
+  export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR
+fi
+
+# Set the correct local config file to use.
+if [[ "$ZSH_TMUX_ITERM2" == "false" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]; then
+  #use this when they have a ~/.tmux.conf
+  export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
+else
+  #use this when they don't have a ~/.tmux.conf
+  export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.only.conf"
+fi
+
+# Wrapper function for tmux.
+function _zsh_tmux_plugin_run() {
+  # We have other arguments, just run them
+  if [[ -n "$@" ]]; then
+    \tmux $@
+  # Try to connect to an existing session.
+  elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]; then
+    \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+    [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
+      # Just run tmux, fixing the TERM variable if requested.
+  else
+    \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+    [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
+  fi
+}
+
+# Use the completions for tmux for our function
+compdef _tmux _zsh_tmux_plugin_run
+
+# Alias tmux to our wrapper function.
+alias tmux=_zsh_tmux_plugin_run
+
+# Autostart if not already in tmux and enabled.
+if [[ ! -n "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" ]]; then
+  # Actually don't autostart if we already did and multiple autostarts are disabled.
+  if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]; then
+    export ZSH_TMUX_AUTOSTARTED=true
+    _zsh_tmux_plugin_run
+  fi
 fi

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -39,8 +39,6 @@ fi
 [[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
 
 
-# Get the absolute path to the current directory
-local zsh_tmux_plugin_path=${0:h}
 
 # Determine if the terminal supports 256 colors
 if [[ `tput colors` == "256" ]]; then
@@ -52,10 +50,10 @@ fi
 # Set the correct local config file to use.
 if [[ "$ZSH_TMUX_ITERM2" != "true" ]] && [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]; then
   #use this when they have a ~/.tmux.conf
-  export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"
+  export _ZSH_TMUX_FIXED_CONFIG="${0:h}/tmux.extra.conf"
 else
   #use this when they don't have a ~/.tmux.conf
-  export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.only.conf"
+  export _ZSH_TMUX_FIXED_CONFIG="${0:h}/tmux.only.conf"
 fi
 
 # Wrapper function for tmux.


### PR DESCRIPTION
This reformats the tmux plugin source code for readability and to follow the OMZ Coding Style Guidelines (2 space indent, use spaces and not tabs, `; then` on the same line as `if`). Also refactors to make the really long lines with embedded conditionals more readable.

Uses `$0` instead of shelling out to `cd` to get the path to the script.

I know normally you're advised to just match existing code style in files, but the current source code mixes tabs and spaces and assumes a 4 space tabs, so the formatting is messed up in the web display or in any text editor that's configured for tabs of a different size.

I'm intending to use this reformat before addressing #3937 or other `tmux` stuff.

Fixes #4425 
