### PR TITLE
git.plugin.zsh: Don't run Git hooks when making a WIP commit

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -236,4 +236,4 @@ alias gupv='git pull --rebase -v'
 alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
-alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit -m "--wip--"'
+alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip--"'


### PR DESCRIPTION
When making a WIP commit, we generally just want to save the state of the current branch temporarily, maybe because we want to push our work for backup purposes, or change branch to work on something else. Therefore, it's generally undesirable to run Git hooks, which might do things like run linters, because we probably don't care if our WIP has lint errors.