### PR TITLE
add alias to sort by version

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -212,6 +212,7 @@ alias gsts='git stash show --text'
 alias gsu='git submodule update'
 
 alias gts='git tag -s'
+alias gtv='git tag | sort -V'
 
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'


### PR DESCRIPTION
an alias I find very helpful when checking the most current version of a project to prevent cases such as:

v2.3.17
v2.3.18
v2.3.19
v2.3.2 -> this isn't a most current version

with "| sort -V"

v2.3.2
v2.3.3
v2.3.4
v2.3.5
v2.3.6
v2.3.7
v2.3.8
v2.3.9
v2.3.10
v2.3.11
v2.3.12
v2.3.13
v2.3.14
v2.3.15
v2.3.16
v2.3.17
v2.3.18
v2.3.19 -> Now we have the current version \o/



