### PR TITLE
archlinux: fix the yasu alias

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -9,7 +9,7 @@ if (( $+commands[yaourt] )); then
   alias yaconf='yaourt -C'        # Fix all configuration files with vimdiff
   # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
   alias yaupg='yaourt -Syua'        # Synchronize with repositories before upgrading packages (AUR packages too) that are out of date on the local system.
-  alias yasu='yaourt --sucre'      # Same as yaupg, but without confirmation
+  alias yasu='yaourt -Syua --force --devel --noconfirm' # Same as yaupg, but without confirmation
   alias yain='yaourt -S'           # Install specific package(s) from the repositories
   alias yains='yaourt -U'          # Install specific package not from the repositories but from a file
   alias yare='yaourt -R'           # Remove the specified package(s), retaining its configuration(s) and required dependencies


### PR DESCRIPTION
It seems like `--sucre` has always been something of an easter egg, it was deemed dangerous and dropped (see https://github.com/archlinuxfr/yaourt/pull/60). We can keep using `yasu` if we explicitly define the alias.

Not sure if this is a good idea, but the alternative would be to remove `yasu`: https://github.com/robbyrussell/oh-my-zsh/pull/4061
