### PR TITLE
Add a space to theme of tonotdo in next to ➜

### DIFF
--- a/themes/tonotdo.zsh-theme
+++ b/themes/tonotdo.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT='%{$fg_no_bold[cyan]%}%n%{$fg_no_bold[magenta]%}➜%{$fg_no_bold[green]%}%3~$(git_prompt_info)%{$reset_color%}» '
+PROMPT='%{$fg_no_bold[cyan]%}%n%{$fg_no_bold[magenta]%}➜ %{$fg_no_bold[green]%}%3~$(git_prompt_info)%{$reset_color%}» '
 RPROMPT='[%*]'
 
 # git theming


### PR DESCRIPTION
I added a space to next to ➜.

**before:**
<img width="544" alt="eeeeeee" src="https://cloud.githubusercontent.com/assets/3052342/10863049/0ff86ebe-8004-11e5-86c4-8b6e58d1297c.png">

**after:**
<img width="558" alt="eeee" src="https://cloud.githubusercontent.com/assets/3052342/10863050/0ff869dc-8004-11e5-99e6-15d839c3d0b2.png">

However, It may be my problem. This changes needs testers.

ref: https://github.com/robbyrussell/oh-my-zsh/issues/4546