### PR TITLE
Update .zsh-update immediately

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -11,9 +11,9 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
+  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
 }
 
 epoch_target=$UPDATE_ZSH_DAYS


### PR DESCRIPTION
Update the `LAST_EPOCH` in `~/.zsh-update` immediately before starting the upgrade. This prevents the "Would you like to check for updates?" prompt from showing up after starting the upgrade process and opening a new shell.

I'd appreciate it if this became the new behaviour. It's been bothering me for a while now 😄 

![Current situation](https://cloud.githubusercontent.com/assets/1312973/17134497/f684cacc-532a-11e6-8af1-46f8672c8371.gif)
