### PR TITLE
Default to using terminfo to set the terminal title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -32,10 +32,10 @@ function title {
         # Try to use terminfo to set the title
         # If the feature is available set title
         if [[ -n "$terminfo[fsl]" ]] && [[ -n "$terminfo[tsl]" ]]; then
-		echoti tsl
-		print -Pn "$1"
-		echoti fsl
-        fi
+	  echoti tsl
+	  print -Pn "$1"
+	  echoti fsl
+	fi
       fi
       ;;
   esac

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -28,6 +28,14 @@ function title {
       if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
         print -Pn "\e]2;$2:q\a" # set window name
         print -Pn "\e]1;$1:q\a" # set tab name
+      else
+        # Try to use terminfo to set the title
+        # If the feature is available set title
+        if [[ -n "$terminfo[fsl]" ]] && [[ -n "$terminfo[tsl]" ]]; then
+		echoti tsl
+		print -Pn "$1"
+		echoti fsl
+        fi
       fi
       ;;
   esac


### PR DESCRIPTION
Currently, the title is only set on supported terminals (i.e. xterm, urxvt, screen etc.). Using terminfo entries to set the terminal title adds support for many more terminals.