### PR TITLE
Add rbenv support for ruby version display in the Avit theme

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -41,6 +41,8 @@ function _vi_status() {
 function _ruby_version() {
   if {echo $fpath | grep -q "plugins/rvm"}; then
     echo "%{$fg[grey]%}$(rvm_prompt_info)%{$reset_color%}"
+  elif {echo $fpath | grep -q "plugins/rbenv"}; then
+    echo "%{$fg[grey]%}$(rbenv_prompt_info)%{$reset_color%}"
   fi
 }
 


### PR DESCRIPTION
The function _ruby_version() which is called in prompt only checks for RVM. I just added rbenv support. It works as expected.