### PR TITLE
Add the alias mvncv and mvncvst

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -45,6 +45,8 @@ mvn-color()
 alias mvncie='mvn clean install eclipse:eclipse'
 alias mvnci='mvn clean install'
 alias mvncist='mvn clean install -DskipTests'
+alias mvncv='mvn clean verify'
+alias mvncvst='mvn clean verify -DskipTests'
 alias mvne='mvn eclipse:eclipse'
 alias mvnce='mvn clean eclipse:clean eclipse:eclipse'
 alias mvnd='mvn deploy'


### PR DESCRIPTION
I often use the phase verify when using Maven, so I propose to include these 2 aliases into the mvn plugin.
