### PR TITLE
znt: update to v2.2.1

### DIFF
--- a/plugins/zsh-navigation-tools/.config/znt/n-kill.conf
+++ b/plugins/zsh-navigation-tools/.config/znt/n-kill.conf
@@ -8,7 +8,7 @@ local active_text=reverse
 # This doesn't cover scripts named "[0-9]## *", which should be very rare
 # (#s) is ^, (#e) is $, # is *, ## is + (comparing to regex)
 # | is alternative, but only in ()
-local NLIST_COLORING_PATTERN="((#s) #[0-9]## |[[][^]]#](#e)|[^ 0-9/?\\\\][^/\\\\]#(#e)|[^ /\\\\]##[^0-9/\\\\ ]##[^/\\\\]#(#e))"
+local NLIST_COLORING_PATTERN="((#s) #[0-9]## |[[][^]]#](#e)|[^ 0-9/?\\\\][^/\\\\]#(#e))"
 local NLIST_COLORING_COLOR=$'\x1b[00;33m'
 local NLIST_COLORING_MATCH_MULTIPLE=1
 

--- a/plugins/zsh-navigation-tools/.config/znt/n-list.conf
+++ b/plugins/zsh-navigation-tools/.config/znt/n-list.conf
@@ -6,7 +6,7 @@ local bold=0
 local colorpair="white/black"
 
 # Should draw the border?
-local border=1
+local border=0
 
 # Combinations of colors to try out with Ctrl-T and Ctrl-G
 # The last number is the bold option, 0 or 1

--- a/plugins/zsh-navigation-tools/n-help
+++ b/plugins/zsh-navigation-tools/n-help
@@ -1,11 +1,11 @@
 autoload colors
 colors
 
-local h1="$fg_bold[cyan]"
+local h1="$fg_bold[magenta]"
 local h2="$fg_bold[green]"
 local h3="$fg_bold[blue]"
 local h4="$fg_bold[yellow]"
-local h5="$fg_bold[magenta]"
+local h5="$fg_bold[cyan]"
 local rst="$reset_color"
 
 LESS="-iRc" less <<<"
@@ -93,4 +93,43 @@ start. This is a way to have handy set of bookmarks prepared in private
 history's file.
 
 Private history is instantly shared among sessions.
+
+${h1}Zshrc integration${rst}
+
+There are 5 standard configuration variables that can be set in zshrc:
+
+${h4}znt_history_active_text${rst}
+\"underline\" or \"reverse\" - how should be active element highlighted
+${h4}znt_history_nlist_coloring_pattern${rst}
+Pattern that can be used to colorize elements
+${h4}znt_history_nlist_coloring_color${rst}
+Color with which to colorize via the pattern
+${h4}znt_history_nlist_coloring_match_multiple${rst}
+Should multiple matches be colorized (${h2}\"0\"${rst} or ${h2}\"1\"${rst})
+${h4}znt_history_keywords ${h2}(array)${rst}
+Search keywords activated with Ctrl-X, F2, Ctrl-/, e.g. ( ${h2}\"git\"${rst} ${h2}\"vim\"${rst} )
+
+Above variables will work for n-history tool. For other tools, change
+\"_history_\" to e.g. \"_cd_\", for the n-cd tool. The same works for
+all 8 tools.
+
+Common configuration of the tools uses variables with \"_list_\" in them:
+
+${h4}znt_list_bold${rst}
+Should draw text in bold (${h2}\"0\"${rst} or ${h2}\"1\"${rst})
+${h4}znt_list_colorpair${rst}
+Main pair of colors to be used, e.g ${h2}\"green/black\"${rst}
+${h4}znt_list_border${rst}
+Should draw borders around windows (${h2}\"0\"${rst} or ${h2}\"1\"${rst})
+${h4}znt_list_themes ${h2}(array)${rst}
+List of themes to try out with Ctrl-T, e.g. ( ${h2}\"white/black/1\"${rst}
+${h2}\"green/black/0\"${rst} )
+${h4}znt_list_instant_select${rst}
+Should pressing enter in search mode leave tool (${h2}\"0\"${rst} or ${h2}\"1\"${rst})
+
+If you used ZNT before v2.1.12 then remove old configuration files
+${h3}~/.config/znt/*.conf${rst} so that ZNT can update them to the latest versions
+that support integration with Zshrc. If you used installer then run it
+again (after the remove of configuration files), that is not needed when
+using as plugin.
 "

--- a/plugins/zsh-navigation-tools/n-history
+++ b/plugins/zsh-navigation-tools/n-history
@@ -157,7 +157,7 @@ _nhistory_generate_most_frequent() {
         vk+="$v"$'\t'"$k"
     done
 
-    print -rl "$title" "${(On)vk[@]}" > "$most_frequent_db"
+    print -rl -- "$title" "${(On)vk[@]}" > "$most_frequent_db"
 }
 
 # Load configuration
@@ -337,16 +337,16 @@ if [ "$REPLY" -gt 0 ]; then
     selected="$reply[REPLY]"
     # ZLE?
     if [ "${(t)CURSOR}" = "integer-local-special" ]; then
-        zle redisplay
-        zle kill-buffer
+        zle .redisplay
+        zle .kill-buffer
         LBUFFER+="$selected"
 
         # Append to private history
         local newline=$'\n'
         selected="${selected//$newline/\\$newline}"
-        [ "$active_view" = "0" ] && print -r "$selected" >> "$private_history_db"
+        [ "$active_view" = "0" ] && print -r -- "$selected" >> "$private_history_db"
     else
-        print -zr "$selected"
+        print -zr -- "$selected"
     fi
 else
     [ "${(t)CURSOR}" = "integer-local-special" ] && zle redisplay

--- a/plugins/zsh-navigation-tools/n-list
+++ b/plugins/zsh-navigation-tools/n-list
@@ -445,7 +445,10 @@ while (( 1 )); do
 
     [ "$border" = "1" ] && zcurses border main
 
-    local top_msg=" F1-change view, ${(C)ZSH_NAME} $ZSH_VERSION, shell level $SHLVL "
+    local top_msg=" ${(C)ZSH_NAME} $ZSH_VERSION, shell level $SHLVL "
+    if [[ "${NLIST_ENABLED_EVENTS[(r)F1]}" = "F1" ]]; then
+        top_msg=" F1-change view,$top_msg"
+    fi
     zcurses move main 0 $(( term_width / 2 - $#top_msg / 2 ))
     zcurses string main $top_msg
 


### PR DESCRIPTION
Changes:
1. Fix for https://github.com/robbyrussell/oh-my-zsh/issues/5120
2. Updated n-help, the documentation tool
3. Lines starting with "-" weren't supported by n-history
4. Ensured immunity to zsh-autosuggestions and zsh-syntax-highlighting
