### PR TITLE
Drop the use of nohup on OSX for tmux compatibility

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -28,7 +28,10 @@ function open_command() {
               ;;
   esac
 
-  nohup $open_cmd "$@" &>/dev/null
+  # don't use nohup on OSX
+  [[ "$OSTYPE" != darwin* ]] && open_cmd="nohup $open_cmd"
+
+  $open_cmd "$@" &>/dev/null
 }
 
 #
@@ -67,7 +70,7 @@ function try_alias_value() {
 #
 # Arguments:
 #    1. name - The variable to set
-#    2. val  - The default value 
+#    2. val  - The default value
 # Return value:
 #    0 if the variable exists, 3 if it was set
 #
@@ -81,12 +84,12 @@ function default() {
 #
 # Arguments:
 #    1. name - The env variable to set
-#    2. val  - The default value 
+#    2. val  - The default value
 # Return value:
 #    0 if the env variable exists, 3 if it was set
 #
 function env_default() {
-    env | grep -q "^$1=" && return 0 
+    env | grep -q "^$1=" && return 0
     export "$1=$2"       && return 3
 }
 
@@ -101,7 +104,7 @@ zmodload zsh/langinfo
 #
 # By default, reserved characters and unreserved "mark" characters are
 # not escaped by this function. This allows the common usage of passing
-# an entire URL in, and encoding just special characters in it, with 
+# an entire URL in, and encoding just special characters in it, with
 # the expectation that reserved and mark characters are used appropriately.
 # The -r and -m options turn on escaping of the reserved and mark characters,
 # respectively, which allows arbitrary strings to be fully escaped for
@@ -112,7 +115,7 @@ zmodload zsh/langinfo
 #
 # Usage:
 #  omz_urlencode [-r] [-m] <string>
-#  
+#
 #    -r causes reserved characters (;/?:@&=+$,) to be escaped
 #
 #    -m causes "mark" characters (_.!~*''()-) to be escaped
@@ -177,8 +180,8 @@ function omz_urlencode() {
 # URL-decode a string
 #
 # Decodes a RFC 2396 URL-encoded (%-escaped) string.
-# This decodes the '+' and '%' escapes in the input string, and leaves 
-# other characters unchanged. Does not enforce that the input is a 
+# This decodes the '+' and '%' escapes in the input string, and leaves
+# other characters unchanged. Does not enforce that the input is a
 # valid URL-encoded string. This is a convenience to allow callers to
 # pass in a full URL or similar strings and decode them for human
 # presentation.
@@ -196,7 +199,7 @@ function omz_urldecode {
   local caller_encoding=$langinfo[CODESET]
   local LC_ALL=C
   export LC_ALL
-  
+
   # Change + back to ' '
   local tmp=${encoded_url:gs/+/ /}
   # Protect other escapes to pass through the printf unchanged
@@ -220,4 +223,3 @@ function omz_urldecode {
 
   echo -E "$decoded"
 }
-


### PR DESCRIPTION
Apparently `nohup` is not needed in OSX, and using it has the side that it may break under tmux with the error

    nohup: can't detach from console: No such file or directory

For now, this commit only drops the use of `nohup` in OSX. But it *may* not be necessary under other similar platforms.

Fixes #4520 