### PR TITLE
agnoster theme: stronger warning about changing SEGMENT_SEPARATOR character

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -43,7 +43,8 @@ CURRENT_BG='NONE'
   # This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
   # what font the user is viewing this source code in. Do not replace the
   # escape sequence with a single literal character.
-  SEGMENT_SEPARATOR=$'\ue0b0' # 
+  # Do not change this! Do not make it '\u2b80'; that is the old, wrong code point.
+  SEGMENT_SEPARATOR=$'\ue0b0'
 }
 
 # Begin a segment


### PR DESCRIPTION
Looks like people still aren't picking up on the documentation for the Powerline characters in Agnoster.

This adds stronger language asking people not to change it, and puts it immediately next to the line with the Unicode value for `$SEGMENT_SEPARATOR`, so it will show up within the window of Git context diffs for someone who's making a commit that might change it.

Closes #4544
Follows up on #4091, #4083