### PR TITLE
Async npm

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -2,11 +2,17 @@
 {
 
   COMPLETION="${ZSH_CACHE_DIR}/npm_completion"
-  [[ ! -f $COMPLETION ]] && npm completion 2>/dev/null >! $COMPLETION
-  source $COMPLETION
-  npm completion 2>/dev/null >! $COMPLETION &
-  
+
+  if [[ ! -f $COMPLETION ]]; then
+    npm completion 2>/dev/null >! $COMPLETION
+    source $COMPLETION
+  else
+    source $COMPLETION
+    npm completion 2>/dev/null >! $COMPLETION &
+  fi
+
   unset COMPLETION
+
   # Install dependencies globally
   alias npmg="npm i -g "
 

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,3 +1,4 @@
+<<<<<<< 38da9b9bb479d3abae6558ba738ec63403ffa2b0
 (( $+commands[npm] )) && {
     __NPM_COMPLETION_FILE="${ZSH_CACHE_DIR}/npm_completion"
 
@@ -10,6 +11,14 @@
 
     unset __NPM_COMPLETION_FILE
 }
+=======
+completion=~/.npm_completion
+if [ ! -f $completion ]; then
+  npm completion 2>/dev/null > $completion
+fi
+source $completion
+(rm $completion; npm completion 2>/dev/null > $completion &)
+>>>>>>> prevent error on first launch
 
 # Install dependencies globally
 alias npmg="npm i -g "

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -43,4 +43,3 @@ alias npmst="npm start"
 
 # Run npm test
 alias npmt="npm test"
-

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,25 +1,10 @@
-<<<<<<< 38da9b9bb479d3abae6558ba738ec63403ffa2b0
-(( $+commands[npm] )) && {
-    __NPM_COMPLETION_FILE="${ZSH_CACHE_DIR}/npm_completion"
-
-    if [[ ! -f $__NPM_COMPLETION_FILE ]]; then
-        npm completion >! $__NPM_COMPLETION_FILE 2>/dev/null
-        [[ $? -ne 0 ]] && rm -f $__NPM_COMPLETION_FILE
-    fi
-
-    [[ -f $__NPM_COMPLETION_FILE ]] && source $__NPM_COMPLETION_FILE
-
-    unset __NPM_COMPLETION_FILE
-}
-=======
-completion=~/.npm_completion
-if [ ! -f $completion ]; then
-  npm completion 2>/dev/null > $completion
-fi
-source $completion
-(rm $completion; npm completion 2>/dev/null > $completion &)
->>>>>>> prevent error on first launch
-
+(( $+commands[npm] )) &&
+(
+  COMPLETION="${ZSH_CACHE_DIR}npm_completion"
+  [[ ! -f $COMPLETION ]] && npm completion 2>/dev/null >! $COMPLETION
+  source $COMPLETION
+  npm completion 2>/dev/null >! $COMPLETION &
+)
 # Install dependencies globally
 alias npmg="npm i -g "
 

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,39 +1,42 @@
 (( $+commands[npm] )) &&
-(
-  COMPLETION="${ZSH_CACHE_DIR}npm_completion"
+{
+
+  COMPLETION="${ZSH_CACHE_DIR}/npm_completion"
   [[ ! -f $COMPLETION ]] && npm completion 2>/dev/null >! $COMPLETION
   source $COMPLETION
   npm completion 2>/dev/null >! $COMPLETION &
-)
-# Install dependencies globally
-alias npmg="npm i -g "
+  
+  unset COMPLETION
+  # Install dependencies globally
+  alias npmg="npm i -g "
 
-# npm package names are lowercase
-# Thus, we've used camelCase for the following aliases:
+  # npm package names are lowercase
+  # Thus, we've used camelCase for the following aliases:
 
-# Install and save to dependencies in your package.json
-# npms is used by https://www.npmjs.com/package/npms
-alias npmS="npm i -S "
+  # Install and save to dependencies in your package.json
+  # npms is used by https://www.npmjs.com/package/npms
+  alias npmS="npm i -S "
 
-# Install and save to dev-dependencies in your package.json
-# npmd is used by https://github.com/dominictarr/npmd
-alias npmD="npm i -D "
+  # Install and save to dev-dependencies in your package.json
+  # npmd is used by https://github.com/dominictarr/npmd
+  alias npmD="npm i -D "
 
-# Execute command from node_modules folder based on current directory
-# i.e npmE gulp
-alias npmE='PATH="$(npm bin)":"$PATH"'
+  # Execute command from node_modules folder based on current directory
+  # i.e npmE gulp
+  alias npmE='PATH="$(npm bin)":"$PATH"'
 
-# Check which npm modules are outdated
-alias npmO="npm outdated"
+  # Check which npm modules are outdated
+  alias npmO="npm outdated"
 
-# Check package versions
-alias npmV="npm -v"
+  # Check package versions
+  alias npmV="npm -v"
 
-# List packages
-alias npmL="npm list"
+  # List packages
+  alias npmL="npm list"
 
-# Run npm start
-alias npmst="npm start"
+  # Run npm start
+  alias npmst="npm start"
 
-# Run npm test
-alias npmt="npm test"
+  # Run npm test
+  alias npmt="npm test"
+}


### PR DESCRIPTION
```
time npm completion > /dev/null                                                                                                                                                                      (develop|✔)
npm completion > /dev/null  0,26s user 0,03s system 105% cpu 0,276 total
```

As you can see npm completion takes quarter of a second to run. And so it introduces quarter of second delay in every zsh initialization. My changes launch npm completion synchronously(blocking) only first time. All subsequent launches will not block zsh initialization.
