### PR TITLE
Allow more flexability in update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -43,7 +43,7 @@ then
     else
       echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
       read line
-      if [ "$line" = Y ] || [ "$line" = y ] || [ -z "$line" ]; then
+      if [[ "$line" = [Yy]* ]] || [ -z "$line" ]; then
         _upgrade_zsh
       else
         _update_zsh_update


### PR DESCRIPTION
Allows users to enter responses such as 'yes', 'yeah', 'yup', etc. for greater flexibility. This also helps the oh-my-zsh updater to conform with common bash conventions.