### PR TITLE
lib/git.zsh: Added git_commits_behind function

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -86,7 +86,7 @@ function git_commits_ahead() {
 # Gets the number of commits behind remote
 function git_commits_behind() {
   if $(command git rev-parse --git-dir > /dev/null 2>&1); then
-    echo $(git rev-list --count $(current_branch)..$(git rev-parse --abbrev-ref --symbolic-full-name @{u}))
+    echo $(git rev-list --count HEAD..@{upstream})
   fi
 }
 

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -83,6 +83,13 @@ function git_commits_ahead() {
   fi
 }
 
+# Gets the number of commits behind remote
+function git_commits_behind() {
+  if git rev-parse --git-dir > /dev/null 2>&1; then
+    echo $(git rev-list --count $(current_branch)..$(git rev-parse --abbrev-ref --symbolic-full-name @{u}))
+  fi
+}
+
 # Outputs if current branch is ahead of remote
 function git_prompt_ahead() {
   if [[ -n "$(command git rev-list origin/$(git_current_branch)..HEAD 2> /dev/null)" ]]; then

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -85,7 +85,7 @@ function git_commits_ahead() {
 
 # Gets the number of commits behind remote
 function git_commits_behind() {
-  if git rev-parse --git-dir > /dev/null 2>&1; then
+  if $(command git rev-parse --git-dir > /dev/null 2>&1); then
     echo $(git rev-list --count $(current_branch)..$(git rev-parse --abbrev-ref --symbolic-full-name @{u}))
   fi
 }


### PR DESCRIPTION
When updating my git prompt, I noticed there was a function for git_commits_ahead, but not one for git_commits_behind. The whitespace edit was an unintentional side effect from emacs.