### PR TITLE
Fix nvm command check

### DIFF
--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,6 +1,6 @@
 # get the node.js version
 function nvm_prompt_info() {
-  [ -f "$HOME/.nvm/nvm.sh" ] || return
+  which nvm >/dev/null 2>/dev/null || return
   local nvm_prompt
   nvm_prompt=$(node -v 2>/dev/null)
   [[ "${nvm_prompt}x" == "x" ]] && return


### PR DESCRIPTION
Issue: When installing `nvm` via [`brew`](http://brew.sh) the `nvm.sh` script is located in the standard brew formula directory rather than in `~/.nvm`. This causes the nvm command check failing.

This merge request solves the problem with the simple `which nvm` command. No matter it's output, the exit code will be non-zero if there is no runnable `nvm` and the script will stop.