### PR TITLE
[Composer] redirect stderr to /dev/null for completion commands

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -7,11 +7,11 @@
 
 # Composer basic command completion
 _composer_get_command_list () {
-    $_comp_command1 --no-ansi | sed "1,/Available commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
+    $_comp_command1 --no-ansi 2>/dev/null | sed "1,/Available commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
 }
 
 _composer_get_required_list () {
-    $_comp_command1 show -s --no-ansi | sed '1,/requires/d' | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }'
+    $_comp_command1 show -s --no-ansi 2>/dev/null | sed '1,/requires/d' | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }'
 }
 
 _composer () {


### PR DESCRIPTION
Composer might display warning messages to stderr (xdebug enabled, version older than 30 day, etc). In those cases it can become user-unfriendly :)

<img width="564" alt="screen shot 2015-12-06 at 13 54 43" src="https://cloud.githubusercontent.com/assets/1205386/11613447/2c03eb04-9c21-11e5-9ba0-4adf59331a07.png">
