### PR TITLE
z plugin: fix loading from custom location

### DIFF
--- a/plugins/z/z.plugin.zsh
+++ b/plugins/z/z.plugin.zsh
@@ -1,6 +1,1 @@
-_load_z() {
-  source $1/z.sh
-}
-
-[[ -f $ZSH_CUSTOM/plugins/z/z.plugin.zsh ]] && _load_z $ZSH_CUSTOM/plugins/z
-[[ -f $ZSH/plugins/z/z.plugin.zsh ]] && _load_z $ZSH/plugins/z
+source ${0:h}/z.sh


### PR DESCRIPTION
The old implementation would attempt to load both the default and custom implementations, with the custom one coming first, so it would get clobbered by the default version.