### PR TITLE
Add gcd for checking out default branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -70,6 +70,7 @@ alias gcl='git clone --recursive'
 alias gclean='git clean -fd'
 alias gpristine='git reset --hard && git clean -dfx'
 alias gcm='git checkout master'
+alias gcd="git remote show origin | awk '/HEAD branch:/ {print \$3}' | xargs git checkout"
 alias gcmsg='git commit -m'
 alias gco='git checkout'
 alias gcount='git shortlog -sn'


### PR DESCRIPTION
Some projects use alternate branches such as `development` for the main operating branch, and `master` is more protected (i.e. CI -> production, etc.).

Git repos have the option of a setting a `default` branch.  This alias is like a project-agnostic `gcm` and can help prevent accidental activity on the wrong branch.
