### PR TITLE
Added "-n name" option to vim-interaction plugin

### DIFF
--- a/plugins/vim-interaction/vim-interaction.plugin.zsh
+++ b/plugins/vim-interaction/vim-interaction.plugin.zsh
@@ -8,10 +8,11 @@ function callvim
 {
   if [[ $# == 0 ]]; then
     cat <<EOH
-usage: callvim [-b cmd] [-a cmd] [file ... fileN]
+usage: callvim [-b cmd] [-a cmd] [-n name] [file ... fileN]
 
   -b cmd     Run this command in GVIM before editing the first file
   -a cmd     Run this command in GVIM after editing the first file
+  -n name    Name of the GVIM server to connect to
   file       The file to edit
   ... fileN  The other files to add to the argslist
 EOH
@@ -21,12 +22,15 @@ EOH
   local cmd=""
   local before="<esc>"
   local after=""
-  while getopts ":b:a:" option
+  local name="GVIM"
+  while getopts ":b:a:n:" option
   do
     case $option in
       a) after="$OPTARG"
          ;;
       b) before="$OPTARG"
+         ;;
+      n) name="$OPTARG"
          ;;
     esac
   done
@@ -43,7 +47,7 @@ EOH
     files=':args! '"${@:A:q}<cr>"
   fi
   cmd="$before$files$after"
-  gvim --remote-send "$cmd"
+  gvim --servername "$name" --remote-send "$cmd"
   if typeset -f postCallVim > /dev/null; then
     postCallVim
   fi


### PR DESCRIPTION
If you are working with many GVim sessions, you need to be able to specify which server to send a file to. This does just that. For example:

$ gvim --servername test file1.txt
$ vvsp -n test file2.txt
