### PR TITLE
pylint.plugin.zsh: Remove include-ids=y

### DIFF
--- a/plugins/pylint/pylint.plugin.zsh
+++ b/plugins/pylint/pylint.plugin.zsh
@@ -1,3 +1,3 @@
 # Aliases
-alias pylint-quick='pylint --reports=n --include-ids=y'
-compdef _pylint-quick pylint-quick='pylint --reports=n --include-ids=y'
+alias pylint-quick='pylint --reports=n'
+compdef _pylint-quick pylint-quick='pylint --reports=n'


### PR DESCRIPTION
The flag `--include-ids` is soon to be deprecated for Pylint. This pull request
removes that option from pylint-quick