### PR TITLE
require custom plugins recursively

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -87,7 +87,7 @@ for plugin ($plugins); do
 done
 
 # Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)); do
+for config_file ($ZSH_CUSTOM/**/*.zsh(N)); do
   source $config_file
 done
 unset config_file


### PR DESCRIPTION
I had an issue where files deeper that one level in `$ZSH_CUSTOM` weren't being sourced.

As a workaround, I created my own file at the `$ZSH_CUSTOM` level that did the recursive sourcing. I made this change locally and benchmarked with `/usr/bin/time zsh -i -c exits` and found it was 100ms  faster. 