### PR TITLE
Update simulator shortcut for XCode 7

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -178,8 +178,13 @@ function simulator {
   # Xcode ≤ 5.x
   if [[ -d "${devfolder}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app" ]]; then
     open "${devfolder}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"
-  # Xcode ≥ 6.x
   else
-    open "${devfolder}/Applications/iOS Simulator.app"
+    # Xcode 6.x
+    if [[ -d "${devfolder}/Applications/iOS Simulator.app" ]]; then
+      open "${devfolder}/Applications/iOS Simulator.app"
+    # Xcode ≥ 7.x
+    else
+      "${devfolder}/Applications/Simulator.app"
+    fi
   fi
 }


### PR DESCRIPTION
The location of the simulator has changed in XCode 7. It's now `"${devfolder}/Applications/Simulator.app"`. I've added an extra if to check for XCode 7 and change the path accordingly.