### PR TITLE
Update autojump.plugin.zsh

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -19,5 +19,5 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . `brew --prefix`/etc/autojump.sh
   fi
 else
-  echo 'Please install autojump to enable the plugin (https://github.com/wting/autojump)';
+  echo 'Please install autojump to enable the plugin (https://github.com/wting/autojump)'
 fi

--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -18,4 +18,6 @@ if [ $commands[autojump] ]; then # check if autojump is installed
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.sh ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump.sh
   fi
+else
+  echo 'Please install autojump to enable the plugin (https://github.com/wting/autojump)';
 fi


### PR DESCRIPTION
I was adding autojump on a new machine and annoyingly forgot that autojump was to be installed on its own. This may be helpful.
