### PR TITLE
Do not override misc env set before sourcing oh-my-zsh

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -19,8 +19,8 @@ fi
 setopt long_list_jobs
 
 ## pager
-export PAGER="less"
-export LESS="-R"
+env_default PAGER 'less'
+env_default LESS '-R'
 
 ## super user alias
 alias _='sudo'


### PR DESCRIPTION
Sourcing oh-my-zsh happens in zshrc, which will override settings of
profile and zshenv.  Treat misc values, `PAGER` and `LESS`, as default
settings without overriding existing values.

Fixes: #1, robbyrussell/oh-my-zsh#3016
