### PR TITLE
Make code in lib/termsupport.zsh more readable

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -16,12 +16,21 @@ function title {
   # if it is set and empty, leave it as is
   : ${2=$1}
 
-  if [[ "$TERM" == screen* ]]; then
-    print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == putty* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM" == cygwin ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-    print -Pn "\e]2;$2:q\a" #set window name
-    print -Pn "\e]1;$1:q\a" #set icon (=tab) name
-  fi
+  case "$TERM" in
+    cygwin|xterm*|putty*|rxvt*|ansi)
+      print -Pn "\e]2;$2:q\a" # set window name
+      print -Pn "\e]1;$1:q\a" # set tab name
+      ;;
+    screen*)
+      print -Pn "\ek$1:q\e\\" # set screen hardstatus
+      ;;
+    *)
+      if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+        print -Pn "\e]2;$2:q\a" # set window name
+        print -Pn "\e]1;$1:q\a" # set tab name
+      fi
+      ;;
+  esac
 }
 
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -36,14 +36,15 @@ function title {
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 # Avoid duplication of directory in terminals with independent dir display
-if [[ $TERM_PROGRAM == Apple_Terminal ]]; then
+if [[ "$TERM_PROGRAM" == Apple_Terminal ]]; then
   ZSH_THEME_TERM_TITLE_IDLE="%n@%m"
 fi
 
 # Runs before showing the prompt
 function omz_termsupport_precmd {
   emulate -L zsh
-  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+
+  if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
     return
   fi
 
@@ -53,11 +54,11 @@ function omz_termsupport_precmd {
 # Runs before executing the command
 function omz_termsupport_preexec {
   emulate -L zsh
-  if [[ $DISABLE_AUTO_TITLE == true ]]; then
+  setopt extended_glob
+
+  if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
     return
   fi
-
-  setopt extended_glob
 
   # cmd name only, or if this is sudo or ssh, the next cmd
   local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -76,19 +76,18 @@ preexec_functions+=(omz_termsupport_preexec)
 # With extra fixes to handle multibyte chars and non-UTF-8 locales
 
 if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
-
   # Emits the control sequence to notify Terminal.app of the cwd
+  # Identifies the directory using a file: URI scheme, including
+  # the host name to disambiguate local vs. remote paths.
   function update_terminalapp_cwd() {
     emulate -L zsh
-    # Identify the directory using a "file:" scheme URL, including
-    # the host name to disambiguate local vs. remote paths.
 
     # Percent-encode the pathname.
     local URL_PATH="$(omz_urlencode -P $PWD)"
     [[ $? != 0 ]] && return 1
-    local PWD_URL="file://$HOST$URL_PATH"
+
     # Undocumented Terminal.app-specific control sequence
-    printf '\e]7;%s\a' $PWD_URL
+    printf '\e]7;%s\a' "file://$HOST$URL_PATH"
   }
 
   # Use a precmd hook instead of a chpwd hook to avoid contaminating output


### PR DESCRIPTION
This PR:

- changes the current messy code of the title function to a `case` statement to make it more readable and easier to expand. Tested by artificially setting `$TERM` and `$TERM_PROGRAM`.
- quotes all variables used in `if` statements per our style guide.
- reorders the Terminal.app working directory function for a more compact code.

I'd merge this PR directly but I'd like a review by another set of eyes, given the recent mistakes I made.
cc @apjanke