### PR TITLE
common-aliases: handle "dev" versions in version check

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -52,7 +52,7 @@ alias mv='mv -i'
 
 # zsh is able to auto-do some kungfoo
 # depends on the SUFFIX :)
-if [ ${ZSH_VERSION//\./} -ge 420 ]; then
+if is-at-least 4.2.0; then
   # open browser on urls
   _browser_fts=(htm html de org net com at cx nl se dk dk php)
   for ft in $_browser_fts ; do alias -s $ft=$BROWSER ; done


### PR DESCRIPTION
Uses `is-at-least` instead of a numeric comparison hack, so versions with non-numeric bits like "4.5.0-dev5" don't throw errors.

Fixes an issue noted in https://github.com/robbyrussell/oh-my-zsh/issues/4441#issuecomment-163790819.