### PR TITLE
refresh .rake_tasks when lib/tasks changed

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -8,7 +8,19 @@ _rake_refresh () {
 }
 
 _rake_does_task_list_need_generating () {
-  [[ ! -f .rake_tasks ]] || [[ Rakefile -nt .rake_tasks ]]
+  [[ ! -f .rake_tasks ]] || [[ Rakefile -nt .rake_tasks ]] || (_is_rails_app && _tasks_changed)
+}
+
+_is_rails_app () {
+  [[ -e "bin/rails" ]] || [ -e "script/rails" ]
+}
+
+_tasks_changed () {
+  local is_changed=1
+  for file in lib/tasks/**/*.rake; do
+    if [[ $file -nt .rake_tasks ]]; then is_changed=0; fi
+  done
+  return is_changed
 }
 
 _rake_generate () {


### PR DESCRIPTION
Hi!

I have found that in Rails app file `.rake_tasks` doesn't refresh.
This happens because `Rakefile` always stays the same.
But all `rake` tasks and `.rake` files are placed in `lib/tasks` folder.

So I have prepared this PR in order to refresh `.rake_tasks` when something has changed in `lib/tasks` folder.

I'm new to shell scripting so any comments are welcome.

Thank you.
