### PR TITLE
Also check for non-system-wide ZSH installation.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -21,7 +21,7 @@ else
   BOLD=""
   NORMAL=""
 fi
-CHECK_ZSH_INSTALLED=$(grep /zsh$ /etc/shells | wc -l)
+CHECK_ZSH_INSTALLED=$((grep /zsh$ /etc/shells || whereis zsh) | wc -l)
 if [ ! $CHECK_ZSH_INSTALLED -ge 1 ]; then
   printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"
   exit


### PR DESCRIPTION
Some users don't have root access on machines and the machines do not have zsh
installed. They can still have zsh installed in their own $HOME. The install
script should also check for that otherwise will report ZSH Not Installed.