### PR TITLE
Use actual `commit --amend` command for Mercurial

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -14,8 +14,7 @@ alias hgo='hg outgoing'
 alias hgp='hg push'
 alias hgs='hg status'
 alias hgsl='hg log --limit 20 --template "{node|short} | {date|isodatesec} | {author|user}: {desc|strip|firstline}\n" '
-# this is the 'git commit --amend' equivalent
-alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
+alias hgca='hg commit --amend'
 # list unresolved files (since hg does not list unmerged files in the status command)
 alias hgun='hg resolve --list'
 


### PR DESCRIPTION
Rather than trying to emulate `git commit --amend` using mercurial queues (which might have side effects if you're using MQ for other things) use the `commit --amend` command which was introduced in Mercurial 2.2 (2012-05-01).