### PR TITLE
Fix hg call when missing on archlinux with command-not-found

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -127,9 +127,8 @@ prompt_git() {
   fi
 }
 
-prompt_hg() {
-  which hg > /dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
+prompt_hg()
+  if ! type hg &> /dev/null ; then
     return
   fi
   local rev status

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -128,9 +128,7 @@ prompt_git() {
 }
 
 prompt_hg() {
-  if ! type hg &> /dev/null; then
-    return
-  fi
+  (( $+commands[hg] )) || return
   local rev status
   if $(hg id >/dev/null 2>&1); then
     if $(hg prompt >/dev/null 2>&1); then

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -127,7 +127,7 @@ prompt_git() {
   fi
 }
 
-prompt_hg()
+prompt_hg() {
   if ! type hg &> /dev/null; then
     return
   fi

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -128,7 +128,7 @@ prompt_git() {
 }
 
 prompt_hg()
-  if ! type hg &> /dev/null ; then
+  if ! type hg &> /dev/null; then
     return
   fi
   local rev status

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -128,6 +128,10 @@ prompt_git() {
 }
 
 prompt_hg() {
+  which hg > /dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    return
+  fi
   local rev status
   if $(hg id >/dev/null 2>&1); then
     if $(hg prompt >/dev/null 2>&1); then


### PR DESCRIPTION
Fixes #5217: a bug when `you can install hg by typing ...` is shown like git branch. Also saves time for those who don't want hg to be installed and have command-not-found enabled as there is no need to search repo for hg each time prompt is being printed.