### PR TITLE
`gl` should do a `git log`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -145,7 +145,7 @@ compdef _git gk='gitk'
 alias gke='\gitk --all $(git log -g --pretty=format:%h)'
 compdef _git gke='gitk'
 
-alias gl='git pull'
+alias gl='git log'
 alias glg='git log --stat --color'
 alias glgp='git log --stat --color -p'
 alias glgg='git log --graph --color'


### PR DESCRIPTION
before `gl` was aliased to `git push`, which probably is not what one expects