### PR TITLE
Add git user profile functions for prompt display

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -188,6 +188,18 @@ function git_compare_version() {
   echo 0
 }
 
+# Outputs the name of the current user
+# Usage example: $(git_current_user_name)
+function git_current_user_name() {
+  command git config user.name 2>/dev/null
+}
+
+# Outputs the email of the current user
+# Usage example: $(git_current_user_email)
+function git_current_user_email() {
+  command git config user.email 2>/dev/null
+}
+
 # This is unlikely to change so make it all statically assigned
 POST_1_7_2_GIT=$(git_compare_version "1.7.2")
 # Clean up the namespace slightly by removing the checker function


### PR DESCRIPTION
Add functions for `git config user.name` and `git config user.email`.

Useful as visual indicator for people who need to switch between different work and home user accounts often.