### PR TITLE
Fix open_command for msys in the git-for-windows SDK

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -23,6 +23,7 @@ function open_command() {
     darwin*)  open_cmd="open" ;;
     cygwin*)  open_cmd="cygstart" ;;
     linux*)   open_cmd="xdg-open" ;;
+    msys*)    open_cmd="start" ;;
     *)        echo "Platform $OSTYPE not supported"
               return 1
               ;;


### PR DESCRIPTION
Added an option for the msys value of $OSTYPE which is set by the git-for-windows SDK
https://github.com/git-for-windows/build-extra/releases/tag/git-sdk-1.0.1
