### PR TITLE
Removes .phing_target generation from phing plugin

### DIFF
--- a/plugins/phing/phing.plugin.zsh
+++ b/plugins/phing/phing.plugin.zsh
@@ -1,15 +1,6 @@
-_phing_does_target_list_need_generating () {
-  [ ! -f .phing_targets ] && return 0;
-  [ build.xml -nt .phing_targets ] && return 0;
-  return 1;
-}
-
 _phing () {
   if [ -f build.xml ]; then
-    if _phing_does_target_list_need_generating; then
-      phing -l|grep -v "\[property\]"|grep -v "Buildfile"|sed 1d|grep -v ":$" |grep -v "^\-*$"|awk '{print $1}' > .phing_targets
-    fi
-    compadd `cat .phing_targets`
+    compadd $(phing -l|grep -v "\[property\]"|grep -v "Buildfile"|sed 1d|grep -v ":$" |grep -v "^\-*$"|awk '{print $1}')
   fi
 }
 

--- a/plugins/phing/phing.plugin.zsh
+++ b/plugins/phing/phing.plugin.zsh
@@ -1,6 +1,6 @@
 _phing () {
   if [ -f build.xml ]; then
-    compadd $(phing -l|grep -v "\[property\]"|grep -v "Buildfile"|sed 1d|grep -v ":$" |grep -v "^\-*$"|awk '{print $1}')
+    compadd $(phing -l|grep -v "\[property\]"|grep -v "Buildfile"|sed 1d|grep -v ":$" |grep -v "^\-*$"|grep -v "Warning:"|awk '{print $1}')
   fi
 }
 


### PR DESCRIPTION
The phing plugin currently drops a `.phing_targets` cache file wherever you run it.  This isn't necessary, `phing -l` takes .03 seconds (on my system) so I can stand to run it each time.

I don't know of any other plugins that cache wherever you are like this, but I'm not a fan of things making messes on my filesystem.

Closes #3415.