### PR TITLE
Fix open_command inside tmux

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -17,6 +17,7 @@ function take() {
 
 function open_command() {
   local open_cmd
+  local nohup
 
   # define the open command
   case "$OSTYPE" in
@@ -28,7 +29,14 @@ function open_command() {
               ;;
   esac
 
-  nohup $open_cmd "$@" &>/dev/null
+  # Use nohup command
+  if [ ${TMUX:-NOT_USE_TMUX} = "NOT_USE_TMUX" ]; then
+    nohup="nohup"
+  else
+    nohup=""
+  fi
+
+  $nohup $open_cmd "$@" &>/dev/null
 }
 
 #


### PR DESCRIPTION
I want to use `open_command` inside tmux.

```
$ tmux
$ nohup open .
appending output to nohup.out
$ cat nohup.out
nohup: can't detach from console: No such file or directory
```

So, I modified `open_command` what not use nohup command inside tmux.

see also: http://stackoverflow.com/questions/23898623/nohup-cant-detach-from-console#comment36797854_23898623
