### PR TITLE
Avoid using "PREFIX" that cause nvm to complain about.

### DIFF
--- a/themes/sunrise.zsh-theme
+++ b/themes/sunrise.zsh-theme
@@ -11,9 +11,9 @@ B=$fg_no_bold[blue]
 RESET=$reset_color
 
 if [ "$USER" = "root" ]; then
-    PROMPTCOLOR="%{$R%}" PREFIX="-!-";
+    PROMPTCOLOR="%{$R%}" PROMPTPREFIX="-!-";
 else
-    PROMPTCOLOR="" PREFIX="---";
+    PROMPTCOLOR="" PROMPTPREFIX="---";
 fi
 
 local return_code="%(?..%{$R%}%? ↵%{$RESET%})"
@@ -67,7 +67,7 @@ function custom_git_prompt() {
 }
 
 # %B sets bold text
-PROMPT='%B$PREFIX %2~ $(custom_git_prompt)%{$M%}%B»%b%{$RESET%} '
+PROMPT='%B$PROMPTPREFIX %2~ $(custom_git_prompt)%{$M%}%B»%b%{$RESET%} '
 RPS1="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$Y%}‹"


### PR DESCRIPTION
`nvm` complains about `PREFIX` when using sunrise theme:

```
nvm is not compatible with the "PREFIX" environment variable: currently set to "---"
Run `unset PREFIX` to unset it.
```

Renaming `PREFIX` to something else fixed this issue.