### PR TITLE
Fix install.sh/upgrade.sh for tput-less systems

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,9 +2,8 @@ set -e
 
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
-tput=$(which tput)
-if [ -n "$tput" ]; then
-    ncolors=$($tput colors)
+if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
 fi
 if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
   RED="$(tput setaf 1)"

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,8 +1,7 @@
 
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
-tput=$(which tput)
-if [ -n "$tput" ]; then
+if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
 fi
 if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then


### PR DESCRIPTION
@fcrozat's original fix assumes `which` not to output anything to STDOUT
in case the command is not found. That is not necessarily true on all
systems. A better solution is to check the return value instead.

Fixes #4376.
Supersedes #4496.