### PR TITLE
Replace rvm specific code to generic ruby_info for alanpeabody.zsh-theme

### DIFF
--- a/themes/alanpeabody.zsh-theme
+++ b/themes/alanpeabody.zsh-theme
@@ -1,14 +1,8 @@
 
 local user='%{$fg[magenta]%}%n@%{$fg[magenta]%}%m%{$reset_color%}'
 local pwd='%{$fg[blue]%}%~%{$reset_color%}'
-local rvm=''
-if which rvm-prompt &> /dev/null; then
-  rvm='%{$fg[green]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    rvm='%{$fg[green]%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
-  fi
-fi
+
+local ruby_info='%{$fg[green]%}‹$(ruby_prompt_info)›%{$reset_color%}'
 local return_code='%(?..%{$fg[red]%}%? ↵%{$reset_color%})'
 local git_branch='$(git_prompt_status)%{$reset_color%}$(git_prompt_info)%{$reset_color%}'
 
@@ -25,4 +19,4 @@ ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[yellow]%} ═"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%} ✭"
 
 PROMPT="${user} ${pwd}$ "
-RPROMPT="${return_code} ${git_branch} ${rvm}"
+RPROMPT="${return_code} ${git_branch} ${ruby_info}"


### PR DESCRIPTION
I replace these logic rvm specific code to generic `#ruby_info` provide in oh-my-zsh.

So that it show ruby-version as well once you add `chruby` plugin in .zshrc
