### PR TITLE
Bind also UP/DOWN arrow keys in history-substring-search

### DIFF
--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -19,8 +19,15 @@ if [[ -n "$terminfo[kcuu1]" ]]; then
   bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
   bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
 fi
+if [[ -n "$terminfo[cuu1]" ]]; then
+  bindkey -M emacs "$terminfo[cuu1]" history-substring-search-up
+  bindkey -M viins "$terminfo[cuu1]" history-substring-search-up
+fi
 if [[ -n "$terminfo[kcud1]" ]]; then
   bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
   bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
 fi
-
+if [[ -n "$terminfo[cud1]" ]]; then
+  bindkey -M emacs "$terminfo[cud1]" history-substring-search-down
+  bindkey -M viins "$terminfo[cud1]" history-substring-search-down
+fi


### PR DESCRIPTION
#### NOT READY

Without it only keypad arrow keys are working. See https://github.com/robbyrussell/oh-my-zsh/issues/2735#issuecomment-160455066

Fixes #2735 

/cc @Konfekt