### PR TITLE
Themes: switch to using ruby_prompt_info()

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -10,9 +10,15 @@
 # Dummy implementations that return false to prevent command_not_found
 # errors with themes, that implement these functions
 # Real implementations will be used when the respective plugins are loaded
-function chruby_prompt_info hg_prompt_info pyenv_prompt_info \
-  rbenv_prompt_info svn_prompt_info vi_mode_prompt_info \
-  virtualenv_prompt_info {
+function chruby_prompt_info \
+  rbenv_prompt_info \
+  hg_prompt_info \
+  pyenv_prompt_info \
+  svn_prompt_info \
+  vi_mode_prompt_info \
+  virtualenv_prompt_info \
+  jenv_prompt_info \
+{
   return 1
 }
 
@@ -22,9 +28,12 @@ function rvm_prompt_info() {
   [ -f $HOME/.rvm/bin/rvm-prompt ] || return 1
   local rvm_prompt
   rvm_prompt=$($HOME/.rvm/bin/rvm-prompt ${=ZSH_THEME_RVM_PROMPT_OPTIONS} 2>/dev/null)
-  [[ "${rvm_prompt}x" == "x" ]] && return 1
-  echo "${ZSH_THEME_RVM_PROMPT_PREFIX:=(}${rvm_prompt}${ZSH_THEME_RVM_PROMPT_SUFFIX:=)}"
+  [[ -z "${rvm_prompt}" ]] && return 1
+  echo "${ZSH_THEME_RUBY_PROMPT_PREFIX}${rvm_prompt}${ZSH_THEME_RUBY_PROMPT_SUFFIX}"
 }
+
+ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
+
 
 # use this to enable users to see their ruby version, no matter which
 # version management system they use

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -42,6 +42,8 @@ ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of th
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
 ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
 ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+ZSH_THEME_RUBY_PROMPT_PREFIX="("
+ZSH_THEME_RUBY_PROMPT_SUFFIX=")"
 
 # Setup the prompt with pretty colors
 setopt prompt_subst

--- a/themes/3den.zsh-theme
+++ b/themes/3den.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT=$'%{$fg[white]%}$(~/.rvm/bin/rvm-prompt) %{$fg_bold[cyan]%}%~%{$reset_color%}$(git_prompt_info) %{$fg[cyan]%}%D{[%I:%M:%S]}\
+PROMPT=$'%{$fg[white]%}$(ruby_prompt_info) %{$fg_bold[cyan]%}%~%{$reset_color%}$(git_prompt_info) %{$fg[cyan]%}%D{[%I:%M:%S]}\
 %{$fg_bold[green]%}%n$%{$reset_color%} '
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[white]%}("

--- a/themes/alanpeabody.zsh-theme
+++ b/themes/alanpeabody.zsh-theme
@@ -1,17 +1,10 @@
 
 local user='%{$fg[magenta]%}%n@%{$fg[magenta]%}%m%{$reset_color%}'
 local pwd='%{$fg[blue]%}%~%{$reset_color%}'
-local rvm=''
-if which rvm-prompt &> /dev/null; then
-  rvm='%{$fg[green]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    rvm='%{$fg[green]%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
-  fi
-fi
 local return_code='%(?..%{$fg[red]%}%? ↵%{$reset_color%})'
 local git_branch='$(git_prompt_status)%{$reset_color%}$(git_prompt_info)%{$reset_color%}'
 
+ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[green]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY=""
@@ -24,5 +17,8 @@ ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[magenta]%} ➜"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[yellow]%} ═"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%} ✭"
 
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[green]%}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
+
 PROMPT="${user} ${pwd}$ "
-RPROMPT="${return_code} ${git_branch} ${rvm}"
+RPROMPT="${return_code} ${git_branch} \$(ruby_prompt_info)"

--- a/themes/amuse.zsh-theme
+++ b/themes/amuse.zsh-theme
@@ -1,17 +1,5 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
 
-rvm_current() {
-  rvm current 2>/dev/null
-}
-
-rbenv_version() {
-  rbenv version 2>/dev/null | awk '{print $1}'
-}
-
-PROMPT='
-%{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
-$ '
-
 # Must use Powerline font, for \uE0A0 to render.
 ZSH_THEME_GIT_PROMPT_PREFIX=" on %{$fg[magenta]%}\uE0A0 "
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
@@ -19,11 +7,12 @@ ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}!"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[green]%}?"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
-if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  RPROMPT='%{$fg_bold[red]%}‹$(rvm_current)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    RPROMPT='%{$fg_bold[red]%}$(rbenv_version)%{$reset_color%}'
-  fi
-fi
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg_bold[red]%}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
+
+PROMPT='
+%{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
+$ '
+
+RPROMPT='$(ruby_prompt_info)'
 

--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -3,19 +3,15 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
 local user_host='%{$terminfo[bold]$fg[green]%}%n@%m%{$reset_color%}'
 local current_dir='%{$terminfo[bold]$fg[blue]%} %~%{$reset_color%}'
-local rvm_ruby=''
-if which rvm-prompt &> /dev/null; then
-  rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    rvm_ruby='%{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
-  fi
-fi
 local git_branch='$(git_prompt_info)%{$reset_color%}'
 
-PROMPT="╭─${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
+ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
+
+PROMPT="╭─${user_host} ${current_dir} \$(ruby_prompt_info) ${git_branch}
 ╰─%B$%b "
-RPS1="${return_code}"
+RPROMPT="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[yellow]%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"

--- a/themes/crunch.zsh-theme
+++ b/themes/crunch.zsh-theme
@@ -29,13 +29,9 @@ ZSH_THEME_GIT_PROMPT_DIRTY=" $CRUNCH_GIT_DIRTY_COLOR✗"
 
 # Our elements:
 CRUNCH_TIME_="$CRUNCH_BRACKET_COLOR{$CRUNCH_TIME_COLOR%T$CRUNCH_BRACKET_COLOR}%{$reset_color%}"
-if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  CRUNCH_RVM_="$CRUNCH_BRACKET_COLOR"["$CRUNCH_RVM_COLOR\${\$(~/.rvm/bin/rvm-prompt i v g)#ruby-}$CRUNCH_BRACKET_COLOR"]"%{$reset_color%}"
-else
-  if which rbenv &> /dev/null; then
-    CRUNCH_RVM_="$CRUNCH_BRACKET_COLOR"["$CRUNCH_RVM_COLOR\${\$(rbenv version | sed -e 's/ (set.*$//' -e 's/^ruby-//')}$CRUNCH_BRACKET_COLOR"]"%{$reset_color%}"
-  fi
-fi
+ZSH_THEME_RUBY_PROMPT_PREFIX="$CRUNCH_BRACKET_COLOR"["$CRUNCH_RVM_COLOR"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="$CRUNCH_BRACKET_COLOR"]"%{$reset_color%}"
+CRUNCH_RVM_='$(ruby_prompt_info)'
 CRUNCH_DIR_="$CRUNCH_DIR_COLOR%~\$(git_prompt_info) "
 CRUNCH_PROMPT="$CRUNCH_BRACKET_COLOR➭ "
 

--- a/themes/dallas.zsh-theme
+++ b/themes/dallas.zsh-theme
@@ -2,14 +2,6 @@
 
 # Grab the current date (%D) and time (%T) wrapped in {}: {%D %T}
 DALLAS_CURRENT_TIME_="%{$fg[white]%}{%{$fg[yellow]%}%D %T%{$fg[white]%}}%{$reset_color%}"
-# Grab the current version of ruby in use (via RVM): [ruby-1.8.7]
-if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  DALLAS_CURRENT_RUBY_="%{$fg[white]%}[%{$fg[magenta]%}\$(~/.rvm/bin/rvm-prompt i v)%{$fg[white]%}]%{$reset_color%}"
-else
-  if which rbenv &> /dev/null; then
-    DALLAS_CURRENT_RUBY_="%{$fg[white]%}[%{$fg[magenta]%}\$(rbenv version | sed -e 's/ (set.*$//')%{$fg[white]%}]%{$reset_color%}"
-  fi
-fi
 # Grab the current machine name: muscato
 DALLAS_CURRENT_MACH_="%{$fg[green]%}%m%{$fg[white]%}:%{$reset_color%}"
 # Grab the current filepath, use shortcuts: ~/Desktop
@@ -28,5 +20,8 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 # Add 3 cyan ✗s if this branch is diiirrrty! Dirty branch!
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[cyan]%}✗✗✗"
 
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[white]%}[%{$fg[magenta]%}"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="%{$fg[white]%}]%{$reset_color%}"
+
 # Put it all together!
-PROMPT="$DALLAS_CURRENT_TIME_$DALLAS_CURRENT_RUBY_$DALLAS_CURRENT_MACH_$DALLAS_CURRENT_LOCA_ $DALLAS_CURRENT_USER_$DALLAS_PROMPT_CHAR_ "
+PROMPT="$DALLAS_CURRENT_TIME_\$(ruby_prompt_info)$DALLAS_CURRENT_MACH_$DALLAS_CURRENT_LOCA_ $DALLAS_CURRENT_USER_$DALLAS_PROMPT_CHAR_ "

--- a/themes/fino-time.zsh-theme
+++ b/themes/fino-time.zsh-theme
@@ -30,10 +30,12 @@ local current_dir='${PWD/#$HOME/~}'
 local git_info='$(git_prompt_info)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%} ${rvm_ruby} %D - %*
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%} \$(ruby_prompt_info) %D - %*
 ╰─$(virtualenv_info)$(prompt_char) "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$FG[202]%}✘✘✘"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$FG[040]%}✔"
+ZSH_THEME_RUBY_PROMPT_PREFIX="‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -20,24 +20,17 @@ function box_name {
     [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-$HOST}
 }
 
-local ruby_env=''
-if which rvm-prompt &> /dev/null; then
-  ruby_env=' ‹$(rvm-prompt i v g)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    ruby_env=' ‹$(rbenv version-name)›%{$reset_color%}'
-  fi
-fi
-
 local current_dir='${PWD/#$HOME/~}'
 local git_info='$(git_prompt_info)'
 local prompt_char='$(prompt_char)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%}${ruby_env}
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%}\$(ruby_prompt_info)
 ╰─${prompt_char}%{$reset_color%} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$FG[202]%}✘✘✘"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$FG[040]%}✔"
+ZSH_THEME_RUBY_PROMPT_PREFIX="‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"

--- a/themes/frontcube.zsh-theme
+++ b/themes/frontcube.zsh-theme
@@ -1,12 +1,13 @@
-local rvm="%{$fg[green]%}[$(rvm-prompt i v g)]%{$reset_color%}"
 
 PROMPT='
 %{$fg_bold[gray]%}%~%{$fg_bold[blue]%}%{$fg_bold[blue]%} % %{$reset_color%}
 %{$fg[green]%}➞  %{$reset_color%'
 
-RPROMPT='$(git_prompt_info) $(rvm)'
+RPROMPT='$(git_prompt_info) $(ruby_prompt_info)'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}[git:"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}] %{$fg[red]%}✖ %{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}] %{$fg[green]%}✔%{$reset_color%}"
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[green]%}["
+ZSH_THEME_RUBY_PROMPT_SUFFIX="]%{$reset_color%}"

--- a/themes/gallois.zsh-theme
+++ b/themes/gallois.zsh-theme
@@ -12,8 +12,8 @@ git_custom_status() {
 }
 
 # RVM component of prompt
-ZSH_THEME_RVM_PROMPT_PREFIX="%{$fg[red]%}["
-ZSH_THEME_RVM_PROMPT_SUFFIX="]%{$reset_color%}"
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}["
+ZSH_THEME_RUBY_PROMPT_SUFFIX="]%{$reset_color%}"
 
 # Combine it all into a final right-side prompt
 RPS1='$(git_custom_status)$(ruby_prompt_info) $EPS1'

--- a/themes/gnzh.zsh-theme
+++ b/themes/gnzh.zsh-theme
@@ -30,21 +30,15 @@ local return_code="%(?..%F{red}%? ↵%f)"
 
 local user_host="${PR_USER}%F{cyan}@${PR_HOST}"
 local current_dir="%B%F{blue}%~%f%b"
-local rvm_ruby=''
-if ${HOME}/.rvm/bin/rvm-prompt &> /dev/null; then # detect user-local rvm installation
-  rvm_ruby='%F{red}‹$(${HOME}/.rvm/bin/rvm-prompt i v g s)›%f'
-elif which rvm-prompt &> /dev/null; then # detect system-wide rvm installation
-  rvm_ruby='%F{red}‹$(rvm-prompt i v g s)›%f'
-elif which rbenv &> /dev/null; then # detect Simple Ruby Version Management
-  rvm_ruby='%F{red}‹$(rbenv version | sed -e "s/ (set.*$//")›%f'
-fi
 local git_branch='$(git_prompt_info)'
 
-PROMPT="╭─${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
+PROMPT="╭─${user_host} ${current_dir} \$(ruby_prompt_info) ${git_branch}
 ╰─$PR_PROMPT "
 RPROMPT="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%F{yellow}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %f"
+ZSH_THEME_RUBY_PROMPT_PREFIX="%F{red}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%f"
 
 }

--- a/themes/itchy.zsh-theme
+++ b/themes/itchy.zsh-theme
@@ -9,10 +9,12 @@ local pwd="%{$fg[yellow]%}%~%{$reset_color%}"
 PROMPT='${user}${host} ${pwd}
 ${smiley}  '
 
-RPROMPT='$(rvm-prompt || rbenv version) %{$fg[white]%}$(git_prompt_info)%{$reset_color%}'
+RPROMPT='$(ruby_prompt_info) %{$fg[white]%}$(git_prompt_info)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX=""
 ZSH_THEME_GIT_PROMPT_SUFFIX=""
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%} ✗%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[green]%} ✔%{$reset_color%}"
 
+ZSH_THEME_RUBY_PROMPT_PREFIX=""
+ZSH_THEME_RUBY_PROMPT_SUFFIX=""

--- a/themes/jaischeema.zsh-theme
+++ b/themes/jaischeema.zsh-theme
@@ -1,16 +1,13 @@
 # jaischeema.zsh-theme
 
 PROMPT='%{$fg_bold[magenta]%}%m%{$reset_color%} at %{$fg_bold[green]%}%~%{$reset_color%} %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}% %{$reset_color%}%{$fg[red]%}❯%{$reset_color%} '
+RPROMPT='$(ruby_prompt_info)'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="±(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
 
-if which rbenv &> /dev/null; then
-  RPROMPT='%{$fg[red]%}$(rbenv version | sed -e "s/ (set.*$//")%{$reset_color%}'
-else
-  if which rvm-prompt &> /dev/null; then
-    RPROMPT='%{$fg[red]%}$(rvm-prompt)%{$reset_color%}'
-  fi
-fi
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="%{$reset_color%}"
+

--- a/themes/macovsky-ruby.zsh-theme
+++ b/themes/macovsky-ruby.zsh-theme
@@ -1,15 +1,1 @@
-# ZSH Theme - Preview: http://gyazo.com/8becc8a7ed5ab54a0262a470555c3eed.png
-local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
-
-if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  PROMPT='%{$fg[green]%}%~%{$reset_color%} %{$fg[red]%}‹$(~/.rvm/bin/rvm-prompt i v)› %{$reset_color%} $(git_prompt_info)%{$reset_color%}%B$%b '
-else
-  if which rbenv &> /dev/null; then
-    PROMPT='%{$fg[green]%}%~%{$reset_color%} %{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")› %{$reset_color%} $(git_prompt_info)%{$reset_color%}%B$%b '
-  fi
-fi
-
-RPS1="${return_code}"
-
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[yellow]%}‹"
-ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
+macovsky.zsh-theme

--- a/themes/macovsky.zsh-theme
+++ b/themes/macovsky.zsh-theme
@@ -1,14 +1,12 @@
 # ZSH Theme - Preview: http://gyazo.com/8becc8a7ed5ab54a0262a470555c3eed.png
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
-if [ -e ~/.rvm/bin/rvm-prompt ]; then
-  PROMPT='%{$fg[green]%}%~%{$reset_color%} %{$fg[red]%}‹$(~/.rvm/bin/rvm-prompt i v)› %{$reset_color%} $(git_prompt_info)%{$reset_color%}%B$%b '
-else
-  if which rbenv &> /dev/null; then
-    PROMPT='%{$fg[green]%}%~%{$reset_color%} %{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")› %{$reset_color%} $(git_prompt_info)%{$reset_color%}%B$%b '
-  fi
-fi
-RPS1="${return_code}"
+PROMPT='%{$fg[green]%}%~%{$reset_color%} $(ruby_prompt_info) $(git_prompt_info)%{$reset_color%}%B$%b '
+RPROMPT="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[yellow]%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
+
+
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="› %{$reset_color%}"

--- a/themes/mira.zsh-theme
+++ b/themes/mira.zsh-theme
@@ -4,22 +4,13 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 local user_host='%{$terminfo[bold]$fg[green]%}%n@%m%{$reset_color%}'
 local current_dir='%{$terminfo[bold]$fg[blue]%} %~%{$reset_color%}'
 
-local rvm_ruby=''
-if which rvm-prompt &> /dev/null; then
-  rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
-else
-  if which rbenv &> /dev/null; then
-    rvm_ruby='%{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
-  fi
-fi
+local nvm_node='%{$fg[green]%}‹node-$(nvm_prompt_info)›%{$reset_color%}'
 
-local nvm_node=''
-nvm_node='%{$fg[green]%}‹node-$(nvm_prompt_info)›%{$reset_color%}'
+local jenv_java='%{$fg[blue]%}‹$(jenv_prompt_info)›%{$reset_color%}'
 
-local jenv_java=''
-jenv_java='%{$fg[blue]%}‹$(jenv_prompt_info)›%{$reset_color%}'
+local git_branch='$(git_prompt_info)'
 
-local git_branch='$(git_prompt_info)%{$reset_color%}'
+local rvm_ruby='$(ruby_prompt_info)'
 
 PROMPT="╭─${user_host} ${current_dir} ${nvm_node} ${rvm_ruby} ${jenv_java} ${git_branch}
 ╰─%B$%b "
@@ -27,3 +18,6 @@ RPS1="${return_code}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[yellow]%}("
 ZSH_THEME_GIT_PROMPT_SUFFIX=") %{$reset_color%}"
+
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}‹"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"

--- a/themes/peepcode.zsh-theme
+++ b/themes/peepcode.zsh-theme
@@ -41,4 +41,4 @@ PROMPT='
 %~
 ${smiley}  %{$reset_color%}'
 
-RPROMPT='%{$fg[white]%} $(~/.rvm/bin/rvm-prompt)$(git_prompt)%{$reset_color%}'
+RPROMPT='%{$fg[white]%} $(ruby_prompt_info)$(git_prompt)%{$reset_color%}'

--- a/themes/simonoff.zsh-theme
+++ b/themes/simonoff.zsh-theme
@@ -23,7 +23,7 @@ function precmd {
     local promptsize=${#${(%):---(%n@%M:%l)---()}}
     local pwdsize=${#${(%):-%~}}
     local gitbranch="$(git_prompt_info)"
-    local rvmprompt="$(rvm_prompt_info)"
+    local rvmprompt="$(ruby_prompt_info)"
     local gitbranchsize=${#${gitbranch:-''}}
     local rvmpromptsize=${#${rvmprompt:-''}}
 
@@ -90,8 +90,8 @@ setprompt () {
     ZSH_THEME_GIT_PROMPT_SUFFIX="]"
     ###
     # Modify RVM prompt
-    ZSH_THEME_RVM_PROMPT_PREFIX=" ["
-    ZSH_THEME_RVM_PROMPT_SUFFIX="]"
+    ZSH_THEME_RUBY_PROMPT_PREFIX=" ["
+    ZSH_THEME_RUBY_PROMPT_SUFFIX="]"
 
 
 ###

--- a/themes/suvash.zsh-theme
+++ b/themes/suvash.zsh-theme
@@ -12,15 +12,9 @@ function collapse_pwd {
     echo $(pwd | sed -e "s,^$HOME,~,")
 }
 
-if which rvm-prompt &> /dev/null; then
-  PROMPT='%{$fg[magenta]%}%n%{$reset_color%} at %{$fg[yellow]%}%m%{$reset_color%} in %{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) using %{$reset_color%}%{$fg[red]%}$(~/.rvm/bin/rvm-prompt)%{$reset_color%} 
+
+PROMPT='%{$fg[magenta]%}%n%{$reset_color%} at %{$fg[yellow]%}%m%{$reset_color%} in %{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) using %{$reset_color%}$(ruby_prompt_info)%{$reset_color%} 
 $(virtualenv_info)$(prompt_char) '
-else
-  if which rbenv &> /dev/null; then
-    PROMPT='%{$fg[magenta]%}%n%{$reset_color%} at %{$fg[yellow]%}%m%{$reset_color%} in %{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) using %{$reset_color%}%{$fg[red]%}$(rbenv version | sed -e "s/ (set.*$//")%{$reset_color%} 
-$(virtualenv_info)$(prompt_char) '
-  fi
-fi
 
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" on %{$fg[magenta]%}"
@@ -28,3 +22,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[green]%}!"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[green]%}?"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
+
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[red]%}"
+ZSH_THEME_RUBY_PROMPT_SUFFIX=""

--- a/themes/wedisagree.zsh-theme
+++ b/themes/wedisagree.zsh-theme
@@ -28,7 +28,7 @@ PROMPT='%{$fg[magenta]%}[%c] %{$reset_color%}'
 RPROMPT='${time} %{$fg[magenta]%}$(git_prompt_info)%{$reset_color%}$(git_prompt_status)%{$reset_color%}$(git_prompt_ahead)%{$reset_color%}'
 
 # Add this at the start of RPROMPT to include rvm info showing ruby-version@gemset-name
-# %{$fg[yellow]%}$(~/.rvm/bin/rvm-prompt)%{$reset_color%} 
+# $(ruby_prompt_info) 
 
 # local time, color coded by last return code
 time_enabled="%(?.%{$fg[green]%}.%{$fg[red]%})%*%{$reset_color%}"
@@ -47,6 +47,9 @@ ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%} ✖" # ⓧ ⑂
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[blue]%} ➜" # ⓡ ⑄
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[magenta]%} ♒" # ⓤ ⑊
 ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg[blue]%} 𝝙"
+
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg[yellow]%}"
+ZSH_THEME_RUBY_PROMPT_SUFFIX="%{$reset_color%}"
 
 # More symbols to choose from:
 # ☀ ✹ ☄ ♆ ♀ ♁ ♐ ♇ ♈ ♉ ♚ ♛ ♜ ♝ ♞ ♟ ♠ ♣ ⚢ ⚲ ⚳ ⚴ ⚥ ⚤ ⚦ ⚒ ⚑ ⚐ ♺ ♻ ♼ ☰ ☱ ☲ ☳ ☴ ☵ ☶ ☷


### PR DESCRIPTION
Changes themes displaying RVM or other Ruby version info to use the central ruby_prompt_info function. This supports more Ruby versioning mechanisms, reduces copy-and-paste code, and avoids "zsh: no such file or directory: /Users/username/.rvm/bin/rvm-prompt" when run on machines that do not have RVM installed.

Changes the prefix/suffix variable names to ZSH_THEME_RUBY_PROMPT_PREFIX and ZSH_THEME_RUBY_PROMPT_SUFFIX, since they apply to all Ruby versioning mechanisms, not just RVM.

Allows empty ZSH_THEME_RUBY_PROMPT_PREFIX and ZSH_THEME_RUBY_PROMPT_SUFFIX.

Fixes #4272
Closes #4523 (by providing a `jenv_prompt_info` stub)
Fixes #4182