### PR TITLE
Add option to disable calling compinit. 

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -64,19 +64,21 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-  # If completion insecurities exist, warn the user without enabling completions.
-  if ! compaudit &>/dev/null; then
-    # This function resides in the "lib/compfix.zsh" script sourced above.
-    handle_completion_insecurities
-  # Else, enable and cache completions to the desired file.
-  else
-    compinit -d "${ZSH_COMPDUMP}"
-  fi
-else
-  compinit -i -d "${ZSH_COMPDUMP}"
-fi
 
+if [[ $ZSH_DISABLE_COMPINIT != true ]]; then
+  if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+      # If completion insecurities exist, warn the user without enabling completions.
+      if ! compaudit &>/dev/null; then
+        # This function resides in the "lib/compfix.zsh" script sourced above.
+        handle_completion_insecurities
+      # Else, enable and cache completions to the desired file.
+      else
+        compinit -d "${ZSH_COMPDUMP}"
+      fi
+  else
+      compinit -i -d "${ZSH_COMPDUMP}"
+  fi
+fi
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
   if [ -f $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh ]; then

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -67,16 +67,16 @@ fi
 
 if [[ $ZSH_DISABLE_COMPINIT != true ]]; then
   if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-      # If completion insecurities exist, warn the user without enabling completions.
-      if ! compaudit &>/dev/null; then
-        # This function resides in the "lib/compfix.zsh" script sourced above.
-        handle_completion_insecurities
-      # Else, enable and cache completions to the desired file.
-      else
-        compinit -d "${ZSH_COMPDUMP}"
-      fi
+    # If completion insecurities exist, warn the user without enabling completions.
+    if ! compaudit &>/dev/null; then
+      # This function resides in the "lib/compfix.zsh" script sourced above.
+      handle_completion_insecurities
+    # Else, enable and cache completions to the desired file.
+    else
+      compinit -d "${ZSH_COMPDUMP}"
+    fi
   else
-      compinit -i -d "${ZSH_COMPDUMP}"
+    compinit -i -d "${ZSH_COMPDUMP}"
   fi
 fi
 # Load all of the plugins that were defined in ~/.zshrc


### PR DESCRIPTION
Add variable `ZSH_DISABLE_COMPINIT`. When set to true, stops omzsh from invoking `compinit`.

Particularly useful when Omzsh is being used as a plugin by zgen, antigen, etc., and the user wants to call `compinit` later.
