### PR TITLE
installer: fix, refactor and add installer arguments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.sh]
+indent_size = 4
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -38,7 +38,18 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/mas
 #### via wget
 
 ```shell
-sh -c "$(wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
+sh -c "$(wget -O- https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+```
+
+#### Manual inspection
+
+It's a good idea to inspect the install script from projects you don't yet know. You can do
+that by downloading the install script first, looking through it so everything looks normal,
+then running it:
+
+```shell
+curl -Lo install.sh https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh
+sh install.sh
 ```
 
 ## Using Oh My Zsh
@@ -68,6 +79,8 @@ plugins=(
   ruby
 )
 ```
+
+_Note that the plugins are separated by whitespace. **Do not** use commas between them._
 
 #### Using Plugins
 
@@ -124,16 +137,53 @@ If you're the type that likes to get their hands dirty, these sections might res
 
 ### Advanced Installation
 
-Some users may want to change the default path, or manually install Oh My Zsh.
+Some users may want to manually install Oh My Zsh, or change the default path or other settings that
+the installer accepts (these settings are also documented at the top of the install script).
 
 #### Custom Directory
 
 The default location is `~/.oh-my-zsh` (hidden in your home directory)
 
-If you'd like to change the install directory with the `ZSH` environment variable, either by running `export ZSH=/your/path` before installing, or by setting it before the end of the install pipeline like this:
+If you'd like to change the install directory with the `ZSH` environment variable, either by running
+`export ZSH=/your/path` before installing, or by setting it before the end of the install pipeline
+like this:
 
 ```shell
-export ZSH="$HOME/.dotfiles/oh-my-zsh"; sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+ZSH="$HOME/.dotfiles/oh-my-zsh" sh install.sh
+```
+
+#### Unattended install
+
+If you're running the Oh My Zsh install script as part of an automated install, you can pass the
+flag `--unattended` to the `install.sh` script. This will have the effect of not trying to change
+the default shell, and also won't run `zsh` when the installation has finished.
+
+```shell
+curl -Lo install.sh https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh
+sh install.sh --unattended
+```
+
+#### Installing from a forked repository
+
+The install script also accepts these variables to allow installation of a different repository:
+
+- `REPO` (default: `robbyrussell/oh-my-zsh`): this takes the form of `owner/repository`. If you set
+  this variable, the installer will look for a repository at `https://github.com/{owner}/{repository}`.
+
+- `REMOTE` (default: `https://github.com/${REPO}.git`): this is the full URL of the git repository
+  clone. You can use this setting if you want to install from a fork that is not on GitHub (GitLab,
+  Bitbucket...) or if you want to clone with SSH instead of HTTPS (`git@github.com:user/project.git`).
+
+  _NOTE: it's incompatible with setting the `REPO` variable. This setting will take precedence._
+
+- `BRANCH` (default: `master`): you can use this setting if you want to change the default branch to be
+  checked out when cloning the repository. This might be useful for testing a Pull Request, or if you
+  want to use a branch other than `master`.
+
+For example:
+
+```shell
+REPO=apjanke/oh-my-zsh BRANCH=edge sh install.sh
 ```
 
 #### Manual Installation
@@ -161,9 +211,10 @@ cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
 ##### 4. Change your default shell
 
 ```shell
-chsh -s /bin/zsh
+chsh -s $(which zsh)
 ```
-You must log out and log back in to see this change.
+
+You must log out from your user session and log back in to see this change.
 
 ##### 5. Initialize your new zsh configuration
 
@@ -173,8 +224,10 @@ Once you open up a new terminal window, it should load zsh with Oh My Zsh's conf
 
 If you have any hiccups installing, here are a few common fixes.
 
-* You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after switching to `oh-my-zsh`.
-* If you installed manually or changed the install location, check the `ZSH` environment variable in `~/.zshrc`.
+* You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after
+switching to `oh-my-zsh`.
+* If you installed manually or changed the install location, check the `ZSH` environment variable in
+`~/.zshrc`.
 
 ### Custom Plugins and Themes
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,114 +1,272 @@
-main() {
-  # Use colors, but only if connected to a terminal, and that terminal
-  # supports them.
-  if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
-  fi
-  if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
-    RED="$(tput setaf 1)"
-    GREEN="$(tput setaf 2)"
-    YELLOW="$(tput setaf 3)"
-    BLUE="$(tput setaf 4)"
-    BOLD="$(tput bold)"
-    NORMAL="$(tput sgr0)"
-  else
-    RED=""
-    GREEN=""
-    YELLOW=""
-    BLUE=""
-    BOLD=""
-    NORMAL=""
-  fi
+#!/bin/sh
+#
+# This script should be run via curl:
+#   sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+# or wget:
+#   sh -c "$(wget -qO- https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+#
+# As an alternative, you can first download the install script and run it afterwards:
+#   wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh
+#   sh install.sh
+#
+# You can tweak the install behavior by setting variables when running the script. For
+# example, to change the path to the Oh My Zsh repository:
+#   ZSH=~/.zsh sh install.sh
+#
+# Respects the following environment variables:
+#   ZSH     - path to the Oh My Zsh repository folder (default: $HOME/.oh-my-zsh)
+#   REPO    - name of the GitHub repo to install from (default: robbyrussell/oh-my-zsh)
+#   REMOTE  - full remote URL of the git repo to install (default: GitHub via HTTPS)
+#   BRANCH  - branch to check out immediately after install (default: master)
+#
+# Other options:
+#   CHSH    - 'no' means the installer will not change the default shell (default: yes)
+#   RUNZSH  - 'no' means the installer will not run zsh after the install (default: yes)
+#
+# You can also pass some arguments to the install script to set some these options:
+#   --skip-chsh: has the same behavior as setting CHSH to 'no'
+#   --unattended: sets both CHSH and RUNZSH to 'no'
+# For example:
+#   sh install.sh --unattended
+#
+set -e
 
-  # Only enable exit-on-error after the non-critical colorization stuff,
-  # which may fail on systems lacking tput or terminfo
-  set -e
+# Default settings
+ZSH=${ZSH:-~/.oh-my-zsh}
+REPO=${REPO:-robbyrussell/oh-my-zsh}
+REMOTE=${REMOTE:-https://github.com/${REPO}.git}
+BRANCH=${BRANCH:-master}
 
-  if ! command -v zsh >/dev/null 2>&1; then
-    printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"
-    exit
-  fi
-
-  if [ ! -n "$ZSH" ]; then
-    ZSH=~/.oh-my-zsh
-  fi
-
-  if [ -d "$ZSH" ]; then
-    printf "${YELLOW}You already have Oh My Zsh installed.${NORMAL}\n"
-    printf "You'll need to remove $ZSH if you want to re-install.\n"
-    exit
-  fi
-
-  # Prevent the cloned repository from having insecure permissions. Failing to do
-  # so causes compinit() calls to fail with "command not found: compdef" errors
-  # for users with insecure umasks (e.g., "002", allowing group writability). Note
-  # that this will be ignored under Cygwin by default, as Windows ACLs take
-  # precedence over umasks except for filesystems mounted with option "noacl".
-  umask g-w,o-w
-
-  printf "${BLUE}Cloning Oh My Zsh...${NORMAL}\n"
-  command -v git >/dev/null 2>&1 || {
-    echo "Error: git is not installed"
-    exit 1
-  }
-  # The Windows (MSYS) Git is not compatible with normal use on cygwin
-  if [ "$OSTYPE" = cygwin ]; then
-    if git --version | grep msysgit > /dev/null; then
-      echo "Error: Windows/MSYS Git is not supported on Cygwin"
-      echo "Error: Make sure the Cygwin git package is installed and is first on the path"
-      exit 1
-    fi
-  fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git "$ZSH" || {
-    printf "Error: git clone of oh-my-zsh repo failed\n"
-    exit 1
-  }
+# Other options
+CHSH=${CHSH:-yes}
+RUNZSH=${RUNZSH:-yes}
 
 
-  printf "${BLUE}Looking for an existing zsh config...${NORMAL}\n"
-  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    printf "${YELLOW}Found ~/.zshrc.${NORMAL} ${GREEN}Backing up to ~/.zshrc.pre-oh-my-zsh${NORMAL}\n";
-    mv ~/.zshrc ~/.zshrc.pre-oh-my-zsh;
-  fi
-
-  printf "${BLUE}Using the Oh My Zsh template file and adding it to ~/.zshrc${NORMAL}\n"
-  cp "$ZSH"/templates/zshrc.zsh-template ~/.zshrc
-  sed "/^export ZSH=/ c\\
-  export ZSH=\"$ZSH\"
-  " ~/.zshrc > ~/.zshrc-omztemp
-  mv -f ~/.zshrc-omztemp ~/.zshrc
-
-  # If this user's login shell is not already "zsh", attempt to switch.
-  TEST_CURRENT_SHELL=$(basename "$SHELL")
-  if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
-    # If this platform provides a "chsh" command (not Cygwin), do it, man!
-    if hash chsh >/dev/null 2>&1; then
-      printf "${BLUE}Time to change your default shell to zsh!${NORMAL}\n"
-      chsh -s $(grep /zsh$ /etc/shells | tail -1)
-    # Else, suggest the user do so manually.
-    else
-      printf "I can't change your shell automatically because this system does not have chsh.\n"
-      printf "${BLUE}Please manually change your default shell to zsh!${NORMAL}\n"
-    fi
-  fi
-
-  printf "${GREEN}"
-  echo '         __                                     __   '
-  echo '  ____  / /_     ____ ___  __  __   ____  _____/ /_  '
-  echo ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '
-  echo '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
-  echo '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
-  echo '                        /____/                       ....is now installed!'
-  echo ''
-  echo ''
-  echo 'Please look over the ~/.zshrc file to select plugins, themes, and options.'
-  echo ''
-  echo 'p.s. Follow us at https://twitter.com/ohmyzsh'
-  echo ''
-  echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh'
-  echo ''
-  printf "${NORMAL}"
-  env zsh -l
+command_exists() {
+	command -v "$@" >/dev/null 2>&1
 }
 
-main
+error() {
+	echo ${RED}"Error: $@"${RESET} >&2
+}
+
+# Set up color sequences
+setup_color() {
+	ncolors=$(tput colors 2>/dev/null) || ncolors=0
+
+	# Only use colors if connected to a terminal that supports them
+	if [ -t 1 ] && [ $ncolors -ge 8 ]; then
+		RED="$(tput setaf 1)"
+		GREEN="$(tput setaf 2)"
+		YELLOW="$(tput setaf 3)"
+		BLUE="$(tput setaf 4)"
+		BOLD="$(tput bold)"
+		RESET="$(tput sgr0)"
+	else
+		RED=$(printf '\033[31m')
+		GREEN=$(printf '\033[32m')
+		YELLOW=$(printf '\033[33m')
+		BLUE=$(printf '\033[34m')
+		BOLD=$(printf '\033[1m')
+		RESET=$(printf '\033[m')
+	fi
+}
+
+setup_ohmyzsh() {
+	# Prevent the cloned repository from having insecure permissions. Failing to do
+	# so causes compinit() calls to fail with "command not found: compdef" errors
+	# for users with insecure umasks (e.g., "002", allowing group writability). Note
+	# that this will be ignored under Cygwin by default, as Windows ACLs take
+	# precedence over umasks except for filesystems mounted with option "noacl".
+	umask g-w,o-w
+
+	echo "${BLUE}Cloning Oh My Zsh...${RESET}"
+
+	command_exists git || {
+		error "git is not installed"
+		exit 1
+	}
+
+	if [ "$OSTYPE" = cygwin ] && git --version | grep -q msysgit; then
+		error "Windows/MSYS Git is not supported on Cygwin"
+		error "Make sure the Cygwin git package is installed and is first on the \$PATH"
+		exit 1
+	fi
+
+	git clone --depth=1 --branch "$BRANCH" "$REMOTE" "$ZSH" || {
+		error "git clone of oh-my-zsh repo failed"
+		exit 1
+	}
+
+	echo
+}
+
+setup_zshrc() {
+	# Keep most recent old .zshrc at .zshrc.pre-oh-my-zsh, and older ones
+	# with datestamp of installation that moved them aside, so we never actually
+	# destroy a user's original zshrc
+	echo "${BLUE}Looking for an existing zsh config...${RESET}"
+
+	# Must use this exact name so uninstall.sh can find it
+	OLD_ZSHRC=~/.zshrc.pre-oh-my-zsh
+	if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+		if [ -e "$OLD_ZSHRC" ]; then
+			OLD_OLD_ZSHRC="${OLD_ZSHRC}-$(date +%Y-%m-%d_%H-%M-%S)"
+			if [ -e "$OLD_OLD_ZSHRC" ]; then
+				error "$OLD_OLD_ZSHRC exists. Can't back up ${OLD_ZSHRC}"
+				error "re-run the installer again in a couple of seconds"
+				exit 1
+			fi
+			mv "$OLD_ZSHRC" "${OLD_OLD_ZSHRC}"
+
+			echo "${YELLOW}Found old ~/.zshrc.pre-oh-my-zsh." \
+				"${GREEN}Backing up to ${OLD_OLD_ZSHRC}${RESET}"
+		fi
+		echo "${YELLOW}Found ~/.zshrc.${RESET} ${GREEN}Backing up to ${OLD_ZSHRC}${RESET}"
+		mv ~/.zshrc "$OLD_ZSHRC"
+	fi
+
+	echo "${GREEN}Using the Oh My Zsh template file and adding it to ~/.zshrc.${RESET}"
+
+	cp "$ZSH/templates/zshrc.zsh-template" ~/.zshrc
+	sed "/^export ZSH=/ c\\
+export ZSH=\"$ZSH\"
+" ~/.zshrc > ~/.zshrc-omztemp
+	mv -f ~/.zshrc-omztemp ~/.zshrc
+
+	echo
+}
+
+setup_shell() {
+	# Skip setup if the user wants or stdin is closed (not running interactively).
+	if [ $CHSH = no ]; then
+		return
+	fi
+
+	# If this user's login shell is already "zsh", do not attempt to switch.
+	if [ "$(basename "$SHELL")" = "zsh" ]; then
+		return
+	fi
+
+	# If this platform doesn't provide a "chsh" command, bail out.
+	if ! command_exists chsh; then
+		cat <<-EOF
+			I can't change your shell automatically because this system does not have chsh.
+			${BLUE}Please manually change your default shell to zsh${RESET}
+		EOF
+		return
+	fi
+
+	echo "${BLUE}Time to change your default shell to zsh:${RESET}"
+
+	# Prompt for user choice on changing the default login shell
+	printf "${YELLOW}Do you want to change your default shell to zsh? [Y/n]${RESET} "
+	read opt
+	case $opt in
+		y*|Y*|"") echo "Changing the shell..." ;;
+		n*|N*) echo "Shell change skipped."; return ;;
+		*) echo "Invalid choice. Shell change skipped."; return ;;
+	esac
+
+	# Test for the right location of the "shells" file
+	if [ -f /etc/shells ]; then
+		shells_file=/etc/shells
+	elif [ -f /usr/share/defaults/etc/shells ]; then # Solus OS
+		shells_file=/usr/share/defaults/etc/shells
+	else
+		error "could not find /etc/shells file. Change your default shell manually."
+		return
+	fi
+
+	# Get the path to the right zsh binary
+	# 1. Use the most preceding one based on $PATH, then check that it's in the shells file
+	# 2. If that fails, get a zsh path from the shells file, then check it actually exists
+	if ! zsh=$(which zsh) || ! grep -qx "$zsh" "$shells_file"; then
+		if ! zsh=$(grep '^/.*/zsh$' "$shells_file" | tail -1) || [ ! -f "$zsh" ]; then
+			error "no zsh binary found or not present in '$shells_file'"
+			error "change your default shell manually."
+			return
+		fi
+	fi
+
+	# We're going to change the default shell, so back up the current one
+	if [ -n $SHELL ]; then
+		echo $SHELL > ~/.shell.pre-oh-my-zsh
+	else
+		grep "^$USER:" /etc/passwd | awk -F: '{print $7}' > ~/.shell.pre-oh-my-zsh
+	fi
+
+	# Actually change the default shell to zsh
+	if ! chsh -s "$zsh"; then
+		error "chsh command unsuccessful. Change your default shell manually."
+	else
+		export SHELL="$zsh"
+		echo "${GREEN}Shell successfully changed to '$zsh'.${RESET}"
+	fi
+
+	echo
+}
+
+main() {
+	# Run as unattended if stdin is closed
+	if [ ! -t 0 ]; then
+		RUNZSH=no
+		CHSH=no
+	fi
+
+	# Parse arguments
+	while [ $# -gt 0 ]; do
+		case $1 in
+			--unattended) RUNZSH=no; CHSH=no ;;
+			--skip-chsh) CHSH=no ;;
+		esac
+		shift
+	done
+
+	setup_color
+
+	if ! command_exists zsh; then
+		echo "${YELLOW}Zsh is not installed.${RESET} Please install zsh first."
+		exit 1
+	fi
+
+	if [ -d "$ZSH" ]; then
+		cat <<-EOF
+			${YELLOW}You already have Oh My Zsh installed.${RESET}
+			You'll need to remove '$ZSH' if you want to reinstall.
+		EOF
+		exit 1
+	fi
+
+	setup_ohmyzsh
+	setup_zshrc
+	setup_shell
+
+	printf "$GREEN"
+	cat <<-'EOF'
+		         __                                     __
+		  ____  / /_     ____ ___  __  __   ____  _____/ /_
+		 / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
+		/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
+		\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
+		                        /____/                       ....is now installed!
+
+
+		Please look over the ~/.zshrc file to select plugins, themes, and options.
+
+		p.s. Follow us on https://twitter.com/ohmyzsh
+
+		p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh
+
+	EOF
+	printf "$RESET"
+
+	if [ $RUNZSH = no ]; then
+		echo "${YELLOW}Run zsh to try it out.${RESET}"
+		exit
+	fi
+
+	exec zsh -l
+}
+
+main "$@"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -10,25 +10,35 @@ if [ -d ~/.oh-my-zsh ]; then
 fi
 
 echo "Looking for original zsh config..."
-if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]; then
-  echo "Found ~/.zshrc.pre-oh-my-zsh -- Restoring to ~/.zshrc";
+ZSHRC_ORIG=~/.zshrc.pre-oh-my-zsh
+if [ -e "$ZSHRC_ORIG" ]; then
+  echo "Found $ZSHRC_ORIG -- Restoring to ~/.zshrc"
 
-  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
-    ZSHRC_SAVE=".zshrc.omz-uninstalled-$(date +%Y%m%d%H%M%S)";
-    echo "Found ~/.zshrc -- Renaming to ~/${ZSHRC_SAVE}";
-    mv ~/.zshrc ~/"${ZSHRC_SAVE}";
+  if [ -e ~/.zshrc ]; then
+    ZSHRC_SAVE=~/.zshrc.omz-uninstalled-$(date +%Y-%m-%d_%H-%M-%S)
+    echo "Found ~/.zshrc -- Renaming to ${ZSHRC_SAVE}"
+    mv ~/.zshrc "${ZSHRC_SAVE}"
   fi
 
-  mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
+  mv "$ZSHRC_ORIG" ~/.zshrc
 
-  echo "Your original zsh config was restored. Please restart your session."
-else
-  if hash chsh >/dev/null 2>&1; then
-    echo "Switching back to bash"
-    chsh -s /bin/bash
+  echo "Your original zsh config was restored."
+fi
+
+if hash chsh >/dev/null 2>&1; then
+  if [ -f ~/.shell.pre-oh-my-zsh ]; then
+    old_shell=$(cat ~/.shell.pre-oh-my-zsh)
   else
-    echo "You can edit /etc/passwd to switch your default shell back to bash"
+	old_shell=/bin/bash
+  fi
+  echo "Switching your shell back to '$old_shell':"
+  if chsh -s "$old_shell"; then
+    rm -f ~/.shell.pre-oh-my-zsh
+  else
+    echo "Could not change default shell. Change it manually by running chsh"
+	echo "or editing the /etc/passwd file."
   fi
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."
+echo "Don't forget to restart your terminal!"


### PR DESCRIPTION
Ready for testing

This is an all-encompassing PR to fix once and for all all issues related to the OMZ installer, as well as adding features requested many times.

---
### Fixes

#### `zshrc` file mangling

- [x] #2499: Some minor alteration concerning `.zshrc.pre-oh-my-zsh`
- [x] #4390: Please, oh please, ask, or at least warn, about overwriting ~/.zshrc on installation PR
- [x] #4391: installer: use timestamped backups to preserve all old zshrcs

Fixes #2499. Fixes #4390. Fixes #4391.

#### Change of default shell issues

- [x] #4131: Does not change default shell to zsh on NixOS
- [x] #4564: Handle systems where /etc/shells does not exist
- [x] [#4818](https://github.com/robbyrussell/oh-my-zsh/issues/4818#issuecomment-178106951): installer doesn't check if the zsh obtained from `/etc/shells` exists
- [x] #5277: Install script set my shell to /usr/local/bin/zsh instead of /bin/zsh
- [x] #6569: Patch for detect shell file in Solus OS
- [x] #7254: Make sure the line begins with a (forward) slash ('/')

Fixes #4131. Fixes #4564. Fixes #4818. Fixes #5277. Fixes #6569. Fixes #7254.

#### Restore default shell

- [x] #3447: oh-my-zsh uninstall.sh issues - switch back to bash is unsatisfactory
- [x] #6119: uninstall zsh didn't revert shell back to bash on OSX
- [x] #6299: Uninstalling oh my zsh does NOT restore previous default shell
- [x] #6356: Fix for #6299: restore previous default shell with uninstall
- [x] #6608: Uninstall restores now the original shell

Fixes #3447. Fixes #6119. Fixes #6299. Fixes #6356. Fixes #6608.

#### `$PATH` management

- [x] #1359: Do not force PATH in the installer
- [x] #2586: install.sh: `PATH=` with no `$PATH` inside
- [x] #2589: Respect original PATH definitions on install
- [x] #4317: Should export PATH contain $PATH in .zshrc?
- [x] #4925: Remove undesirable hardcoding of PATH into zshrc

Fixes #1359. Fixes #2586. Fixes #4925. Closes #2589. Closes #4317.

### New features

#### Skip change of default shell

- [x] #4261: Prevent shell change during setup
- [x] #7100: Suggestion: add a flag to bypass setting zsh as default shell
- [x] #7266: Adds skip-chsh flag to switch login shell step
- [x] #7721: Installation script shouldn't alter default shell
- [x] #7865: Make setting the default shell during installation optional

Fixes #4621. Fixes #7100. Fixes #7266. Fixes #7721. Fixes #7865.

The installer respects the environment variable `CHSH`. Set to `no`, it will skip the chsh step. It also reads the flag `--skip-chsh` which has the same effect. For instance, these two are equivalent:
```sh
CHSH=no sh install.sh
sh install.sh --skip-chsh
```

#### Don't run zsh after install

- [x] #4393: [Discuss] What should installer behavior be, esp wrt launching new shells?
- [x] #5002: add a way to not launch zsh after finishing
- [x] #5853: Add a flag to prevent the "launch" of zsh
- [x] #5893: Allow batch mode installation
- [x] #6547: Add support for --silent option in install.sh script
- [x] #7790: Add non-interactive option to install script

Fixes #4393. Fixes #5002. Fixes #5853. Fixes #5893. Fixes #6547. Fixes #7790.

As in the skip-chsh feature above, the installer respects the variable `RUNZSH`, which when set to `no` will skip the zsh call when the install is done. The flag `--unattended` also sets `RUNZSH=no`, as well as setting `CHSH=no`. So these two are equivalent:
```sh
RUNZSH=no CHSH=no sh install.sh
sh install.sh --unattended
```

#### Forks

- [x] #3648: Installer: add ability to install from forked repos
- [x] #5628: Zsh installer defaults to main repo even if installed from fork sync
- [x] #7496: make installation script configurable for forks

Fixes #3648. Fixes #5628. Fixes #7496.

The installer respects the following environment variables, that can be set up when calling it with `VAR=value sh install.sh`.

- `REPO`: value in the form of `owner/project`. Useful for forks in GitHub (defaults to `robbyrussell/oh-my-zsh).
- `BRANCH`: default branch to check out once the clone has finished (defaults to master).
- `REMOTE`: full remote URL (supersedes `REPO` if set). You could for example choose an ssh remote URL, like `git@github.com:user/oh-my-zsh`, or another fork from GitLab or Bitbucket.

### Other

- [x] #5194: installer: git clone using ssh URL if https fails
- [x] #5320: Greatly improve the OMZ install.sh
- [x] #7007: Replace the current shell with the new ZSH instance

Fixes #5320. Fixes #7007.
Closes #5194.
