### PR TITLE
installer: fix ordering of Cygwin MSYS git check

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -53,11 +53,6 @@ main() {
     echo "Error: git is not installed"
     exit 1
   }
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
-    printf "Error: git clone of oh-my-zsh repo failed\n"
-    exit 1
-  }
-
   # The Windows (MSYS) Git is not compatible with normal use on cygwin
   if [ "$OSTYPE" = cygwin ]; then
     if git --version | grep msysgit > /dev/null; then
@@ -66,6 +61,11 @@ main() {
       exit 1
     fi
   fi
+  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+    printf "Error: git clone of oh-my-zsh repo failed\n"
+    exit 1
+  }
+
 
   printf "${BLUE}Looking for an existing zsh config...${NORMAL}\n"
   if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then


### PR DESCRIPTION
The test added in #3646 to prevent use of the incompatible MSYS `git` isn't working because the test ended up after the `git clone` call. This moves it to the right location.

Fixes #4551.