### PR TITLE
Added plugin for Visual Studio Code

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,0 +1,17 @@
+## Visual Studio Code
+
+Plugin for Visual Studio Code, a text editor for Mac OS X, Windows, and Linux 
+
+### Requirements
+
+ * [Visual Studio Code](https://code.visualstudio.com)
+ 
+### Usage
+
+ * If the `code` command is called without an argument, launch VS Code
+
+ * If `code` is passed a directory, cd to it and open it in VS Code
+
+ * If `code` is passed a file, open it in VS Code
+
+*NOTE: `vscode` can be used as an alias in place of `code`*

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -1,0 +1,17 @@
+alias vscode='code'
+
+#
+# If the code command is called without an argument, launch VS Code
+# If code is passed a directory, cd to it and open it in VS Code
+# If code is passed a file, open it in VS code
+#
+function code {
+    if [[ $# = 0 ]]
+    then
+        open -a "Visual Studio Code"
+    else
+        local argPath="$1"
+        [[ $1 = /* ]] && argPath="$1" || argPath="$PWD/${1#./}"
+        open -a "Visual Studio Code" "$argPath"
+    fi
+}


### PR DESCRIPTION
Added a plugin to enable triggering Visual Studio Code from the command line. Nothing fancy.

p.s. Not sure why the changes from Feb 2015 are included here. I thought they'd already been merged. I've rebased from the original, but I'm not that hot with Git, so not sure what's going on there.