### PR TITLE
Create npm completion on first run

### DIFF
--- a/plugins/npm/.gitignore
+++ b/plugins/npm/.gitignore
@@ -1,0 +1,1 @@
+npm_completion

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,4 +1,12 @@
-eval "$(npm completion 2>/dev/null)"
+__NPM_COMPLETION_DIR="${0:A:h}"
+__NPM_COMPLETION_FILE="${__NPM_COMPLETION_DIR}/npm_completion"
+
+if [[ ! -f $__NPM_COMPLETION_FILE ]]; then
+    npm completion > $__NPM_COMPLETION_FILE || rm -f $__NPM_COMPLETION_FILE
+    compinit -i -d "${ZSH_COMPDUMP}"
+fi
+
+source $__NPM_COMPLETION_FILE
 
 # Install dependencies globally
 alias npmg="npm i -g "


### PR DESCRIPTION
I admit it looks a bit hacky but running `npm completion` takes ~280ms and really slows down the initialization time.

What do you think? Any nicer way of doing this?

By the way: Any reason `compinit` is run before all plugins get loaded? Would allow creating `_PLUGINNAME` files on the first run of a plugin.