### PR TITLE
Fix iTerm crash on window re-size

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -6,7 +6,7 @@ function zle-keymap-select() {
 
 # Ensure that the prompt is redrawn when the terminal size changes.
 TRAPWINCH() {
-  zle && { zle reset-prompt; zle -R }
+  zle &&  zle -R
 }
 
 zle -N zle-keymap-select


### PR DESCRIPTION
This PR fixes a crash that happens on OS X when using the vi-mode plugin with iTerm 2 and re-sizing a window.