### PR TITLE
colored-man-pages: Use Portable `less` Path

### DIFF
--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -25,7 +25,7 @@ man() {
 		LESS_TERMCAP_so=$(printf "\e[1;44;33m") \
 		LESS_TERMCAP_ue=$(printf "\e[0m") \
 		LESS_TERMCAP_us=$(printf "\e[1;32m") \
-		PAGER=/usr/bin/less \
+		PAGER="${commands[less]:-$PAGER}" \
 		_NROFF_U=1 \
 		PATH="$HOME/bin:$PATH" \
 			man "$@"


### PR DESCRIPTION
The `colored-man-pages` plugin breaks the `man` command on NixOS. This commit fixes the issue by using `/usr/bin/env` to determine the path to the `less` command.