### PR TITLE
installer: ignore errors in color setup, for FreeBSD portability

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,5 +1,3 @@
-set -e
-
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
 tput=$(which tput)
@@ -21,6 +19,11 @@ else
   BOLD=""
   NORMAL=""
 fi
+
+# Only enable exit-on-error after the non-critical colorization stuff,
+# which may fail on systems lacking tput or terminfo
+set -e
+
 CHECK_ZSH_INSTALLED=$(grep /zsh$ /etc/shells | wc -l)
 if [ ! $CHECK_ZSH_INSTALLED -ge 1 ]; then
   printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"


### PR DESCRIPTION
This is a hack to keep the installer working on systems without tput/terminfo, including FreeBSD (at least in the default installation for 10.2).

Fixes #4404.
Follows up on #3664.