### PR TITLE
Improve oneline logs [litter enhance]

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -161,7 +161,7 @@ alias glgm='git log --graph --max-count=10'
 alias glo='git log --oneline --decorate --color'
 alias glol="git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
 alias glola="git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all"
-alias glog='git log --oneline --decorate --color --graph'
+alias glog="git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --"
 alias glp="_git_log_prettily"
 compdef _git glp=git-log
 


### PR DESCRIPTION
enhance alise glog (see image)

#### git log --oneline --decorate --color --graph

![qq20151101-1 2x](https://cloud.githubusercontent.com/assets/448364/10867629/a0ec890c-80a7-11e5-92f3-f9c6e944a34c.jpg)

#### git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --

![qq20151101-2 2x](https://cloud.githubusercontent.com/assets/448364/10867630/c838e78a-80a7-11e5-82e3-07830eb4f94d.jpg)
