### PR TITLE
Add OSX support for command-not-found

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -23,3 +23,11 @@ if [ -f /usr/libexec/pk-command-not-found ]; then
         return $retval
     }
 fi
+
+# OSX command-not-found support
+# https://github.com/Homebrew/homebrew-command-not-found
+if type brew &> /dev/null; then
+  if brew command command-not-found-init > /dev/null 2>&1; then
+    eval "$(brew command-not-found-init)";
+  fi
+fi


### PR DESCRIPTION
Added support for Brew on OSX.
Using command-not-found for Brew found at https://github.com/Homebrew/homebrew-command-not-found.

Close #4150