### PR TITLE
Tweak pyenv plugin

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -18,6 +18,7 @@ for pyenvdir in "${pyenvdirs[@]}" ; do
         export PYENV_ROOT=$pyenvdir
         export PATH=${pyenvdir}/bin:$PATH
         eval "$(pyenv init --no-rehash - zsh)"
+        eval "$(pyenv virtualenv-init - zsh)"
 
         function pyenv_prompt_info() {
             echo "$(pyenv version-name)"

--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -17,7 +17,7 @@ for pyenvdir in "${pyenvdirs[@]}" ; do
         FOUND_PYENV=1
         export PYENV_ROOT=$pyenvdir
         export PATH=${pyenvdir}/bin:$PATH
-        eval "$(pyenv init --no-rehash - zsh)"
+        eval "$(pyenv init - zsh)"
         eval "$(pyenv virtualenv-init - zsh)"
 
         function pyenv_prompt_info() {


### PR DESCRIPTION
I use pyenv a lot, but the inbuilt plugin is missing a few things, so I thought I'd update it.

1. 8a95ced - Initialize pyenv virtualenvs, to get autocompletion for them.
2. 8a362b2 - Re-enable pyenv rehashing. It's useful, so not sure why it's disabled.

Let me know if this is OK!