### PR TITLE
Moved git.io url to https

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -71,7 +71,7 @@ exist_gh() { # [DIRECTORY]
 #
 git.io() {
   emulate -L zsh
-  curl -i -s http://git.io -F "url=$1" | grep "Location" | cut -f 2 -d " "
+  curl -i -s https://git.io -F "url=$1" | grep "Location" | cut -f 2 -d " "
 }
 
 # End Functions #############################################################


### PR DESCRIPTION
git.io now redirects to https. So the current function break. Changing it to https fixes the issue.