### PR TITLE
Added plugin to delete a word forward like Alt+Backspace Reverse

### DIFF
--- a/plugins/reverse-word-delete/README.md
+++ b/plugins/reverse-word-delete/README.md
@@ -1,0 +1,17 @@
+# reverse-word-delete
+
+This plugins allows you to delete the word next to your cursor.
+
+> Alt+Backspace delete the word previous to your cursor
+
+## Instalation
+
+Just add "reverse-word-delete" to your plugins list
+
+```shell
+plugins=(git command-not-found common-aliases reverse-word-delete)
+```
+
+## Example
+
+[![asciicast](https://asciinema.org/a/MLAoU7pNxyfyqme902kGbF5ZF.png)](https://asciinema.org/a/MLAoU7pNxyfyqme902kGbF5ZF)

--- a/plugins/reverse-word-delete/reverse-word-delete.plugin.zsh
+++ b/plugins/reverse-word-delete/reverse-word-delete.plugin.zsh
@@ -1,0 +1,7 @@
+reverse-word-delete() {
+  RBUFFER=$(echo "$RBUFFER" | sed -e "s/^\W*\w*//")
+}
+
+zle -N reverse-word-delete
+# Defined shortcut keys: [Esc] [Esc]
+bindkey '3~' reverse-word-delete


### PR DESCRIPTION
I've create an plugin that allow you to use "Alt+Delete" to remove next word occurence on RBUFFER.
This works like "Alt+Backspace", but reverse.
