### PR TITLE
add tab command support for iTerm3

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -46,6 +46,18 @@ EOF
       end tell
 EOF
 
+    elif [[ "$the_app" == 'iTerm2' ]]; then
+    osascript <<EOF
+      tell application "iTerm2"
+        tell current window
+          set newTab to (create tab with default profile)
+            tell current session of newTab
+              write text "${command}"
+          end tell
+        end tell
+      end tell
+EOF
+
   else
     echo "tab: unsupported terminal app: $the_app"
     false


### PR DESCRIPTION
iTerm3 has a bit different AppleScript syntax
https://www.iterm2.com/applescript.html

I have ported `tab` command for it.