### PR TITLE
Update 'tm' function to take multiple files on the command-line

### DIFF
--- a/plugins/textmate/textmate.plugin.zsh
+++ b/plugins/textmate/textmate.plugin.zsh
@@ -1,13 +1,14 @@
 # If the tm command is called without an argument, open TextMate in the current directory
 # If tm is passed a directory, cd to it and open it in TextMate
-# If tm is passed a file, open it in TextMate
+# If tm is passed anything else (i.e., a list of files and/or options), pass them all along
+#    This allows easy opening of multiple files.
 function tm() {
 	if [[ -z $1 ]]; then
 		mate .
-	else
+	elif [[ -d $1 ]]; then
 		mate $1
-		if [[ -d $1 ]]; then
-			cd $1
-		fi
+		cd $1
+	else
+		mate "$@"
 	fi
 }


### PR DESCRIPTION
It seems counter-intuitive to me that `tm file1 file2` or `tm foo.*` only opens the first file. Thus, I took it upon myself to update `textmate.plugin.zsh` to open multiple files if specified. I kept all the existing functionality the same. In particular, if the first arg is a directory, the function ignores everything after it and opens the directory in TextMate.