### PR TITLE
completion: turn off the #3889 compfix check by default

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -11,6 +11,8 @@ fpath=($ZSH/functions $ZSH/completions $fpath)
 # Load all stock functions (from $fpath files) called below.
 autoload -U compaudit compinit
 
+: ${ZSH_DISABLE_COMPFIX:=true}
+
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$ZSH_CUSTOM" ]]; then
@@ -62,13 +64,17 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-# If completion insecurities exist, warn the user without enabling completions.
-if ! compaudit &>/dev/null; then
-  # This function resides in the "lib/compfix.zsh" script sourced above.
-  handle_completion_insecurities
-# Else, enable and cache completions to the desired file.
+if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+  # If completion insecurities exist, warn the user without enabling completions.
+  if ! compaudit &>/dev/null; then
+    # This function resides in the "lib/compfix.zsh" script sourced above.
+    handle_completion_insecurities
+  # Else, enable and cache completions to the desired file.
+  else
+    compinit -d "${ZSH_COMPDUMP}"
+  fi
 else
-  compinit -d "${ZSH_COMPDUMP}"
+  compinit -i -d "${ZSH_COMPDUMP}"
 fi
 
 # Load all of the plugins that were defined in ~/.zshrc


### PR DESCRIPTION
This turns off the insecure-completion-dir checking from #3889 by default but still leaves it in the codebase. Adds a `$ZSH_DISABLE_COMPFIX` to control it, and makes it true by default.

This will let us do some more testing on the #3889 stuff before making it the default for everyone. It's complex.

Fixes #4383 
Fixes #4388 
