### PR TITLE
Remove undesirable hardcoding of PATH into zshrc

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -53,7 +53,7 @@ plugins=(git)
 
 # User configuration
 
-export PATH=$HOME/bin:/usr/local/bin:$PATH
+# export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 # export MANPATH="/usr/local/man:$MANPATH"
 
 source $ZSH/oh-my-zsh.sh

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -80,12 +80,6 @@ main() {
   " ~/.zshrc > ~/.zshrc-omztemp
   mv -f ~/.zshrc-omztemp ~/.zshrc
 
-  printf "${BLUE}Copying your current PATH and adding it to the end of ~/.zshrc for you.${NORMAL}\n"
-  sed "/export PATH=/ c\\
-  export PATH=\"$PATH\"
-  " ~/.zshrc > ~/.zshrc-omztemp
-  mv -f ~/.zshrc-omztemp ~/.zshrc
-
   # If this user's login shell is not already "zsh", attempt to switch.
   TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
   if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then


### PR DESCRIPTION
See b67961d for why hardcoding the PATH into zshrc is a bad idea and why it's better to allow the user to make those customizations as needed.