### PR TITLE
Don't correct cp commands

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,4 +1,5 @@
 if [[ "$ENABLE_CORRECTION" == "true" ]]; then
+  alias cp='nocorrect cp'
   alias ebuild='nocorrect ebuild'
   alias gist='nocorrect gist'
   alias heroku='nocorrect heroku'


### PR DESCRIPTION
we currently don't autocorrect for file operations mv, mkdir, adding cp for consistency 
