### PR TITLE
add 'mvn clean install -DskipTests --offline' alias to speed up maven compile

### DIFF
--- a/plugins/mvn/README.md
+++ b/plugins/mvn/README.md
@@ -15,6 +15,7 @@ plugins=(... mvn)
 | `mvncie`             | `mvn clean install eclipse:eclipse`             |
 | `mvnci`              | `mvn clean install`                             |
 | `mvncist`            | `mvn clean install -DskipTests`                 |
+| `mvncisto`           | `mvn clean install -DskipTests --offline`       |
 | `mvne`               | `mvn eclipse:eclipse`                           |
 | `mvnd`               | `mvn deploy`                                    |
 | `mvnp`               | `mvn package`                                   |

--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -45,6 +45,7 @@ mvn-color()
 alias mvncie='mvn clean install eclipse:eclipse'
 alias mvnci='mvn clean install'
 alias mvncist='mvn clean install -DskipTests'
+alias mvncisto='mvn clean install -DskipTests --offline'
 alias mvne='mvn eclipse:eclipse'
 alias mvnce='mvn clean eclipse:clean eclipse:eclipse'
 alias mvnd='mvn deploy'


### PR DESCRIPTION
It doesn't need to check the latest dependency for the most part.