### PR TITLE
better handling of loadable modules

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -27,12 +27,16 @@ fi
 
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
-# TIP: Add files you don't want in git to .gitignore
-for config_file ($ZSH/lib/*.zsh); do
+# TIP: Add file names you don't want in array "config_exclude"
+for config_file (${ZSH}/lib/*.zsh); do
+  config_name=${config_file:r:t}
   custom_config_file="${ZSH_CUSTOM}/lib/${config_file:t}"
+  if [ -n "${config_exclude[(r)${config_name}]}" ]; then
+    continue
+  fi
   [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
-  source $config_file
-done
+  source ${config_file}
+done; unset config_file config_name custom_config_file
 
 
 is_plugin() {

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -45,6 +45,14 @@ ZSH_THEME="robbyrussell"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
+# If you want exclude some modules from loading,
+# you'll need to specify file names only (without extension) to do this.
+# Example: config_exclude=(bzr)
+# This will prevent loading ${ZSH}/lib/bzr.zsh and ${ZSH_CUSTOM}/lib/bzr.zsh,
+# if any.
+# However, you may load modules by yourself in any time.
+config_exclude=()
+
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)


### PR DESCRIPTION
prevent loading specific modules (oh-my-zsh/lib/*.zsh) via "config_exclude" variable instead of messing with .gitignore
