### PR TITLE
[FIX ERROR] Refactor for function in plugins/rake-fast/rake-fast.plugin.zsh

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -8,17 +8,7 @@ _rake_refresh () {
 }
 
 _rake_does_task_list_need_generating () {
-  if [ ! -f .rake_tasks ]; then return 0;
-  else
-    if [[ "$OSTYPE" = darwin* ]]; then
-      accurate=$(stat -f%m .rake_tasks)
-      changed=$(stat -f%m Rakefile)
-    else
-      accurate=$(stat -c%Y .rake_tasks)
-      changed=$(stat -c%Y Rakefile)
-    fi
-    return $(expr $accurate '>=' $changed)
-  fi
+  [[ ! -f .rake_tasks ]] || [[ Rakefile -nt .rake_tasks ]]
 }
 
 _rake_generate () {


### PR DESCRIPTION
# WHAT
I refactored rake-fast plugin.

# WHY
If this plugin condition is `[[ "$OSTYPE" = darwin* ]];`,  the case of my stat An error will occur.
My stat doesn't have -c option because I'm using GNU core utilities that was installed in the Homebrew.

# ERROR LOGS
My environments:
OS: OS X Yosemite
stat: 8.24 (GNU core utilities)
```
$ rake [TAB] 
Try 'stat --help' for more information.
stat: invalid option -- '%'
Try 'stat --help' for more information.

_rake_does_task_list_need_generating:10: bad math expression: operand expected at `>='
stat: invalid option -- '%'
Try 'stat --help' for more information.
stat: invalid option -- '%'
Try 'stat --help' for more information.
_rake_does_task_list_need_generating:10: bad math expression: operand expected at `>='
stat: invalid option -- '%'
Try 'stat --help' for more information.
stat: invalid option -- '%'
Try 'stat --help' for more information.
_rake_does_task_list_need_generating:10: bad math expression: operand expected at `>='
```