### PR TITLE
Added --force-with-lease method to git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -95,6 +95,10 @@ ggf() {
 [[ "$#" != 1 ]] && local b="$(git_current_branch)"
 git push --force origin "${b:=$1}"
 }
+ggfl() {
+[[ "$#" != 1 ]] && local b="$(git_current_branch)"
+git push --force-with-lease origin "${b:=$1}"
+}
 compdef _git ggf=git-checkout
 ggl() {
 if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then


### PR DESCRIPTION
This PR adds the ability to use `ggfl` to force push but with the option of `--force-with-lease` so you don't overwrite someone else's code.
