### PR TITLE
Fix LC_CTYPE

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -34,9 +34,20 @@ else
 fi
 
 # only define LC_CTYPE if undefined
-if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then
-	export LC_CTYPE=${LANG%%:*} # pick the first entry from LANG
-fi
+LC_CTYPE=${LC_CTYPE:-${LC_ALL:-${LANG:-C}}}
+case $LC_CTYPE in
+   *.utf8|*.UTF-8)
+    # All is correct
+    ;;
+   *)
+    # Need to select an UTF-8 locale
+    local -a available
+    available=("${(f)$(locale -a 2> /dev/null)}")
+    export LC_CTYPE=${${${${(@M)available:#*.UTF-8}[1]}:-${${(@M)available:#*.utf8}[1]}}:-C.UTF-8}
+    unset available
+   ;;
+esac
+export LC_CTYPE
 
 # recognize comments
 setopt interactivecomments

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -32,20 +32,17 @@ CURRENT_BG='NONE'
 
 # Special Powerline characters
 
-() {
-  local LC_ALL="" LC_CTYPE="en_US.UTF-8"
-  # NOTE: This segment separator character is correct.  In 2012, Powerline changed
-  # the code points they use for their special characters. This is the new code point.
-  # If this is not working for you, you probably have an old version of the
-  # Powerline-patched fonts installed. Download and install the new version.
-  # Do not submit PRs to change this unless you have reviewed the Powerline code point
-  # history and have new information.
-  # This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
-  # what font the user is viewing this source code in. Do not replace the
-  # escape sequence with a single literal character.
-  # Do not change this! Do not make it '\u2b80'; that is the old, wrong code point.
-  SEGMENT_SEPARATOR=$'\ue0b0'
-}
+# NOTE: This segment separator character is correct.  In 2012, Powerline changed
+# the code points they use for their special characters. This is the new code point.
+# If this is not working for you, you probably have an old version of the
+# Powerline-patched fonts installed. Download and install the new version.
+# Do not submit PRs to change this unless you have reviewed the Powerline code point
+# history and have new information.
+# This is defined using a Unicode escape sequence so it is unambiguously readable, regardless of
+# what font the user is viewing this source code in. Do not replace the
+# escape sequence with a single literal character.
+# Do not change this! Do not make it '\u2b80'; that is the old, wrong code point.
+SEGMENT_SEPARATOR=$'\ue0b0'
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,


### PR DESCRIPTION
See #2012 for some context. Many unicode-related tasks need that
coaelescing to handle unicode correctly. If for some reason, the user is
using a not using a non-unicode locale, we want to ensure that at least
LC_CTYPE is set to an unicode locale.

It's difficult to know if a locale is an unicode one, so we assume that
we want UTF-8 as an unicode codec. Aliases are not handled, so LC_CTYPE
may be redefined even if it was already unicode aware.

The first available UTF-8 locale is used because there is no guarantee
that C.UTF-8 or en_US.UTF-8 are available. For LC_CTYPE, there is no
difference between those locales as coaelescing is not dependant on the
language.

LC_CTYPE is exported as oh-my-zsh may use some shell tools at some
point (sed, awk, ...).
