### PR TITLE
NixOS: Use autojump.sh to figure out location of autojump.zsh

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,8 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . $HOME/.autojump/etc/profile.d/autojump.zsh
   elif [ -f $HOME/.autojump/share/autojump/autojump.zsh ]; then # another manual user-local installation
     . $HOME/.autojump/share/autojump/autojump.zsh
-  elif [ -f $HOME/.nix-profile/etc/profile.d/autojump.zsh ]; then # nix installation
-    . $HOME/.nix-profile/etc/profile.d/autojump.zsh
+  elif [ -f $HOME/.nix-profile/etc/profile.d/autojump.sh ]; then # nix installation
+    . $HOME/.nix-profile/etc/profile.d/autojump.sh
   elif [ -f /usr/share/autojump/autojump.zsh ]; then # debian and ubuntu package
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation


### PR DESCRIPTION
`$HOME/.nix-profile/etc/profile.d/autojump.zsh` does not exist anymore, `autojump.sh` determines the shell and sources the appropriate file.
