### PR TITLE
Handle systems where /etc/shells does not exist

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -24,10 +24,12 @@ main() {
   # which may fail on systems lacking tput or terminfo
   set -e
 
-  CHECK_ZSH_INSTALLED=$(grep /zsh$ /etc/shells | wc -l)
-  if [ ! $CHECK_ZSH_INSTALLED -ge 1 ]; then
-    printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"
-    exit
+  if [ -f /etc/shells ]; then
+    CHECK_ZSH_INSTALLED=$(grep /zsh$ /etc/shells | wc -l)
+    if [ ! $CHECK_ZSH_INSTALLED -ge 1 ]; then
+      printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"
+      exit
+    fi
   fi
   unset CHECK_ZSH_INSTALLED
 
@@ -90,12 +92,12 @@ main() {
   TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
   if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
     # If this platform provides a "chsh" command (not Cygwin), do it, man!
-    if hash chsh >/dev/null 2>&1; then
+    if [ -f /etc/shells ] && hash chsh >/dev/null 2>&1; then
       printf "${BLUE}Time to change your default shell to zsh!${NORMAL}\n"
       chsh -s $(grep /zsh$ /etc/shells | tail -1)
     # Else, suggest the user do so manually.
     else
-      printf "I can't change your shell automatically because this system does not have chsh.\n"
+      printf "I can't change your shell automatically because this system does not have chsh and /etc/shells.\n"
       printf "${BLUE}Please manually change your default shell to zsh!${NORMAL}\n"
     fi
   fi


### PR DESCRIPTION
The /etc/shells file may not exist on all system - one of them being when running on a non-rooted Android environment such as [Termux](http://termux.com/).

I got a couple of reports that Oh-My-Zsh does not install on Termux, so there is definitely interest in running it on Android phones & tablets. Once fixing the `install.sh` file it works fine!
