### PR TITLE
[FIX #4525]: Fix typo

### DIFF
--- a/plugins/git-extras/git-extras.plugin.zsh
+++ b/plugins/git-extras/git-extras.plugin.zsh
@@ -302,7 +302,7 @@ zstyle ':completion:*:*:git:*' user-commands \
     count:'count commits' \
     create-branch:'create local and remote branch' \
     delete-branch:'delete local and remote branch' \
-    delete-merged-brancees:'delete merged branches'\
+    delete-merged-branches:'delete merged branches'\
     delete-submodule:'delete submodule' \
     delete-tag:'delete local and remote tag' \
     effort:'display effort statistics' \


### PR DESCRIPTION
# WHAT
I fixed typo in `plugins/git-extras/git-extras.plugin.zsh`.

# REF
https://github.com/robbyrussell/oh-my-zsh/issues/4525