### PR TITLE
"fishy" theme: Shorten path .foo to .f, not .

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -5,7 +5,7 @@ _fishy_collapsed_wd() {
    BEGIN {
       binmode STDIN,  ":encoding(UTF-8)";
       binmode STDOUT, ":encoding(UTF-8)";
-   }; s|^$HOME|~|g; s|/([^/.])[^/]*(?=/)|/$1|g; s|/\.([^/])[^/]*(?=/)|/.$1|g;
+   }; s|^$ENV{HOME}|~|g; s|/([^/.])[^/]*(?=/)|/$1|g; s|/\.([^/])[^/]*(?=/)|/.$1|g
 ')
 }
 

--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -1,13 +1,13 @@
 # ZSH Theme emulating the Fish shell's default prompt.
 
 _fishy_collapsed_wd() {
-  echo $(pwd | perl -pe "
+  echo $(pwd | perl -pe '
    BEGIN {
-      binmode STDIN,  ':encoding(UTF-8)';
-      binmode STDOUT, ':encoding(UTF-8)';
-   }; s|^$HOME|~|g; s|/([^/])[^/]*(?=/)|/\$1|g
-")
-} 
+      binmode STDIN,  ":encoding(UTF-8)";
+      binmode STDOUT, ":encoding(UTF-8)";
+   }; s|^$HOME|~|g; s|/([^/.])[^/]*(?=/)|/$1|g; s|/\.([^/])[^/]*(?=/)|/.$1|g;
+')
+}
 
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'
 PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>) '


### PR DESCRIPTION
When the current path is `/home/user/.config/doublecmd` the prompt now reads `/h/u/.c/doublecmd`, not `/h/u/./doublecmd` as was the case. This matches what the Fish shell does.

Enclose the Perl snippet in single quotes instead of double quotes.