### PR TITLE
Make Bash aliases available on zsh

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -82,3 +82,8 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# inlcude bash aliases if any
+if [ -f ~/.bash_aliases ]; then
+  . ~/.bash_aliases
+fi


### PR DESCRIPTION
If there is a custom .bash_aliases file, load it also