### PR TITLE
Use value of xcode-select path instead of just using the finder default

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -14,8 +14,9 @@ function xc {
     return 1
   else
     echo "Found ${xcode_proj[1]}"
-    XCODEPATH=`xcode-select -p`
-    open -a ${XCODEPATH%/*/*} "${xcode_proj[1]}"
+    active_path=$(xcode-select -p)
+    active_path=${active_path%%/Contents/Developer*}
+    open -a "${active_path}" "${xcode_proj[1]}"
   fi
 }
 

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -15,8 +15,13 @@ function xc {
   else
     echo "Found ${xcode_proj[1]}"
     active_path=$(xcode-select -p)
-    active_path=${active_path%%/Contents/Developer*}
-    open -a "${active_path}" "${xcode_proj[1]}"
+    if [[ ${active_path} =~ "Xcode" ]]; then
+        active_path=${active_path%%/Contents/Developer*}
+        echo "Opening with ${active_path}"
+        open -a "${active_path}" "${xcode_proj[1]}"
+    else # No Xcode installed
+        open "${xcode_proj[1]}" # Fall back to using Finder suggested application
+    fi
   fi
 }
 

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -14,7 +14,8 @@ function xc {
     return 1
   else
     echo "Found ${xcode_proj[1]}"
-    open "${xcode_proj[1]}"
+    XCODEPATH=`xcode-select -p`
+    open -a ${XCODEPATH%/*/*} "${xcode_proj[1]}"
   fi
 }
 


### PR DESCRIPTION
## Problem:

By default the `open` command uses the Finder's "Open With" value. The problem with this is that it seems to always be set to the Beta version of Xcode if Xcode is installed.
## Suggestion:

This PR proposes getting the version of Xcode to use from the `xcode-select` tool which is more commonly used to switch between versions of the Xcode command line tools. (Similar to rbenv but for Xcode version) This parameter is more likely to reflect a developers preference for which version of Xcode they would like to use for development. 
## Technical notes

By default the `xcode-select` tool return the full path to the Xcode binary, often "/Applications/Xcode.app/Contents/Developer", while `open -a` expects an Application path. Here we have used bash's parameter expansion to discard the `/Contents/Developer` part of the path. 
