### PR TITLE
Ask for confirmation before uninstall

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,3 +1,10 @@
+read -r -p "Are you sure you want to remove Oh My Zsh? [y/N] " confirmation
+if ! [[ $confirmation =~ ^[yY]$ ]]
+then
+    echo "Uninstall cancelled"
+    exit
+fi
+
 echo "Removing ~/.oh-my-zsh"
 if [ -d ~/.oh-my-zsh ]
 then


### PR DESCRIPTION
I lost a bunch of configs this afternoon because uninstall_oh_my_zsh was in my path and I accidentally executed it (betrayed by tab completion...), so here is a patch to ask before removing stuff, so this doesn't happen again.