### PR TITLE
Add alias for switching to previous branch ('git checkout -')

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -40,6 +40,8 @@ function work_in_progress() {
 
 alias g='git'
 
+alias g-='git checkout @{-1}' # ie. 'git checkout -'
+
 alias ga='git add'
 alias gaa='git add --all'
 alias gapa='git add --patch'


### PR DESCRIPTION
@robbyrussell / @mcornella - I've added a small convenience alias to the `git` plugin!

It is based on the alias suggested in [this article](https://marcgg.com/blog/2015/10/18/git-checkout-minus/):

> `alias g-='git checkout -'`

... but I decided to use the original syntax, to ensure compatibility with older versions of `git`:

> `alias g-='git checkout @{-1}'`

Hope you like!  :smile:

@pvdb
