### PR TITLE
Fix 'ack-grep' bug for non-ubuntu users

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -22,7 +22,7 @@ alias _='sudo'
 alias please='sudo'
 
 ## more intelligent acking for ubuntu users
-if which ack-grep > /dev/null;
+if which ack-grep &> /dev/null;
 then
   alias afind='ack-grep -il'
 else


### PR DESCRIPTION
Redirect STDERR along with STDOUT when looking for ack-grep

Fixes #4454
Closes #4456