### PR TITLE
Adds option for directory to Xcode xc function.

### DIFF
--- a/plugins/xcode/README.md
+++ b/plugins/xcode/README.md
@@ -26,7 +26,7 @@ plugins=(... xcode)
 
 ###  `xc`
 
-Opens the current directory in Xcode as an Xcode project. This will open one of the `.xcworkspace` and `.xcodeproj` files that it can find in the current working directory.
+Opens the current directory in Xcode as an Xcode project. This will open one of the `.xcworkspace` and `.xcodeproj` files that it can find in the current working directory. You can also specify a directory to look in for the Xcode files.
 Returns 1 if it didn't find any relevant files.
 
 ###  `simulator`

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -7,10 +7,19 @@ alias xcsel='sudo xcode-select --switch'
 # source: http://gist.github.com/subdigital/5420709
 function xc {
   local xcode_proj
-  xcode_proj=(*.{xcworkspace,xcodeproj}(N))
+  if [[ $# == 0 ]]; then
+    xcode_proj=(*.{xcworkspace,xcodeproj}(N))
+  else
+    xcode_proj=($1/*.{xcworkspace,xcodeproj}(N))
+  fi
+
 
   if [[ ${#xcode_proj} -eq 0 ]]; then
-    echo "No xcworkspace/xcodeproj file found in the current directory."
+    if [[ $# == 0 ]]; then
+      echo "No xcworkspace/xcodeproj file found in the current directory."
+    else
+      echo "No xcworkspace/xcodeproj file found in $1."
+    fi
     return 1
   else
     echo "Found ${xcode_proj[1]}"


### PR DESCRIPTION
I've found myself doing this:

```sh
> xc
No xcworkspace/xcodeproj file found in the current directory.
> cd Project ; xc ; cd ..
```

To open a project in a subdirectory from the command line. And sometimes I forget to `cd ..` 😬 

So I thought I would add the option to the plugin. It's my first contribution, so let me know if there's anything I need to change in the PR.