### PR TITLE
Use _rake_command instead of bundled_rake when using bundler plugin

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -12,7 +12,11 @@ _rake_does_task_list_need_generating () {
 }
 
 _rake_generate () {
-  rake --silent --tasks | cut -d " " -f 2 > .rake_tasks
+  if type bundled_rake &> /dev/null && type _rake_command &> /dev/null; then
+    _rake_command --silent --tasks | cut -d " " -f 2 > .rake_tasks
+  else
+    command rake --silent --tasks | cut -d " " -f 2 > .rake_tasks
+  fi
 }
 
 _rake () {


### PR DESCRIPTION
# WHAT
Use `_rake_command` instead of `bundled_rake` when using bundler plugin.

# WHY
An error occur if there is a Gemfile.
`bundled_rake` and `rake-fast` aren't compatible. so I'd like to use _rake_command.
However this changes doesn't become a solution to the root of the problem.
but itself (bundled_rake) have not any problem.

## erros logs

```
$ rake [tab]
Generating .rake_tasks...
rake aborted!
Don't know how to build task './bin/--silent'
```