### PR TITLE
Disable bracketed-paste-magic in zsh 5.1.1, where it is buggy

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,14 +1,19 @@
 ## Load smart urls if available
-for d in $fpath; do
-	if [[ -e "$d/url-quote-magic" ]]; then
-		if [[ -e "$d/bracketed-paste-magic" ]]; then
-			autoload -Uz bracketed-paste-magic
-			zle -N bracketed-paste bracketed-paste-magic
-		fi
-		autoload -U url-quote-magic
-		zle -N self-insert url-quote-magic
-	fi
-done
+# bracketed-paste-magic is known buggy in zsh 5.1.1 (only), so skip it there; see #4434
+autoload -Uz is-at-least
+if [[ $ZSH_VERSION != 5.1.1 ]]; then
+  for d in $fpath; do
+  	if [[ -e "$d/url-quote-magic" ]]; then
+  		if is-at-least 5.1; then
+  			autoload -Uz bracketed-paste-magic
+  			zle -N bracketed-paste bracketed-paste-magic
+  		fi
+  		autoload -Uz url-quote-magic
+  		zle -N self-insert url-quote-magic
+      break
+  	fi
+  done
+fi
 
 ## jobs
 setopt long_list_jobs
@@ -22,8 +27,7 @@ alias _='sudo'
 alias please='sudo'
 
 ## more intelligent acking for ubuntu users
-if which ack-grep &> /dev/null;
-then
+if which ack-grep &> /dev/null; then
   alias afind='ack-grep -il'
 else
   alias afind='ack -il'


### PR DESCRIPTION
Fixes #4434 (at least as much as it can be fixed).
Fixes #4452 

There is a bracketed-paste-magic bug specific to zsh 5.1.1 that can cause input to hang after pasting certain characters if bracketed-paste-magic is enabled as an input widget. To reproduce, run `zsh 5.1.1` and paste 日本語 into your terminal.

This PR works around it by checking for zsh 5.1.1, and not enabling bracketed-paste-magic for that version. Also disables url-quote-magic for that version, because since zsh 5.1, url-quote-magic requires bracketed-paste-magic.

