### PR TITLE
gulp plugin support for babel (and other compilers?)

### DIFF
--- a/plugins/gulp/gulp.plugin.zsh
+++ b/plugins/gulp/gulp.plugin.zsh
@@ -2,12 +2,12 @@
 
 #
 # gulp-autocompletion-zsh
-# 
+#
 # Autocompletion for your gulp.js tasks
 #
 # Copyright(c) 2014 André König <andre.koenig@posteo.de>
 # MIT Licensed
-# 
+#
 
 #
 # André König
@@ -20,7 +20,7 @@
 # in the current directory.
 #
 function $$gulp_completion {
-    compls="$(grep -Eo "gulp.task\((['\"](([a-zA-Z0-9]|-)*)['\"],)" gulpfile.js 2>/dev/null | grep -Eo "['\"](([a-zA-Z0-9]|-)*)['\"]" | sed s/"['\"]"//g | sort)"
+    compls="$(grep -Eo "gulp.task\((['\"](([a-zA-Z0-9]|-)*)['\"],)" gulpfile*.js 2>/dev/null | grep -Eo "['\"](([a-zA-Z0-9]|-)*)['\"]" | sed s/"['\"]"//g | sort)"
 
     completions=(${=compls})
     compadd -- $completions


### PR DESCRIPTION
This simple change adds wildcard support to `gulpfile*.js`. Mine for example is named `gulpfile.babel.js` which enables the babel compiler to be used in the gulpfile.