### PR TITLE
Support bundler

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -13,6 +13,8 @@ function _rails_command () {
 function _rake_command () {
   if [ -e "bin/rake" ]; then
     bin/rake $@
+  elif type bundle &> /dev/null && [ -e "Gemfile" ]; then
+    bundle exec rake $@
   else
     command rake $@
   fi


### PR DESCRIPTION
Even if current directory is not rails project, _rake_command and bundler should be useable.
Because user is using bundler plugin and rails plugin so rake command is overrode as a _rake_command.
So We cannot use rake command with bundler.

In my developed gem:
```
$ rake -T
rake aborted!
LoadError: cannot load such file -- rspec/core/rake_task
/Users/sachin21dev/Projects/github.com/sachin21/space2underscore/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```
And this error can be reproduced in all gem products. because _rake_command using rake without bundler.

FYI some of my zshrc:
```shell
plugins=(
  autojump
  brew
  brew-cask
  bundler
  docker
  gem
  git
  go
  heroku
  history
  pip
  pyenv
  rails
  rake-fast
  ruby
  sublime
  tmux
  vagrant
)
```