### PR TITLE
Fix bug in compass docs search

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -38,7 +38,7 @@ Available search contexts are:
 | bootsnipp     | `http://bootsnipp.com/search?q=`                                         |
 | caniuse       | `http://caniuse.com/#search=`                                            |
 | codepen       | `http://codepen.io/search?q=`                                            |
-| compass       | `http://compass-style.org/search?q=`                                     |
+| compassdoc    | `http://compass-style.org/search?q=`                                     |
 | cssflow       | `http://www.cssflow.com/search?q=`                                       |
 | dartlang      | `https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:`  |
 | emberjs       | `http://emberjs.com/api/#stp=1&stq=`                                     |

--- a/plugins/frontend-search/_frontend-search.sh
+++ b/plugins/frontend-search/_frontend-search.sh
@@ -19,7 +19,7 @@ function _frontend() {
   commands=(
     'jquery: Search in jQuery website'
     'mdn: Search in MDN website'
-    'compass: Search in COMPASS website'
+    'compassdoc: Search in COMPASS website'
     'html5please: Search in HTML5 Please website'
     'caniuse: Search in Can I Use website'
     'aurajs: Search in AuraJs website'
@@ -57,7 +57,7 @@ function _frontend() {
         mdn)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
-        compass)
+        compassdoc)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         html5please)

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -4,7 +4,7 @@ alias bem='frontend bem'
 alias bootsnipp='frontend bootsnipp'
 alias caniuse='frontend caniuse'
 alias codepen='frontend codepen'
-alias compass='frontend compass'
+alias compassdoc='frontend compassdoc'
 alias cssflow='frontend cssflow'
 alias dartlang='frontend dartlang'
 alias emberjs='frontend emberjs'
@@ -32,7 +32,7 @@ function frontend() {
     bootsnipp      'http://bootsnipp.com/search?q='
     caniuse        'http://caniuse.com/#search='
     codepen        'http://codepen.io/search?q='
-    compass        'http://compass-style.org/search?q='
+    compassdoc     'http://compass-style.org/search?q='
     cssflow        'http://www.cssflow.com/search?q='
     dartlang       'https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:'
     emberjs        'http://emberjs.com/api/#stp=1&stq='
@@ -57,7 +57,7 @@ function frontend() {
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
-      print -P "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compass, cssflow,"
+      print -P "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
       print -P "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,"
       print -P "  qunit, reactjs, smacss, stackoverflow, unheap"
       print -P ""
@@ -73,7 +73,7 @@ function frontend() {
     echo ""
     echo "Valid contexts are:"
     echo ""
-    echo "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compass, cssflow, "
+    echo "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, "
     echo "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,  "
     echo "  qunit, reactjs, smacss, stackoverflow, unheap"
     echo ""


### PR DESCRIPTION
The plugin alias for `compass` is overriding default `compass` calls via CLI. Now `compassdoc` is used instead `compass`.


@robbyrussell Can you take a look in this PR, please?