### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,7 +53,7 @@ plugins=(git bundler osx rake ruby)
 
 #### Using Plugins
 
-Most plugins (should! we're working on this) include a __README__, which documents how to use them.
+Most plugins (should! we're working on this) include a __README__, with documents how to use them.
 
 ### Themes
 


### PR DESCRIPTION
A sentence was wrong. Changed:

Most plugins (should! we're working on this) include a __README__, **which** documents how to use them.

to:

Most plugins (should! we're working on this) include a __README__, **with** documents how to use them.