### PR TITLE
Add jenv plugin

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -12,7 +12,7 @@
 # Real implementations will be used when the respective plugins are loaded
 function chruby_prompt_info hg_prompt_info pyenv_prompt_info \
   rbenv_prompt_info svn_prompt_info vi_mode_prompt_info \
-  virtualenv_prompt_info {
+  virtualenv_prompt_info jenv_prompt_info {
   return 1
 }
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,3 @@
+# jenv oh-my-zsh plugin
+
+[jenv](http://www.jenv.be/) is a Java version manager similiar to [rbenv](http://rbenv.org/) and [pyenv]|(https://github.com/yyuu/pyenv).  This plugin initializes jenv and adds provides the jenv_prompt_info function to add Java version information to prompts.

--- a/plugins/jenv/jenv.plugin.zsh
+++ b/plugins/jenv/jenv.plugin.zsh
@@ -1,0 +1,33 @@
+_homebrew-installed() {
+    type brew &> /dev/null
+}
+
+_jenv-from-homebrew-installed() {
+    brew --prefix jenv &> /dev/null
+}
+
+jenvdirs=("$HOME/.jenv" "/usr/local/jenv" "/opt/jenv")
+if _homebrew-installed && _jenv-from-homebrew-installed ; then
+    jenvdirs+=($(brew --prefix jenv) "${jenvdirs[@]}")
+fi
+
+FOUND_JENV=0
+for jenvdir in "${jenvdirs[@]}" ; do
+    if [ -d $jenvdir/bin -a $FOUND_JENV -eq 0 ] ; then
+        FOUND_JENV=1
+        export PATH="${jenvdir}/bin:$PATH"
+        eval "$(jenv init - zsh)"
+
+        function jenv_prompt_info() {
+          echo "$(jenv version-name)"
+        }
+    fi
+    if [ -d $jenvdir/versions -a $FOUND_JENV -eq 0 ] ; then
+        export JENV_ROOT=$jenvdir
+    fi
+done
+unset jenvdir
+
+if [ $FOUND_JENV -eq 0 ] ; then
+    function jenv_prompt_info() { echo "system: $(java -version 2>&1 | cut -f 2 -d ' ')" }
+fi


### PR DESCRIPTION
Initializes jenv and provides the jenv_prompt_info funtion to add Java version information to prompts.  This function is stubbed in prompt_info_functions script to allow it to be safely called regardless of whether or not the jenv plugin is loaded.
