### PR TITLE
Update gitignore.plugin: comma separated arguments

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl -sL https://www.gitignore.io/api/$@ ;}
+function gi() { curl -sL https://www.gitignore.io/api/`echo $@ | sed s/" "/,/g` ;}
 
 _gitignoreio_get_command_list() {
   curl -sL https://www.gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Seems like this is more like the intended effect, splits arguments with commas for proper gitignore.io api request. Thanks for teaching me about custom compdef completions!