### PR TITLE
autoenv: actually source autoenv once located

### DIFF
--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -17,6 +17,7 @@ In the meantime the autoenv plugin is DISABLED.
 END
     return 1
   fi
+  source $autoenv_dir/activate.sh
 fi
 }
 [[ $? != 0 ]] && return $?


### PR DESCRIPTION
Fixes bug introduced in #4440. This bug will prevent autoenv from actually being loaded, even if it is found.