### PR TITLE
adding gchid, a useful shorthand to change user.name and user.email

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -224,3 +224,9 @@ alias gvt='git verify-tag'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit -m "--wip--"'
+
+gchid() {
+  [[ -n $1 ]] && {git config user.name $1}
+  [[ -n $2 ]] && {git config user.email $2}
+}
+


### PR DESCRIPTION
I did this because I have this issue with multiple git identities on many projects between work, personal life and side projects so I needed this shorthand. I think this would be useful to someone else. So.
