### PR TITLE
Add MANUAL_TITLE to temporarily stop auto_title from changing

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -56,7 +56,7 @@ function omz_termsupport_precmd {
     return
   fi
 
-  title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
+  title ${MANUAL_TITLE:-$ZSH_THEME_TERM_TAB_TITLE_IDLE} ${MANUAL_TITLE:-$ZSH_THEME_TERM_TITLE_IDLE}
 }
 
 # Runs before executing the command
@@ -69,8 +69,8 @@ function omz_termsupport_preexec {
   fi
 
   # cmd name only, or if this is sudo or ssh, the next cmd
-  local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
-  local LINE="${2:gs/%/%%}"
+  local CMD=${MANUAL_TITLE:-${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}}
+  local LINE=${MANUAL_TITLE:-"${2:gs/%/%%}"}
 
   title '$CMD' '%100>...>$LINE%<<'
 }

--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -42,13 +42,13 @@ if [[ "$TERM" == screen* ]]; then
     local -a cmd; cmd=(${(z)1}) # the command string
     eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_EXEC"
     eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_EXEC"
-    screen_set $tab_title $tab_hardstatus
+    screen_set ${MANUAL_TITLE:-$tab_title} ${MANUAL_TITLE:-$tab_hardstatus}
   }
   # called by zsh before showing the prompt
   function precmd()
   {
     eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_PROMPT"
     eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_PROMPT"
-    screen_set $tab_title $tab_hardstatus
+    screen_set ${MANUAL_TITLE:-tab_title} ${MANUAL_TITLE:-$tab_hardstatus}
   }
 fi

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -22,7 +22,7 @@ fi
 
 printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Zsh"
 cd "$ZSH"
-if git pull --rebase --stat origin master
+if git pull --rebase --stat upstream master
 then
   printf '%s' "$GREEN"
   printf '%s\n' '         __                                     __   '


### PR DESCRIPTION
Hi,

I had an issue where I used to have many screen windows with vim open, and the windows would get all labeled as 'vim'. This would be really bad in order to know which window had what opened. Instead of simply disabling the automatic title and setting the fixed name, I wanted to set an environment variable so that, when set, the window would stop automatically changing. I was surprised that there was no other way from stopping the auto-title from updating other that disabling it from being loaded. 

I don't know if you would find this solution interesting, and neither if the changes on the screen plugin are truly needed (I've changed this quite awhile ago), but I wanted to contribute if others would also think that this would be an interesting behavior.

Cheers,
Werner.