### PR TITLE
Optimize the ys.zsh-theme make it simpler

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -35,16 +35,16 @@ ys_hg_prompt_info() {
 	fi
 }
 
-local exit_code="%(?,%?,%{$fg[red]%}%?%{$reset_color%})"
+local exit_code="%(?,,C:%{$fg[red]%}%?%{$reset_color%})"
 
 # Prompt format:
 #
-# PRIVILEGES USER @ MACHINE in DIRECTORY on git:BRANCH STATE [TIME] tty:$TTY L:$SHELL_LEVEL N:LINE_NUM C:LAST_EXIT_CODE
+# PRIVILEGES USER @ MACHINE in DIRECTORY on git:BRANCH STATE [TIME] C:LAST_EXIT_CODE
 # $ COMMAND
 #
 # For example:
 #
-# % ys @ ys-mbp in ~/.oh-my-zsh on git:master x [21:47:42] tty:s000 L:1 N:12 C:0
+# % ys @ ys-mbp in ~/.oh-my-zsh on git:master x [21:47:42] C:0
 # $
 PROMPT="
 %{$terminfo[bold]$fg[blue]%}#%{$reset_color%} \
@@ -56,5 +56,5 @@ PROMPT="
 ${hg_info}\
 ${git_info}\
  \
-%{$fg[white]%}[%*] tty:%l L:%L N:%i C:$exit_code
+%{$fg[white]%}[%*] $exit_code
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"


### PR DESCRIPTION
Remove the tty info, and optimized the exit code.

```
# user @ host in ~/Downloads/test on git:temp x [18:58:52]
$

# user @ host in ~/Downloads/test on git:temp x [18:58:52] C:127
$
```

The `C:127` is the last exit code, it appears only when the exit code is not zero.