### PR TITLE
Docker Plugin: Display images for push/pull/build

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -48,6 +48,7 @@ __build() {
         '--rm[Remove intermediate containers after a successful build]' \
         '(-t,--tag=)'{-t,--tag=}'[Repository name (and optionally a tag) to be applied to the resulting image in case of success]' \
         '*:files:_files'
+    __docker_images
 }
 
 __commit() {
@@ -194,10 +195,11 @@ __ps() {
 __pull() {
     _arguments \
         '(-t,--tag=)'{-t,--tag=}'[Download tagged image in repository]'
+    __docker_images
 }
 
 __push() {
-    # no arguments
+    __docker_images
 }
 
 __restart() {


### PR DESCRIPTION
This will allow auto-completion of image names when pushing or pulling.
It is especially helpful when using custom registries.

This takes a long time to type out by hand every time:
`registry.example.com/user/project:tag`