### PR TITLE
Fix `vagrant`'s completion

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -79,7 +79,7 @@ __vagrant-box ()
 
    case $state in
        (command)
-           _describe -t commands "gem subcommand" _box_arguments
+           _describe -t commands "vagrant subcommand" _box_arguments
            return
        ;;
 
@@ -108,7 +108,7 @@ _arguments -C \
 
 case $state in
   (command)
-      _describe -t commands "gem subcommand" _1st_arguments
+      _describe -t commands "vagrant subcommand" _1st_arguments
       return
   ;;
 


### PR DESCRIPTION
When completing `vagrant` commands, it says “Completing _gem_ subcommand.” Oops. :P
