### PR TITLE
Add support in profiles plugin for directories

### DIFF
--- a/plugins/profiles/profiles.plugin.zsh
+++ b/plugins/profiles/profiles.plugin.zsh
@@ -6,7 +6,11 @@ parts=(${(s:.:)HOST})
 for i in {${#parts}..1}; do
   profile=${(j:.:)${parts[$i,${#parts}]}}
   file=$ZSH_CUSTOM/profiles/$profile
-  if [ -f $file ]; then
+  if [ -d $file ]; then
+    for config_file ($file/*.zsh(N)); do
+      source $config_file
+    done
+  elif [ -f $file ]; then
     source $file
   fi
 done


### PR DESCRIPTION
The profiles plugin currently has support to load a single "profile"
file for each component in the FQDN. This changeset makes it so the
plugin supports the filename actually being a directory with multiple
*.zsh files in it. Each of those files are then loaded in alphabetical
order