### PR TITLE
Fixed special chars error on plugins names and paths

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -38,12 +38,11 @@ done
 is_plugin() {
   local base_dir=$1
   local name=$2
-  test -f $base_dir/plugins/$name/$name.plugin.zsh \
-    || test -f $base_dir/plugins/$name/_$name
+   [[ -f $base_dir/plugins/$name/$name.plugin.zsh ]] || [[ -f $base_dir/plugins/$name/_$name ]]
 }
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
-for plugin ($plugins); do
+for plugin ("$plugins"); do
   if is_plugin $ZSH_CUSTOM $plugin; then
     fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
   elif is_plugin $ZSH $plugin; then


### PR DESCRIPTION
I was getting the following error:

```
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too many arguments
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too many arguments
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too many arguments
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too many arguments
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too many arguments
is_plugin:cd:4: too many arguments
is_plugin:cd:3: too man..
```

Due to special chars on plugins paths.