### PR TITLE
Fix coding styles for libs

### DIFF
--- a/lib/bzr.zsh
+++ b/lib/bzr.zsh
@@ -1,10 +1,10 @@
 ## Bazaar integration
 ## Just works with the GIT integration just add $(bzr_prompt_info) to the PROMPT
 function bzr_prompt_info() {
-	BZR_CB=`bzr nick 2> /dev/null | grep -v "ERROR" | cut -d ":" -f2 | awk -F / '{print "bzr::"$1}'`
-	if [ -n "$BZR_CB" ]; then
-		BZR_DIRTY=""
-		[[ -n `bzr status` ]] && BZR_DIRTY=" %{$fg[red]%} * %{$fg[green]%}"
-		echo "$ZSH_THEME_SCM_PROMPT_PREFIX$BZR_CB$BZR_DIRTY$ZSH_THEME_GIT_PROMPT_SUFFIX"
-	fi
+  BZR_CB=$(bzr nick 2> /dev/null | grep -v "ERROR" | cut -d ":" -f2 | awk -F / '{print "bzr::"$1}')
+  if [ -n "$BZR_CB" ]; then
+    BZR_DIRTY=""
+    [[ -n `bzr status` ]] && BZR_DIRTY=" %{$fg[red]%} * %{$fg[green]%}"
+    echo "$ZSH_THEME_SCM_PROMPT_PREFIX$BZR_CB$BZR_DIRTY$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  fi
 }

--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -18,6 +18,7 @@
 function clipcopy() {
   emulate -L zsh
   local file=$1
+
   if [[ $OSTYPE == darwin* ]]; then
     if [[ -z $file ]]; then
       pbcopy
@@ -39,7 +40,7 @@ function clipcopy() {
       fi
     elif which xsel &>/dev/null; then
       if [[ -z $file ]]; then
-        xsel --clipboard --input 
+        xsel --clipboard --input
       else
         cat "$file" | xsel --clipboard --input
       fi

--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -17,14 +17,14 @@ function handle_completion_insecurities() {
   #     /usr/share/zsh/5.0.6
   #
   # Since the ignorable first line is printed to stderr and thus not captured,
-  # stderr is squelched to prevent this output from leaking to the user. 
+  # stderr is squelched to prevent this output from leaking to the user.
   local -aU insecure_dirs
   insecure_dirs=( ${(f@):-"$(compaudit 2>/dev/null)"} )
 
   # If no such directories exist, get us out of here.
   if (( ! ${#insecure_dirs} )); then
-      print "[oh-my-zsh] No insecure completion-dependent directories detected."
-      return
+    print "[oh-my-zsh] No insecure completion-dependent directories detected."
+    return
   fi
 
   # List ownership and permissions of all insecure directories.

--- a/lib/diagnostics.zsh
+++ b/lib/diagnostics.zsh
@@ -30,7 +30,7 @@
 #
 # This is written in a defensive style so it still works (and can detect) cases when
 # basic functionality like echo and which have been redefined. In particular, almost
-# everything is invoked with "builtin" or "command", to work in the face of user 
+# everything is invoked with "builtin" or "command", to work in the face of user
 # redefinitions.
 #
 # OPTIONS
@@ -59,7 +59,7 @@ function omz_diagnostic_dump() {
   emulate -L zsh
 
   builtin echo "Generating diagnostic dump; please be patient..."
-  
+
   local thisfcn=omz_diagnostic_dump
   local -A opts
   local opt_verbose opt_noverbose opt_outfile
@@ -72,10 +72,12 @@ function omz_diagnostic_dump() {
   if [[ ${#*} > 0 ]]; then
     opt_outfile=$1
   fi
+
   if [[ ${#*} > 1 ]]; then
     builtin echo "$thisfcn: error: too many arguments" >&2
     return 1
   fi
+
   if [[ -n "$opt_outfile" ]]; then
     outfile="$opt_outfile"
   fi
@@ -90,7 +92,7 @@ function omz_diagnostic_dump() {
   builtin echo
   builtin echo Diagnostic dump file created at: "$outfile"
   builtin echo
-  builtin echo To share this with OMZ developers, post it as a gist on GitHub 
+  builtin echo To share this with OMZ developers, post it as a gist on GitHub
   builtin echo at "https://gist.github.com" and share the link to the gist.
   builtin echo
   builtin echo "WARNING: This dump file contains all your zsh and omz configuration files,"
@@ -105,8 +107,8 @@ function _omz_diag_dump_one_big_text() {
   builtin echo oh-my-zsh diagnostic dump
   builtin echo
   builtin echo $outfile
-  builtin echo 
-  
+  builtin echo
+
   # Basic system and zsh information
   command date
   command uname -a
@@ -124,6 +126,7 @@ function _omz_diag_dump_one_big_text() {
   for program in $programs; do
     extra_str="" sha_str=""
     progfile=$(builtin which $program)
+
     if [[ $? == 0 ]]; then
       if [[ -e $progfile ]]; then
         if builtin whence shasum &>/dev/null; then
@@ -140,6 +143,7 @@ function _omz_diag_dump_one_big_text() {
       builtin echo "$program: not found"
     fi
   done
+
   builtin echo
   builtin echo Command Versions:
   builtin echo "zsh: $(zsh --version)"
@@ -151,7 +155,7 @@ function _omz_diag_dump_one_big_text() {
 
   # Core command definitions
   _omz_diag_dump_check_core_commands || return 1
-  builtin echo  
+  builtin echo
 
   # ZSH Process state
   builtin echo Process state:
@@ -167,7 +171,7 @@ function _omz_diag_dump_one_big_text() {
   #TODO: Should this include `env` instead of or in addition to `export`?
   builtin echo Exported:
   builtin echo $(builtin export | command sed 's/=.*//')
-  builtin echo 
+  builtin echo
   builtin echo Locale:
   command locale
   builtin echo
@@ -181,7 +185,7 @@ function _omz_diag_dump_one_big_text() {
   builtin echo
   builtin echo 'compaudit output:'
   compaudit
-  builtin echo 
+  builtin echo
   builtin echo '$fpath directories:'
   command ls -lad $fpath
   builtin echo
@@ -224,7 +228,7 @@ function _omz_diag_dump_one_big_text() {
   local cfgfile cfgfiles
   # Some files for bash that zsh does not use are intentionally included
   # to help with diagnosing behavior differences between bash and zsh
-  cfgfiles=( /etc/zshenv /etc/zprofile /etc/zshrc /etc/zlogin /etc/zlogout 
+  cfgfiles=( /etc/zshenv /etc/zprofile /etc/zshrc /etc/zlogin /etc/zlogout
     $zdotdir/.zshenv $zdotdir/.zprofile $zdotdir/.zshrc $zdotdir/.zlogin $zdotdir/.zlogout
     ~/.zsh.pre-oh-my-zsh
     /etc/bashrc /etc/profile ~/.bashrc ~/.profile ~/.bash_profile ~/.bash_logout )
@@ -258,8 +262,8 @@ function _omz_diag_dump_check_core_commands() {
   # (For back-compatibility, if any of these are newish, they should be removed,
   # or at least made conditional on the version of the current running zsh.)
   # "history" is also excluded because OMZ is known to redefine that
-  reserved_words=( do done esac then elif else fi for case if while function 
-    repeat time until select coproc nocorrect foreach end '!' '[[' '{' '}' 
+  reserved_words=( do done esac then elif else fi for case if while function
+    repeat time until select coproc nocorrect foreach end '!' '[[' '{' '}'
     )
   builtins=( alias autoload bg bindkey break builtin bye cd chdir command
     comparguments compcall compctl compdescribe compfiles compgroups compquote comptags
@@ -331,7 +335,7 @@ function _omz_diag_dump_os_specific_version() {
   case "$OSTYPE" in
     darwin*)
       osname=$(command sw_vers -productName)
-      osver=$(command sw_vers -productVersion)      
+      osver=$(command sw_vers -productVersion)
       builtin echo "OS Version: $osname $osver build $(sw_vers -buildVersion)"
       ;;
     cygwin)
@@ -350,4 +354,3 @@ function _omz_diag_dump_os_specific_version() {
     builtin echo
   done
 }
-

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -31,31 +31,37 @@ function parse_git_dirty() {
 
 # Gets the difference between the local and remote branches
 function git_remote_status() {
-    local remote ahead behind git_remote_status git_remote_status_detailed
-    remote=${$(command git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)/refs\/remotes\/}
-    if [[ -n ${remote} ]]; then
-        ahead=$(command git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-        behind=$(command git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
+  local remote ahead behind git_remote_status git_remote_status_detailed
+  remote=${$(command git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)/refs\/remotes\/}
 
-        if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
-        elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
-            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}"
-        elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
-            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
-        elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
-            git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
-        fi
+  if [[ -n ${remote} ]]; then
+    ahead=$(command git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
+    behind=$(command git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
 
-        if [[ -n $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
-        fi
-
-        echo $git_remote_status
+    if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
+        git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
+    elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
+        git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
+        git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}"
+    elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
+        git_remote_status="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
+        git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
+    elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
+        git_remote_status="$ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
+        git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$reset_color%}"
     fi
+
+    if [[ -n $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
+        git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+    fi
+
+    echo $git_remote_status
+  fi
+
+  if [ $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]; then
+    git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+  fi
+  echo $git_remote_status
 }
 
 # Outputs the name of the current branch

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -3,15 +3,15 @@
 autoload -Uz is-at-least
 if [[ $ZSH_VERSION != 5.1.1 ]]; then
   for d in $fpath; do
-  	if [[ -e "$d/url-quote-magic" ]]; then
-  		if is-at-least 5.1; then
-  			autoload -Uz bracketed-paste-magic
-  			zle -N bracketed-paste bracketed-paste-magic
-  		fi
-  		autoload -Uz url-quote-magic
-  		zle -N self-insert url-quote-magic
+    if [[ -e "$d/url-quote-magic" ]]; then
+      if is-at-least 5.1; then
+        autoload -Uz bracketed-paste-magic
+        zle -N bracketed-paste bracketed-paste-magic
+      fi
+      autoload -Uz url-quote-magic
+      zle -N self-insert url-quote-magic
       break
-  	fi
+    fi
   done
 fi
 
@@ -35,7 +35,7 @@ fi
 
 # only define LC_CTYPE if undefined
 if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then
-	export LC_CTYPE=${LANG%%:*} # pick the first entry from LANG
+  export LC_CTYPE=${LANG%%:*} # pick the first entry from LANG
 fi
 
 # recognize comments

--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -6,17 +6,17 @@
 typeset -AHg FX FG BG
 
 FX=(
-    reset     "%{[00m%}"
-    bold      "%{[01m%}" no-bold      "%{[22m%}"
-    italic    "%{[03m%}" no-italic    "%{[23m%}"
-    underline "%{[04m%}" no-underline "%{[24m%}"
-    blink     "%{[05m%}" no-blink     "%{[25m%}"
-    reverse   "%{[07m%}" no-reverse   "%{[27m%}"
+  reset     "%{[00m%}"
+  bold      "%{[01m%}" no-bold      "%{[22m%}"
+  italic    "%{[03m%}" no-italic    "%{[23m%}"
+  underline "%{[04m%}" no-underline "%{[24m%}"
+  blink     "%{[05m%}" no-blink     "%{[25m%}"
+  reverse   "%{[07m%}" no-reverse   "%{[27m%}"
 )
 
 for color in {000..255}; do
-    FG[$color]="%{[38;5;${color}m%}"
-    BG[$color]="%{[48;5;${color}m%}"
+  FG[$color]="%{[38;5;${color}m%}"
+  BG[$color]="%{[48;5;${color}m%}"
 done
 
 

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -6,7 +6,7 @@
 # Fully supports screen, iterm, and probably most modern xterm and rxvt
 # (In screen, only short_tab_title is used)
 # Limited support for Apple Terminal (Terminal can't set window and tab separately)
-function title {
+function title() {
   emulate -L zsh
   setopt prompt_subst
 
@@ -49,7 +49,7 @@ if [[ "$TERM_PROGRAM" == Apple_Terminal ]]; then
 fi
 
 # Runs before showing the prompt
-function omz_termsupport_precmd {
+function omz_termsupport_precmd() {
   emulate -L zsh
 
   if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
@@ -60,7 +60,7 @@ function omz_termsupport_precmd {
 }
 
 # Runs before executing the command
-function omz_termsupport_preexec {
+function omz_termsupport_preexec() {
   emulate -L zsh
   setopt extended_glob
 

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -3,17 +3,16 @@ autoload -U colors && colors
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
 # Enable ls colors
-if [ "$DISABLE_LS_COLORS" != "true" ]
-then
+if [ "$DISABLE_LS_COLORS" != "true" ]; then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
   if [[ "$(uname -s)" == "NetBSD" ]]; then
     # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   elif [[ "$(uname -s)" == "OpenBSD" ]]; then
-    # On OpenBSD, "gls" (ls from GNU coreutils) and "colorls" (ls from base, 
-    # with color and multibyte support) are available from ports.  "colorls"  
-    # will be installed on purpose and can't be pulled in by installing 
+    # On OpenBSD, "gls" (ls from GNU coreutils) and "colorls" (ls from base,
+    # with color and multibyte support) are available from ports.  "colorls"
+    # will be installed on purpose and can't be pulled in by installing
     # coreutils, so prefer it to "gls".
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null 2>&1 && alias ls='colorls -G'
@@ -27,11 +26,10 @@ setopt auto_cd
 setopt multios
 setopt cdablevars
 
-if [[ x$WINDOW != x ]]
-then
-    SCREEN_NO="%B$WINDOW%b "
+if [[ x$WINDOW != x ]]; then
+  SCREEN_NO="%B$WINDOW%b "
 else
-    SCREEN_NO=""
+  SCREEN_NO=""
 fi
 
 # Apply theming defaults


### PR DESCRIPTION
Hi there.
I think oh-my-zsh's `./lib/*` should be corrected coding styles. because oh-my-zsh was defined coding styles on wiki however `./lib/*` was not corrected coding styles.
But oh-my-zsh's plugins are too many. so We can't correct coding styles for `./plugins/*` because too many… :cry:
However I corrected coding styles for only `./lib/*`.