### PR TITLE
Git: move current_branch() to core

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -6,19 +6,12 @@ zstyle -s ":vcs_info:git:*:-all-" "command" _omz_git_git_cmd
 # Functions
 #
 
-# The current branch name
-# Usage example: git pull origin $(current_branch)
-# Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
-# it's not a symbolic ref, but in a Git repo.
+# The name of the current branch
+# Back-compatibility wrapper for when this function was defined here in
+# the plugin, before being pulled in to core lib/git.zsh as git_current_branch()
+# to fix the core -> git plugin dependency.
 function current_branch() {
-  local ref
-  ref=$($_omz_git_git_cmd symbolic-ref --quiet HEAD 2> /dev/null)
-  local ret=$?
-  if [[ $ret != 0 ]]; then
-    [[ $ret == 128 ]] && return  # no git repo.
-    ref=$($_omz_git_git_cmd rev-parse --short HEAD 2> /dev/null) || return
-  fi
-  echo ${ref#refs/heads/}
+  git_current_branch
 }
 # The list of remotes
 function current_repository() {
@@ -99,7 +92,7 @@ alias gfo='git fetch origin'
 alias gg='git gui citool'
 alias gga='git gui citool --amend'
 ggf() {
-[[ "$#" != 1 ]] && local b="$(current_branch)"
+[[ "$#" != 1 ]] && local b="$(git_current_branch)"
 git push --force origin "${b:=$1}"
 }
 compdef _git ggf=git-checkout
@@ -107,23 +100,23 @@ ggl() {
 if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
 git pull origin "${*}"
 else
-[[ "$#" == 0 ]] && local b="$(current_branch)"
+[[ "$#" == 0 ]] && local b="$(git_current_branch)"
 git pull origin "${b:=$1}"
 fi
 }
 compdef _git ggl=git-checkout
-alias ggpull='git pull origin $(current_branch)'
+alias ggpull='git pull origin $(git_current_branch)'
 compdef _git ggpull=git-checkout
 ggp() {
 if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
 git push origin "${*}"
 else
-[[ "$#" == 0 ]] && local b="$(current_branch)"
+[[ "$#" == 0 ]] && local b="$(git_current_branch)"
 git push origin "${b:=$1}"
 fi
 }
 compdef _git ggp=git-checkout
-alias ggpush='git push origin $(current_branch)'
+alias ggpush='git push origin $(git_current_branch)'
 compdef _git ggpush=git-checkout
 ggpnp() {
 if [[ "$#" == 0 ]]; then
@@ -133,9 +126,9 @@ ggl "${*}" && ggp "${*}"
 fi
 }
 compdef _git ggpnp=git-checkout
-alias ggsup='git branch --set-upstream-to=origin/$(current_branch)'
+alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 ggu() {
-[[ "$#" != 1 ]] && local b="$(current_branch)"
+[[ "$#" != 1 ]] && local b="$(git_current_branch)"
 git pull --rebase origin "${b:=$1}"
 }
 compdef _git ggu=git-checkout

--- a/themes/eastwood.zsh-theme
+++ b/themes/eastwood.zsh-theme
@@ -14,9 +14,9 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 # Customized git status, oh-my-zsh currently does not allow render dirty status before branch
 git_custom_status() {
-  local cb=$(current_branch)
+  local cb=$(git_current_branch)
   if [ -n "$cb" ]; then
-    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$(git_current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
 }
 

--- a/themes/gallois.zsh-theme
+++ b/themes/gallois.zsh-theme
@@ -1,3 +1,5 @@
+# Depends on the git plugin for work_in_progress()
+
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}["
 ZSH_THEME_GIT_PROMPT_SUFFIX="]%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}*%{$reset_color%}"
@@ -5,9 +7,9 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 #Customized git status, oh-my-zsh currently does not allow render dirty status before branch
 git_custom_status() {
-  local cb=$(current_branch)
+  local cb=$(git_current_branch)
   if [ -n "$cb" ]; then
-    echo "$(parse_git_dirty)%{$fg_bold[yellow]%}$(work_in_progress)%{$reset_color%}$ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    echo "$(parse_git_dirty)%{$fg_bold[yellow]%}$(work_in_progress)%{$reset_color%}$ZSH_THEME_GIT_PROMPT_PREFIX$(git_current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
 }
 

--- a/themes/josh.zsh-theme
+++ b/themes/josh.zsh-theme
@@ -9,7 +9,7 @@ function josh_prompt {
   (( spare_width = ${COLUMNS} ))
   prompt=" "
 
-  branch=$(current_branch)
+  branch=$(git_current_branch)
   ruby_version=$(rvm_prompt_info || rbenv_prompt_info)
   path_size=${#PWD}
   branch_size=${#branch}
@@ -31,7 +31,7 @@ function josh_prompt {
     prompt=" $prompt"
   done
   
-  prompt="%{%F{green}%}$PWD$prompt%{%F{red}%}$(rvm_prompt_info || rbenv_prompt_info)%{$reset_color%} $(current_branch)"
+  prompt="%{%F{green}%}$PWD$prompt%{%F{red}%}$(rvm_prompt_info || rbenv_prompt_info)%{$reset_color%} $(git_current_branch)"
   
   echo $prompt
 }

--- a/themes/juanghurtado.zsh-theme
+++ b/themes/juanghurtado.zsh-theme
@@ -1,5 +1,3 @@
-# Needs Git plugin for current_branch method
-
 # Color shortcuts
 RED=$fg[red]
 YELLOW=$fg[yellow]
@@ -40,4 +38,4 @@ ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$WHITE%}]"
 PROMPT='
 %{$GREEN_BOLD%}%n@%m%{$WHITE%}:%{$YELLOW%}%~%u$(parse_git_dirty)$(git_prompt_ahead)%{$RESET_COLOR%}
 %{$BLUE%}>%{$RESET_COLOR%} '
-RPROMPT='%{$GREEN_BOLD%}$(current_branch)$(git_prompt_short_sha)$(git_prompt_status)%{$RESET_COLOR%}'
+RPROMPT='%{$GREEN_BOLD%}$(git_current_branch)$(git_prompt_short_sha)$(git_prompt_status)%{$RESET_COLOR%}'

--- a/themes/mortalscumbag.zsh-theme
+++ b/themes/mortalscumbag.zsh-theme
@@ -5,7 +5,7 @@ function my_git_prompt() {
   STATUS=""
 
   # is branch ahead?
-  if $(echo "$(git log origin/$(current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
+  if $(echo "$(git log origin/$(git_current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
     STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
 
@@ -37,7 +37,7 @@ function my_git_prompt() {
 }
 
 function my_current_branch() {
-  echo $(current_branch || echo "(no branch)")
+  echo $(git_current_branch || echo "(no branch)")
 }
 
 function ssh_connection() {

--- a/themes/peepcode.zsh-theme
+++ b/themes/peepcode.zsh-theme
@@ -28,7 +28,7 @@ git_dirty() {
 }
 
 git_prompt() {
-  local cb=$(current_branch)
+  local cb=$(git_current_branch)
   if [ -n "$cb" ]; then
     local repo_path=$(git_repo_path)
     echo " %{$fg_bold[grey]%}$cb %{$fg[white]%}$(git_commit_id)%{$reset_color%}$(git_mode)$(git_dirty)"

--- a/themes/sunrise.zsh-theme
+++ b/themes/sunrise.zsh-theme
@@ -1,6 +1,5 @@
 # Sunrise theme for oh-my-zsh
 # Intended to be used with Solarized: http://ethanschoonover.com/solarized
-# (Needs Git plugin for current_branch method)
 
 # Color shortcuts
 R=$fg_no_bold[red]


### PR DESCRIPTION
Moves the `current_branch()` function from the `git` plugin to the core `lib/git.zsh`, since there are other functions in core OMZ or in themes that depend on it, and we don't want any core -> plugin dependencies.

Fixes #4085 
Fixes #4059 
Fixes #331
Fixes #4581