### PR TITLE
Fix error when ack-grep is not found

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -22,7 +22,7 @@ alias _='sudo'
 alias please='sudo'
 
 ## more intelligent acking for ubuntu users
-if which ack-grep > /dev/null;
+if which ack-grep > /dev/null 2>&1;
 then
   alias afind='ack-grep -il'
 else


### PR DESCRIPTION
The `which` command may send output to stderr when the resulting path is not found (i.e. an error is encountered). That error output must be discarded.