### PR TITLE
add ZSH_MODULE_PATH to customize module path when zmodload

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -8,7 +8,11 @@ setopt always_to_end
 
 WORDCHARS=''
 
-zmodload -i zsh/complist
+if [[ -n $ZSH_MODULE_PATH ]]; then
+    module_path=$ZSH_MODULE_PATH zmodload -i zsh/complist
+else
+    zmodload -i zsh/complist
+fi
 
 ## case-insensitive (all),partial-word and then substring completion
 if [ "x$CASE_SENSITIVE" = "xtrue" ]; then

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -92,7 +92,12 @@ function env_default() {
 
 
 # Required for $langinfo
-zmodload zsh/langinfo
+if [[ -n $ZSH_MODULE_PATH ]]; then
+    module_path=$ZSH_MODULE_PATH zmodload zsh/langinfo
+else
+    zmodload zsh/langinfo
+fi
+
 
 # URL-encode a string
 #

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -45,6 +45,9 @@ ZSH_THEME="robbyrussell"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
+# Would you like to use another module_path than zsh compiled with?
+# export ZSH_MODULE_PATH=/path/to/zsh-module
+
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env zsh
 
-zmodload zsh/datetime
+if [[ -n $ZSH_MODULE_PATH ]]; then
+    module_path=$ZSH_MODULE_PATH zmodload zsh/datetime
+else
+    zmodload zsh/datetime
+fi
 
 function _current_epoch() {
   echo $(( $EPOCHSECONDS / 60 / 60 / 24 ))


### PR DESCRIPTION
This will allow oh-my-zsh still works when modules are moved to other place instead of path from compile time config