### PR TITLE
git.plugin: remove the conflicting gvt alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -213,7 +213,5 @@ alias gup='git pull --rebase'
 alias gupv='git pull --rebase -v'
 alias glum='git pull upstream master'
 
-alias gvt='git verify-tag'
-
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit -m "--wip--"'


### PR DESCRIPTION
My Go vendoring tool https://github.com/FiloSottile/gvt is picking up some popularity, and many users have trouble initially because of the `git verify-tag` alias.

Now, this is a bit awkward.

I clearly am to blame here for not vetting the name, but the damage is done (I honestly didn't expect gvt to become popular...). Now, I honestly doubt `verify-tag` is that much used (or at all), so maybe you will consider scrapping the alias for the users convenience? :pray: :relaxed: 

See FiloSottile/gvt#19 and FiloSottile/gvt#4 for user reports.