### PR TITLE
plugin for displaying command's execution time

### DIFF
--- a/plugins/timer/README.md
+++ b/plugins/timer/README.md
@@ -1,0 +1,18 @@
+This plugin allows to display command's execution time in a very nonintrusive way.
+
+Timer can be tuned by these two variables:
+* `TIMER_PRECISION` allows to control number of decimal places (default `1`)
+* `TIMER_FORMAT` allows to adjust display format (default `'/%d'`)
+
+Sample session:
+
+    me@here:~$ sleep 1                                         /1.0s
+    me@here:~$ sleep 73                                     /1m13.0s
+    me@here:~$ TIMER_FORMAT='[%d]'; TIMER_PRECISION=2         [0.00s]
+    me@here:~$ head -c50 < /dev/urandom | hexdump
+    0000000 b2 16 20 f0 29 1f 61 2d 8a 29 20 8c 8c 39 5a ab
+    0000010 21 47 0e f9 ee a4 76 46 71 9e 4f 6b a4 c4 51 cb
+    0000020 f9 1f 7e b9 6f 2c ae dd cf 40 6d 64 a8 fb d3 db
+    0000030 09 37
+    0000032                                                  [0.02s]
+

--- a/plugins/timer/README.md
+++ b/plugins/timer/README.md
@@ -8,11 +8,10 @@ Sample session:
 
     me@here:~$ sleep 1                                         /1.0s
     me@here:~$ sleep 73                                     /1m13.0s
-    me@here:~$ TIMER_FORMAT='[%d]'; TIMER_PRECISION=2         [0.00s]
+    me@here:~$ TIMER_FORMAT='[%d]'; TIMER_PRECISION=2        [0.00s]
     me@here:~$ head -c50 < /dev/urandom | hexdump
     0000000 b2 16 20 f0 29 1f 61 2d 8a 29 20 8c 8c 39 5a ab
     0000010 21 47 0e f9 ee a4 76 46 71 9e 4f 6b a4 c4 51 cb
     0000020 f9 1f 7e b9 6f 2c ae dd cf 40 6d 64 a8 fb d3 db
     0000030 09 37
     0000032                                                  [0.02s]
-

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -1,0 +1,18 @@
+preexec() {
+  __timer_cmd_start_time=$(date '+%s')
+}
+
+precmd() {
+  if [ -n "${__timer_cmd_start_time}" ]; then
+    local cmd_end_time=$(date '+%s')
+    local tdiff=$((${cmd_end_time} - ${__timer_cmd_start_time}))
+    unset __timer_cmd_start_time
+    local tdiffstr='/'
+    if (( tdiff >= 60 )); then
+      tdiffstr+="$((tdiff / 60))m"
+    fi
+    tdiffstr+="$((tdiff % 60))s"
+    local cols=$(($COLUMNS - ${#tdiffstr} - 1))
+    echo -e "\033[1A\033[${cols}C ${tdiffstr}"
+  fi
+}

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -3,12 +3,12 @@ preexec() {
 }
 
 precmd() {
-  if [ -n "${__timer_cmd_start_time}" ]; then
+  if [ -n "$__timer_cmd_start_time" ]; then
     local cmd_end_time=$(date '+%s')
-    local tdiff=$((${cmd_end_time} - ${__timer_cmd_start_time}))
+    local tdiff=$((cmd_end_time - __timer_cmd_start_time))
     unset __timer_cmd_start_time
     local tdiffstr="$((tdiff / 60))m$((tdiff % 60))s"
-    local cols=$(($COLUMNS - ${#tdiffstr#0m} - 2))
+    local cols=$((COLUMNS - ${#tdiffstr#0m} - 2))
     echo -e "\033[1A\033[${cols}C \`${tdiffstr#0m}"
   fi
 }

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -6,7 +6,8 @@ __timer_format_duration() {
   local mins=$(printf '%.0f' $(($1 / 60)))
   local secs=$(printf "%.${TIMER_PRECISION:-1}f" $(($1 - 60 * mins)))
   local duration_str=$(echo "${mins}m${secs}s")
-  echo "${TIMER_SYMBOL:-\`}${duration_str#0m}"
+  local format="${TIMER_FORMAT:-/%d}"
+  echo "${format//\%d/${duration_str#0m}}"
 }
 
 preexec() {

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -7,12 +7,8 @@ precmd() {
     local cmd_end_time=$(date '+%s')
     local tdiff=$((${cmd_end_time} - ${__timer_cmd_start_time}))
     unset __timer_cmd_start_time
-    local tdiffstr='/'
-    if (( tdiff >= 60 )); then
-      tdiffstr+="$((tdiff / 60))m"
-    fi
-    tdiffstr+="$((tdiff % 60))s"
-    local cols=$(($COLUMNS - ${#tdiffstr} - 1))
-    echo -e "\033[1A\033[${cols}C ${tdiffstr}"
+    local tdiffstr="$((tdiff / 60))m$((tdiff % 60))s"
+    local cols=$(($COLUMNS - ${#tdiffstr#0m} - 2))
+    echo -e "\033[1A\033[${cols}C \`${tdiffstr#0m}"
   fi
 }

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -4,9 +4,9 @@ __timer_current_time() {
 
 __timer_format_duration() {
   local mins=$(printf '%.0f' $(($1 / 60)))
-  local secs=$(printf '%.1f' $(($1 - 60 * mins)))
+  local secs=$(printf "%.${TIMER_PRECISION:-1}f" $(($1 - 60 * mins)))
   local duration_str=$(echo "${mins}m${secs}s")
-  echo "\`${duration_str#0m}"
+  echo "${TIMER_SYMBOL:-\`}${duration_str#0m}"
 }
 
 preexec() {

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -1,14 +1,25 @@
+__timer_current_time() {
+  perl -MTime::HiRes=time -e'print time'
+}
+
+__timer_format_duration() {
+  local mins=$(printf '%.0f' $(($1 / 60)))
+  local secs=$(printf '%.1f' $(($1 - 60 * mins)))
+  local duration_str=$(echo "${mins}m${secs}s")
+  echo "\`${duration_str#0m}"
+}
+
 preexec() {
-  __timer_cmd_start_time=$(date '+%s')
+  __timer_cmd_start_time=$(__timer_current_time)
 }
 
 precmd() {
-  if [ -n "$__timer_cmd_start_time" ]; then
-    local cmd_end_time=$(date '+%s')
+  if [ -n "${__timer_cmd_start_time}" ]; then
+    local cmd_end_time=$(__timer_current_time)
     local tdiff=$((cmd_end_time - __timer_cmd_start_time))
     unset __timer_cmd_start_time
-    local tdiffstr="$((tdiff / 60))m$((tdiff % 60))s"
-    local cols=$((COLUMNS - ${#tdiffstr#0m} - 2))
-    echo -e "\033[1A\033[${cols}C \`${tdiffstr#0m}"
+    local tdiffstr=$(__timer_format_duration ${tdiff})
+    local cols=$((COLUMNS - ${#tdiffstr} - 1))
+    echo -e "\033[1A\033[${cols}C ${tdiffstr}"
   fi
 }

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -10,11 +10,11 @@ __timer_format_duration() {
   echo "${format//\%d/${duration_str#0m}}"
 }
 
-preexec() {
+__timer_save_time_preexec() {
   __timer_cmd_start_time=$(__timer_current_time)
 }
 
-precmd() {
+__timer_display_timer_precmd() {
   if [ -n "${__timer_cmd_start_time}" ]; then
     local cmd_end_time=$(__timer_current_time)
     local tdiff=$((cmd_end_time - __timer_cmd_start_time))
@@ -24,3 +24,6 @@ precmd() {
     echo -e "\033[1A\033[${cols}C ${tdiffstr}"
   fi
 }
+
+preexec_functions+=(__timer_save_time_preexec)
+precmd_functions+=(__timer_display_timer_precmd)


### PR DESCRIPTION
This plugin allows to display command's execution time in a very nonintrusive way.

Timer can be tuned by these two variables:
* `TIMER_PRECISION` allows to control number of decimal places (default `1`)
* `TIMER_FORMAT` allows to adjust display format (default `'/%d'`)

Tested on OSX and Ubuntu.

Sample session:

    me@here:~$ sleep 1                                         /1.0s
    me@here:~$ sleep 73                                     /1m13.0s
    me@here:~$ IMER_FORMAT='[%d]'; TIMER_PRECISION=2         [0.00s]
    me@here:~$ head -c50 < /dev/urandom | hexdump
    0000000 b2 16 20 f0 29 1f 61 2d 8a 29 20 8c 8c 39 5a ab
    0000010 21 47 0e f9 ee a4 76 46 71 9e 4f 6b a4 c4 51 cb
    0000020 f9 1f 7e b9 6f 2c ae dd cf 40 6d 64 a8 fb d3 db
    0000030 09 37
    0000032                                                  [0.02s]