### PR TITLE
Add asdf version manager plugin

### DIFF
--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -1,0 +1,27 @@
+## asdf
+
+**Maintainer:** [@RobLoach](https://github.com/RobLoach)
+
+Adds integration with [asdf](https://github.com/asdf-vm/asdf), the extendable version manager, with support for Ruby, Node.js, Elixir, Erlang and more.
+
+### Installation
+
+1. Enable the plugin by adding it to your `plugins` definition in `~/.zshrc`.
+
+  ```
+  plugins=(asdf)
+  ```
+
+2. [Install asdf](https://github.com/asdf-vm/asdf#setup) by running the following:
+  ```
+  git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+  ```
+
+### Usage
+
+See the [asdf usage documentation](https://github.com/asdf-vm/asdf#usage) for information on how to use asdf:
+
+```
+asdf plugin-add nodejs git@github.com:asdf-vm/asdf-nodejs.git
+asdf install nodejs 5.9.1
+```

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,0 +1,7 @@
+# Find where asdf should be installed.
+ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
+
+# Load asdf, if found.
+if [ -f $ASDF_DIR/asdf.sh ]; then
+    . $ASDF_DIR/asdf.sh
+fi


### PR DESCRIPTION
[asdf](https://github.com/asdf-vm/asdf) is an extendable version manager with support for Ruby, Node.js, Elixir, [and more](https://github.com/asdf-vm/asdf#usage).

```
asdf plugin-add nodejs git@github.com:asdf-vm/asdf-nodejs.git
asdf install nodejs 5.9.1
```

This plugin simply loads asdf if it finds it. asdf provides the zsh completion for us. The corresponding issue for this is https://github.com/robbyrussell/oh-my-zsh/issues/4942 .