### PR TITLE
github plugin: remove hub

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,10 +1,3 @@
-# Set up hub wrapper for git, if it is available; http://github.com/github/hub
-if [ "$commands[(I)hub]" ]; then
-  if hub --version &>/dev/null; then
-    eval $(hub alias -s zsh)
-  fi
-fi
-
 # Functions #################################################################
 
 # Based on https://github.com/dbb/githome/blob/master/.config/zsh/functions


### PR DESCRIPTION
It should not be included in the github plugin, because it is a tool by itself
and can cause some issues.

Apart from that it does (up to) 2 unnecessary calls to the `hub`
command.

After all, the integration boils down to:

```
alias git=hub
```

This is not enough for an own plugin, but users should just add this to
their zshrc.
