### PR TITLE
znt: optimizations for zsh<=5.2

### DIFF
--- a/plugins/zsh-navigation-tools/.config/znt/n-cd.conf
+++ b/plugins/zsh-navigation-tools/.config/znt/n-cd.conf
@@ -1,4 +1,5 @@
 # Hotlist
+# Try to use $ZSH_VERSION, e.g. /usr/share/zsh/$ZSH_VERSION/functions
 local hotlist
 hotlist=(
     ~/.config/znt
@@ -7,7 +8,6 @@ hotlist=(
     /usr/local/share/zsh/site-functions
     /usr/local/share/zsh
     /usr/local/bin
-    /usr/lib
 )
 
 # Suppress adding (to directory stack) directories visited by n-cd

--- a/plugins/zsh-navigation-tools/README.md
+++ b/plugins/zsh-navigation-tools/README.md
@@ -25,7 +25,7 @@ widgets exist, znt-cd-widget and znt-kill-widget, they can be too assigned
 to key combinations (no need for autoload when using Oh My Zsh):
 
     zle -N znt-cd-widget
-    bindkey "^T" znt-cd-widget
+    bindkey "^A" znt-cd-widget
     zle -N znt-kill-widget
     bindkey "^Y" znt-kill-widget
 

--- a/plugins/zsh-navigation-tools/n-history
+++ b/plugins/zsh-navigation-tools/n-history
@@ -42,7 +42,7 @@ if [ "$REPLY" -gt 0 ]; then
     # ZLE?
     if [ "${(t)CURSOR}" = "integer-local-special" ]; then
         zle redisplay
-        zle kill-whole-line
+        zle kill-buffer
         zle -U "$selected"
     else
         print -zr "$selected"

--- a/plugins/zsh-navigation-tools/n-list
+++ b/plugins/zsh-navigation-tools/n-list
@@ -1,6 +1,7 @@
 # $1, $2, ... - elements of the list
 # $NLIST_NONSELECTABLE_ELEMENTS - array of indexes (1-based) that cannot be selected
 # $REPLY is the output variable - contains index (1-based) or -1 when no selection
+# $reply (array) is the second part of the output - use the index (REPLY) to get selected element
 #
 # Copy this file into /usr/share/zsh/site-functions/
 # and add 'autoload n-list` to .zshrc
@@ -164,6 +165,7 @@ integer current_difference=0
 local prev_search_buffer=""
 integer prev_uniq_mode=0
 integer prev_start_idx=-1
+local MBEGIN MEND MATCH mbegin mend match
 
 # Ability to remember the list between calls
 if [[ -z "$NLIST_REMEMBER_STATE" || "$NLIST_REMEMBER_STATE" -eq 0 || "$NLIST_REMEMBER_STATE" -eq 2 ]]; then
@@ -264,11 +266,15 @@ while (( 1 )); do
             local search_pattern=""
             local colsearch_pattern=""
             if [ -n "$search_buffer" ]; then
-                # Patterns will be *foo*~^*bar* and foo|bar)
+                # Patterns will be *foo*~^*bar* and (foo|bar)
                 search_pattern="${search_buffer// ##/*~^*}"
                 colsearch_pattern="${search_buffer// ##/|}"
 
-                list=( "${(@M)list:#(#i)*$~search_pattern*}" )
+                # The repeat will make the matching work on a fresh heap
+                repeat 1; do
+                    list=( "${(@M)list:#(#i)*$~search_pattern*}" )
+                done
+
                 last_element="$#list"
             fi
 
@@ -287,7 +293,10 @@ while (( 1 )); do
 
             if [ -n "$colsearch_pattern" ]; then
                 local red=$'\x1b[00;31m' reset=$'\x1b[00;00m'
-                disp_list=( "${(@)disp_list//(#mi)($~colsearch_pattern)/$red${MATCH}$reset}" )
+                # The repeat will make the matching work on a fresh heap
+                repeat 1; do
+                    disp_list=( "${(@)disp_list//(#mi)($~colsearch_pattern)/$red${MATCH}$reset}" )
+                done
             fi
 
             # We have display list, lets replace newlines with "\n" when needed (1/2)
@@ -380,7 +389,7 @@ while (( 1 )); do
 
     # Get the special (i.e. "keypad") key or regular key
     if [ -n "$key" ]; then
-        final_key="$key" 
+        final_key="$key"
     elif [ -n "$keypad" ]; then
         final_key="$keypad"
     else

--- a/plugins/zsh-navigation-tools/n-list-draw
+++ b/plugins/zsh-navigation-tools/n-list-draw
@@ -98,7 +98,7 @@ shift 7
 integer max_text_len=page_width-x_offset
 
 [ "$bold" = "0" ] && bold="" || bold="+bold"
-[[ "$active_text" = "underline" || "$active_text" = "reverse" ]] || active_text="reverse"
+[[ "$active_text" = "underline" || "$active_text" = "reverse" ]] || local active_text="reverse"
 # With Linux terminal underline won't work properly
 [ "$TERM" = "linux" ] && active_text="reverse"
 

--- a/plugins/zsh-navigation-tools/n-list-input
+++ b/plugins/zsh-navigation-tools/n-list-input
@@ -44,7 +44,7 @@ case "$key" in
         [ "$current_idx" -lt "$last_element" ] && current_idx=current_idx+1;
         _nlist_compute_first_to_show_idx
         ;;
-    (PPAGE)
+    (PPAGE|$'\b'|$'\C-?'|BACKSPACE)
         current_idx=current_idx-page_height
         [ "$current_idx" -lt 1 ] && current_idx=1;
         _nlist_compute_first_to_show_idx
@@ -72,7 +72,7 @@ case "$key" in
         current_idx=last_element
         _nlist_compute_first_to_show_idx
         ;;
-    ($'\n')
+    ($'\n'|ENTER)
         # Is that element selectable?
         # Check for this only when there is no search
         if [[ "$NLIST_SEARCH_BUFFER" != "" || "$NLIST_IS_UNIQ_MODE" -eq 1 ||
@@ -137,7 +137,7 @@ esac
 else
 
 case "$key" in
-    ($'\n')
+    ($'\n'|ENTER)
         search=0
         _nlist_cursor_visibility 0
         ;;

--- a/plugins/zsh-navigation-tools/znt-history-widget
+++ b/plugins/zsh-navigation-tools/znt-history-widget
@@ -1,7 +1,11 @@
 autoload znt-usetty-wrapper n-history
 local NLIST_START_IN_SEARCH_MODE=1
 local NLIST_START_IN_UNIQ_MODE=1
-local NLIST_SET_SEARCH_TO="$BUFFER"
+
+# Only if current $BUFFER doesn't come from history
+if [ "$HISTCMD" = "$HISTNO" ]; then
+    local NLIST_SET_SEARCH_TO="$BUFFER"
+fi
 
 znt-usetty-wrapper n-history "$@"
 


### PR DESCRIPTION
ZNT: Final optimizations for zsh <= 5.2, n-history won't use $BUFFER if it comes from history, backspace key triggers previous page, updated comments, README.md and done some code polishing. Was testing the changes for 4 weeks
