### PR TITLE
Use default branch on recently created Mercurial repository

### DIFF
--- a/plugins/branch/branch.plugin.zsh
+++ b/plugins/branch/branch.plugin.zsh
@@ -17,7 +17,12 @@ function branch_prompt_info() {
     # Mercurial repository
     if [[ -d "${current_dir}/.hg" ]]
     then
-      echo '☿' $(<"$current_dir/.hg/branch")
+      if [[ -f "$current_dir/.hg/branch" ]]
+      then
+        echo '☿' $(<"$current_dir/.hg/branch")
+      else
+        echo '☿ default'
+      fi
       return;
     fi
     # Defines path as parent directory and keeps looking for :)


### PR DESCRIPTION
After `hg init` command, sometimes Mercurial does not create `.hg/branch` file so we'll use 'default' as fallback, which is the master branch in Mercurial repositories.