### PR TITLE
Peepcode theme: Don't try to use RVM if not installed

### DIFF
--- a/themes/peepcode.zsh-theme
+++ b/themes/peepcode.zsh-theme
@@ -41,4 +41,10 @@ PROMPT='
 %~
 ${smiley}  %{$reset_color%}'
 
-RPROMPT='%{$fg[white]%} $(~/.rvm/bin/rvm-prompt)$(git_prompt)%{$reset_color%}'
+if [[ -d ~/.rvm ]] && [[ -e ~/.rvm/bin/rvm-prompt ]]; then
+    rvm_prompt='$(~/.rvm/bin/rvm-prompt)'
+else
+    rvm_prompt=''
+fi
+
+RPROMPT='%{$fg[white]%} $rvm_prompt$(git_prompt)%{$reset_color%}'


### PR DESCRIPTION
Copied from #4971, created from a feature branch instead

I just installed oh-my-zsh and I immediately fell for the Peepcode theme. The only problem is that it keeps trying to access the Ruby Version Manager (rvm-prompt) which I don't have installed, giving the same error after each command:

`zsh: no such file or directory: /home/harald/.rvm/bin/rvm-prompt`

This small piece of code checks for the existence of the ~/.rvm folder, and if it's not there it just disregards that part of the prompt.

