### PR TITLE
Make install script safer

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,3 +1,4 @@
+function main() {
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
 tput=$(which tput)
@@ -117,3 +118,6 @@ echo 'p.p.s. Get stickers and t-shirts at http://shop.planetargon.com.'
 echo ''
 printf "${NORMAL}"
 env zsh
+}
+
+main


### PR DESCRIPTION
This changeset wraps all of the commands in tools/install.sh in a
function and then calls that function as the last line of the
script.

The current install instructions ask the user to download the install
script using `curl` and pass the result to `sh`. This is totally
fine (as long as both the instructions and the script itself are served
using HTTPS), but the script should be written in a way such that it
doesn't start trying to actually *do* anything until the very last line.

The reason is due to the way `curl` works: if the socket drops before the
request is complete (server abruptly hangs up, client's internet flakes
out, etc.), `curl` will return the partial data that it received. Here
is an example of that:

![partial file execution](https://cldup.com/qU_Mnh2GmT.png)

A way this might cause issues for tools/install.sh is if the connection drops
after cloning but before the repository (L53-56). The .zshrc
configuration will not be copied and the shell will not be changed, but
if the user tries to run the install script again it will claim
oh-my-zsh is already installed (L31-39).

While this is not a particularly dangerous error condition (the user can
just delete .oh-my-zsh and re-run), it can certainly be confusing for
new users. This also helps future-proof the script for a time when it
might need to use a "dangerous" command, e.g. `rm`, and we want to make
sure it happens in the most transactional way possible.