### PR TITLE
dircycle: remove redundant key bindings

### DIFF
--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -27,11 +27,11 @@ insert-cycledright () {
 zle -N insert-cycledright
 
 
-# add key bindings for iTerm2
-if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-	bindkey "^[[1;6D" insert-cycledleft
-	bindkey "^[[1;6C" insert-cycledright
-else
-	bindkey "\e[1;6D" insert-cycledleft
-	bindkey "\e[1;6C" insert-cycledright
-fi
+# These sequences work for xterm, Apple Terminal.app, and probably others.
+# Not for rxvt-unicode, but it doesn't seem differentiate Ctrl-Shift-Arrow
+# from plain Shift-Arrow, at least by default.
+# iTerm2 does not have these key combinations defined by default; you will need
+# to add them under "Keys" in your profile if you want to use this. You can do
+# this conveniently by loading the "xterm with Numeric Keypad" preset.
+bindkey "\e[1;6D" insert-cycledleft
+bindkey "\e[1;6C" insert-cycledright


### PR DESCRIPTION
In bindkey strings, "^[" and "\e" mean the same thing. They're both notations for Escape.

This removes the redundant bindings and unnecessary `iTerm.app` test, which suggests special behavior for iTerm2. iTerm2 does behave differently, but this sequence isn't it: by default, Ctrl-Shift-Arrow doesn't send anything. There's an "xterm with Numeric Keypad" key preset you can load; that gives you these same character sequence bindings. (The "Terminal.app" compatibility one looks more like `urxvt`.)