### PR TITLE
Add an alias to push current local branch to same name on remote

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -165,6 +165,7 @@ alias gmtvim='git mergetool --no-prompt --tool=vimdiff'
 alias gmum='git merge upstream/master'
 
 alias gp='git push'
+alias gpoh='git push origin HEAD'
 alias gpd='git push --dry-run'
 alias gpoat='git push origin --all && git push origin --tags'
 compdef _git gpoat=git-push


### PR DESCRIPTION
**Background**

* Every time we want to create a Pull Request(PR) wrt our current branch, we generally push to remote and then create a PR against a branch like master. One can now push their current branch to the same name on remote without specifying their branch name.

**Documentation referred for the command -**

* This command is taken from the git related docs at https://git-scm.com/docs/git-push .