### PR TITLE
Use builtin cd and pwd in tmux plugin

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -37,7 +37,7 @@ if which tmux &> /dev/null
 
 
 	# Get the absolute path to the current directory
-	local zsh_tmux_plugin_path="$(cd "$(dirname "$0")" && pwd)"
+	local zsh_tmux_plugin_path="$(builtin cd "$(dirname "$0")" && builtin pwd)"
 
 	# Determine if the terminal supports 256 colors
 	if [[ `tput colors` == "256" ]]


### PR DESCRIPTION
Use the builtin `cd` and `pwd`, as these could have been overridden by aliases or other plugins.