### PR TITLE
Plugin rake-fast: add Rails compatibility

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -8,7 +8,23 @@ _rake_refresh () {
 }
 
 _rake_does_task_list_need_generating () {
-  [[ ! -f .rake_tasks ]] || [[ Rakefile -nt .rake_tasks ]]
+  _rake_tasks_missing || _rakefile_has_changes || _sub_rake_files_have_changes
+}
+
+_rake_tasks_missing () {
+  [[ ! -f .rake_tasks ]]
+}
+
+_rakefile_has_changes () {
+  [[ Rakefile -nt .rake_tasks ]]
+}
+
+_sub_rake_files_have_changes () {
+  if find . -type f -name "*.rake" 2>/dev/null | grep -q .; then
+    [[ $(find ./**/*.rake(.om[1])) -nt .rake_tasks ]]
+  else
+    false
+  fi
 }
 
 _rake_generate () {


### PR DESCRIPTION
This PR adds Rails compatibility to the rake-fast plugin. 

The problem I was running into is that currently, rake-fast is only watching the main Rakefile for changes in order invalidate the cache. However, in Rails, the main Rakefile rarely changes. Instead, it requires all the *.rake files defined in lib/tasks/.

This change checks to see if any .rake files have been changed, in addition to the existing checks.

I discussed this with @KevinBongart on the original rake-fast repo: https://github.com/KevinBongart/rake-fast/issues/4
