### PR TITLE
Fixing strange git unstaged prompt behavior

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -36,7 +36,7 @@ CURRENT_BG='NONE'
   local LC_ALL="" LC_CTYPE="en_US.UTF-8"
   # NOTE: This segment separator character is correct.  In 2012, Powerline changed
   # the code points they use for their special characters. This is the new code point.
-  # If this is not working for you, you probably have an old version of the 
+  # If this is not working for you, you probably have an old version of the
   # Powerline-patched fonts installed. Download and install the new version.
   # Do not submit PRs to change this unless you have reviewed the Powerline code point
   # history and have new information.
@@ -118,7 +118,7 @@ prompt_git() {
     zstyle ':vcs_info:*' get-revision true
     zstyle ':vcs_info:*' check-for-changes true
     zstyle ':vcs_info:*' stagedstr '✚'
-    zstyle ':vcs_info:git:*' unstagedstr '●'
+    zstyle ':vcs_info:*' unstagedstr '●'
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info


### PR DESCRIPTION
I noticed that for certain projects with unstaged changed I would get a 'U' character instead of the '●' character. This should fix that.

Original:
<img width="518" alt="screen shot 2015-11-07 at 4 38 41 pm" src="https://cloud.githubusercontent.com/assets/1276131/11017476/33f48036-856e-11e5-9a3c-a17a78a304ad.png">

With fix:
<img width="406" alt="screen shot 2015-11-07 at 4 39 47 pm" src="https://cloud.githubusercontent.com/assets/1276131/11017478/4decfa04-856e-11e5-8d53-e1ccc0c1e2cc.png">

(edit: I also have a custom coloring for virtualenvs active. You can ignore that)
