### PR TITLE
znt: more optimizing workarounds for 5.0.6 <= zsh < 5.2

### DIFF
--- a/plugins/zsh-navigation-tools/README.md
+++ b/plugins/zsh-navigation-tools/README.md
@@ -105,7 +105,7 @@ colorize output of the tools, via their config files (check out e.g. n-cd.conf,
 it uses this).
 
 ## Performance
-ZNT are fastest with Zsh before 5.0.8 and starting from 5.2
+ZNT are fastest with Zsh before 5.0.6 and starting from 5.2
 
 
 vim:filetype=conf

--- a/plugins/zsh-navigation-tools/n-list
+++ b/plugins/zsh-navigation-tools/n-list
@@ -243,7 +243,9 @@ while (( 1 )); do
 
             # Take all elements, including duplicates and non-selectables
             typeset +U list
-            list=( "$@" )
+            repeat 1; do
+                list=( "$@" )
+            done
 
             # Remove non-selectable elements
             [ "$#NLIST_NONSELECTABLE_ELEMENTS" -gt 0 ] && for i in "${(nO)NLIST_NONSELECTABLE_ELEMENTS[@]}"; do
@@ -309,7 +311,9 @@ while (( 1 )); do
 
             # Take all elements, including duplicates and non-selectables
             typeset +U list
-            list=( "$@" )
+            repeat 1; do
+                list=( "$@" )
+            done
 
             # Remove non-selectable elements only when in uniq mode
             [ "$NLIST_IS_UNIQ_MODE" -eq 1 ] && [ "$#NLIST_NONSELECTABLE_ELEMENTS" -gt 0 ] &&


### PR DESCRIPTION
Optimizations towards heap management of set of Zsh versions. Search of three letter keyword is 6.7 sec vs. 15.3 sec in one of tests