### PR TITLE
colored-man plugin: Quoted PATH variable

### DIFF
--- a/plugins/colored-man/colored-man.plugin.zsh
+++ b/plugins/colored-man/colored-man.plugin.zsh
@@ -27,6 +27,6 @@ man() {
 	  LESS_TERMCAP_us=$(printf "\e[1;32m") \
 	  PAGER=/usr/bin/less \
 	  _NROFF_U=1 \
-	  PATH=${HOME}/bin:${PATH} \
+	  "PATH=${HOME}/bin:${PATH}" \
 	  			   man "$@"
 }


### PR DESCRIPTION
Some environments (in my case, cygwin) have PATH variables with directories with spaces in them, breaking colored-man. Adding quotes around the PATH environment variable makes the plugin run OK.