### PR TITLE
add event sink for custom folders

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -7,7 +7,7 @@ function uninstall_oh_my_zsh() {
 }
 
 function upgrade_oh_my_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH ZSH_CUSTOM=$ZSH_CUSTOM /bin/sh $ZSH/tools/upgrade.sh
 }
 
 function take() {

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -11,7 +11,7 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH ZSH_CUSTOM=$ZSH_CUSTOM  /bin/sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
 }

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -34,6 +34,12 @@ then
   printf "${BLUE}%s\n" "Hooray! Oh My Zsh has been updated and/or is at the current version."
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "To keep up on the latest news and updates, follow us on twitter: https://twitter.com/ohmyzsh"
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "Get your Oh My Zsh swag at:  http://shop.planetargon.com/"
+
+  if [ -f $ZSH_CUSTOM/tools/custom_event.sh ]; then
+    # Notify user's custom code of upgrades
+    env ZSH=$ZSH ZSH_CUSTOM=$ZSH_CUSTOM /bin/sh $ZSH_CUSTOM/tools/custom_event.sh upgrade
+  fi
+
 else
   printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
 fi


### PR DESCRIPTION
For those of us not lucky enough to get our (custom) theme included in the repo, keeping the theme up-to-date across machines/environments is a painful process. I've used several solutions over the years but would like to see some real support from oh-my-zsh. This PR is it pretty lightweight way to give a user's custom folder notification of when "upgrades" happen for the base oh-my-zsh.