### PR TITLE
Encode64 Plugin - Fix wrong `echo` usage

### DIFF
--- a/plugins/encode64/encode64.plugin.zsh
+++ b/plugins/encode64/encode64.plugin.zsh
@@ -1,4 +1,4 @@
-encode64(){ echo -n $1 | base64 }
-decode64(){ echo -n $1 | base64 --decode }
+encode64(){ printf '%s' $1 | base64 }
+decode64(){ printf '%s' $1 | base64 --decode }
 alias e64=encode64
 alias d64=decode64


### PR DESCRIPTION
Currently, encode64 plugin using `echo -n` to print the content
of `$1` variable. This approach will not work with arbitrary data,
which contains sequence of escaped characters, since when many
`echo` implementation will expand them:
```
encode64 '\t\n'
```
is wrong since when it try to generate base64 of string contains a tab, a newline instead of literal `\t` and `\n`.

This commit change the usage to `printf`, which is builtin in all
POSIX shells and can print arbitrary data reliability:
```
printf '%s' '\t\n' | base64
```
will generate base64 of literal `\t` follow by `\n`