### PR TITLE
Add alias for git push to origin/current branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -177,6 +177,7 @@ alias gpoat='git push origin --all && git push origin --tags'
 compdef _git gpoat=git-push
 alias gpu='git push upstream'
 alias gpv='git push -v'
+alias gpcb='git push origin $(current_branch)'
 
 alias gr='git remote'
 alias gra='git remote add'


### PR DESCRIPTION
This is something I do a lot. I thought I would make an alias for it. Other people might also like it.

The wiki will need updating. :hankey: 