### PR TITLE
Fix autojump sourcing on OSX with Macports

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -14,7 +14,7 @@ if [ $commands[autojump] ]; then # check if autojump is installed
   elif [ -f /usr/local/share/autojump/autojump.zsh ]; then # freebsd installation
     . /usr/local/share/autojump/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
-    . /opt/local/etc/profile.d/autojump.zsh
+    . /opt/local/etc/profile.d/autojump.sh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.sh ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump.sh
   fi

--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -13,7 +13,7 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /etc/profile.d/autojump.sh
   elif [ -f /usr/local/share/autojump/autojump.zsh ]; then # freebsd installation
     . /usr/local/share/autojump/autojump.zsh
-  elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
+  elif [ -f /opt/local/etc/profile.d/autojump.sh ]; then # mac os x with ports
     . /opt/local/etc/profile.d/autojump.sh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.sh ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump.sh


### PR DESCRIPTION
The last version of autojump available on Macports does not have anymore different shell scripts (.sh, .zsh, .bash ...) to be sourced but just one autojump.sh that takes care of that located at `/opt/local/etc/profile.d/autojump.sh`

fix #4625 
