### PR TITLE
Adding new Theme & missed correction in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,7 +104,7 @@ The default location is `~/.oh-my-zsh` (hidden in your home directory)
 If you'd like to change the install directory with the `ZSH` environment variable, either by running `export ZSH=/your/path` before installing, or by setting it before the end of the install pipeline like this:
 
 ```shell
-export ZSH="$HOME/.dotfiles/oh-my-zsh"; sh -c "$(curl -fsSL https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+export ZSH="$HOME/.dotfiles/oh-my-zsh"; sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
 ```
 
 #### Manual Installation

--- a/themes/fklama.zsh-theme
+++ b/themes/fklama.zsh-theme
@@ -1,0 +1,9 @@
+local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )%{$reset_color%}"
+local machine="%(!:%{$fg_bold[magenta]%}%m:%{$fg_bold[yellow]%}%m)%{$reset_color%}"
+local final_prompt="%(!:%{$fg_bold[red]%}:%{$fg_bold[green]%})%#%{$reset_color%}"
+PROMPT='${ret_status} ${machine} %{$fg[cyan]%}%c%{$reset_color%} $(git_prompt_info)${final_prompt} '
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%})%{$fg[yellow]%}✗"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
Based on robbytussell theme.
I mainly added the hostname so I can quickly tell on which host I am,
and use the symbols `#`/`%` depending if the user is root or not. The color of the hostname also changes from yellow to magenta for root.

Also added a missing change from `raw.github.com` to `raw.githubusercontent.com`.