### PR TITLE
modify Plugin:themes, better support for custom themes

### DIFF
--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,24 +1,35 @@
 function theme
 {
     if [ -z "$1" ] || [ "$1" = "random" ]; then
-	themes=($ZSH/themes/*zsh-theme)
-	N=${#themes[@]}
-	((N=(RANDOM%N)+1))
-	RANDOM_THEME=${themes[$N]}
-	source "$RANDOM_THEME"
-	echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+        themes=($ZSH/themes/*zsh-theme)
+        N=${#themes[@]}
+        ((N=(RANDOM%N)+1))
+        RANDOM_THEME=${themes[$N]}
+        source "$RANDOM_THEME"
+        echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
     else
-	if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-	then
-	    source "$ZSH_CUSTOM/$1.zsh-theme"
-	else
-	    source "$ZSH/themes/$1.zsh-theme"
-	fi
+        if [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]
+        then
+            source "$ZSH_CUSTOM/themes/$1.zsh-theme"
+        elif [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
+        then
+            source "$ZSH_CUSTOM/$1.zsh-theme"
+        else
+            source "$ZSH/themes/$1.zsh-theme"
+        fi
     fi
 }
 
 function lstheme
 {
-    cd $ZSH/themes
-    ls *zsh-theme | sed 's,\.zsh-theme$,,'
+    # default themes
+    ls $ZSH/themes | grep '.zsh-theme$' | sed 's,\.zsh-theme$,,'
+
+    # custom themes
+    ls $ZSH_CUSTOM | grep '.zsh-theme$' | sed 's,\.zsh-theme$,,'
+
+    if [ -d "$ZSH_CUSTOM/themes" ]
+    then
+        ls $ZSH_CUSTOM/themes | grep '.zsh-theme$' | sed 's,\.zsh-theme$,,'
+    fi
 }


### PR DESCRIPTION
These feature was added:

### 1. search theme-files in `$ZSH_CUSTOM/themes`
The original source only search `$ZSH_CUSTOM`，but as the [oh-my-zsh-wiki-Customization](https://github.com/robbyrussell/oh-my-zsh/wiki/Customization) said, the custom theme-files may better put into '$ZSH_CUSTOM/themes'.
so, '$ZSH_CUSTOM/themes' need to be searched.

### 2. lstheme for custom
The original source only list the default themes,
Now, the custom themes were added to be list behind the default themes