### PR TITLE
Fix homebrew aws slow initialization time

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -1,11 +1,3 @@
-_homebrew-installed() {
-  type brew &> /dev/null
-}
-
-_awscli-homebrew-installed() {
-  brew list awscli &> /dev/null
-}
-
 export AWS_HOME=~/.aws
 
 function agp {
@@ -27,8 +19,8 @@ function aws_profiles {
 
 compctl -K aws_profiles asp
 
-if _homebrew-installed && _awscli-homebrew-installed ; then
-  _aws_zsh_completer_path=$(brew --prefix awscli)/libexec/bin/aws_zsh_completer.sh
+if [ -f /usr/local/opt/awscli/libexec/bin/aws_zsh_completer.sh ]; then
+  _aws_zsh_completer_path=/usr/local/opt/awscli/libexec/bin/aws_zsh_completer.sh
 else
   _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi


### PR DESCRIPTION
Saves ~300ms initialization time

After activating the aws plugin my terminal opened noticeably slower and tracked it down to the two brew calls (`list` & `prefix`) which take ~150ms each. I don’t think a lot of people install homebrew in a different directory so this change doesn’t have a big disadvantage.
