### PR TITLE
chruby plugin locals moved inside function

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -16,9 +16,6 @@
 # rvm and rbenv plugins also provide this alias
 alias rubies='chruby'
 
-local _chruby_path
-local _chruby_auto
-
 _homebrew-installed() {
     whence brew &> /dev/null
 }
@@ -42,6 +39,9 @@ if _ruby-build_installed; then
 fi
 
 _source_from_omz_settings() {
+    local _chruby_path
+    local _chruby_auto
+    
     zstyle -s :omz:plugins:chruby path _chruby_path
     zstyle -s :omz:plugins:chruby auto _chruby_auto
 


### PR DESCRIPTION
The locals `_chruby_auto` and `_chruby_path` were previously declared at the top of the plugin, but they only seem to be used inside of `_source_from_omz_settings()`. This caused the following odd behavior when using this plugin (locals & their values are printed when sourcing `.zshrc`:

```
$ source ~/.zshrc
_chruby_path=''
_chruby_auto=''
```

@webframp feel free to chime in if there was some rationale that I'm missing - I'm no shellscripting pro