### PR TITLE
Fix -n option argument error

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -208,7 +208,7 @@ alias gts='git tag -s'
 alias gtv='git tag | sort -V'
 
 alias gunignore='git update-index --no-assume-unchanged'
-alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
+alias gunwip='git log -n1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 alias gup='git pull --rebase'
 alias gupv='git pull --rebase -v'
 alias glum='git pull upstream master'


### PR DESCRIPTION
By removing the whitespace between the "-n" option and the argument
value "1", this commit fixes the issue of the "gunwip" alias.

fix #5079