### PR TITLE
Add plugin: dasht (issue: 5040)

### DIFF
--- a/plugins/dasht/_dasht
+++ b/plugins/dasht/_dasht
@@ -1,0 +1,14 @@
+#compdef dasht
+_main() {
+
+  local commands
+  commands=(`dasht-docsets 2>/dev/null`)
+
+  if (( CURRENT >= 3 )); then
+    _describe -t commands 'commands' commands
+  fi
+
+  return 0
+}
+
+_main


### PR DESCRIPTION
Gets list of installed _docsets_ via `dasht-docsets 2>/dev/null` and provides them as autocompletion for second, third, etc. arguments. 
