### PR TITLE
Adds git alias to rebase current branch with master

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,6 +33,13 @@ function work_in_progress() {
   fi
 }
 
+# Rebase current branch with the most updated master
+# 
+function rebase_with_master() {
+    local b=$(git_current_branch)
+    git checkout master && git pull --rebase && git checkout $b && git rebase master
+}
+
 #
 # Aliases
 # (sorted alphabetically)
@@ -174,6 +181,7 @@ alias gpv='git push -v'
 alias gr='git remote'
 alias gra='git remote add'
 alias grb='git rebase'
+alias grbb='rebase_with_master'
 alias grba='git rebase --abort'
 alias grbc='git rebase --continue'
 alias grbi='git rebase -i'


### PR DESCRIPTION
Adds the alias `grbb` that rebase the current branch with master. 

This alias abstract the following:

``` Shell
$ git branch
  master
* my-feature-branch
$ git checkout master
$ git pull --rebase
$ git checkout my-feature-branch
$ git rebase master
First, rewinding head to replay your work on top of it...
```

So instead you'd only use:

``` Shell
$ git branch
  master
* my-feature-branch
$ grbb
First, rewinding head to replay your work on top of it...
```
