### PR TITLE
Create an alias to open up sublime project

### DIFF
--- a/plugins/sublime/README.md
+++ b/plugins/sublime/README.md
@@ -15,5 +15,7 @@ Plugin for Sublime Text, a cross platform text and code editor, available for Li
  * If `st` is passed a file, open it in Sublime Text
 
  * If `stt` command is called, it is equivalent to `st .`, opening the current folder in Sublime Text
- 
+
  * If `sst` command is called, it is like `sudo st`, opening the file or folder in Sublime Text. Useful for editing system protected files.
+
+ * If `stp` command is called, it find a `.sublime-project` file by traversing up the directory structure. If there is no `.sublime-project` file, but if the current folder is a Git repo, opens up the root directory of the repo. If the current folder is not a Git repo, then opens up the current directory.

--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -56,3 +56,32 @@ elif [[ "$OSTYPE" = 'cygwin' ]]; then
 fi
 
 alias stt='st .'
+
+find_project()
+{
+    local PROJECT_ROOT="${PWD}"
+    local FINAL_DEST="."
+
+    while [[ $PROJECT_ROOT != "/" && ! -d "$PROJECT_ROOT/.git" ]]; do
+        PROJECT_ROOT=$(dirname $PROJECT_ROOT)
+    done
+
+    if [[ $PROJECT_ROOT != "/" ]]; then
+        local PROJECT_NAME="${PROJECT_ROOT##*/}"
+
+        local SUBL_DIR=$PROJECT_ROOT
+        while [[ $SUBL_DIR != "/" && ! -f "$SUBL_DIR/$PROJECT_NAME.sublime-project" ]]; do
+            SUBL_DIR=$(dirname $SUBL_DIR)
+        done
+
+        if [[ $SUBL_DIR != "/" ]]; then
+            FINAL_DEST="$SUBL_DIR/$PROJECT_NAME.sublime-project"
+        else
+            FINAL_DEST=$PROJECT_ROOT
+        fi
+    fi
+
+    st $FINAL_DEST
+}
+
+alias stp=find_project


### PR DESCRIPTION
`stp` commands works in following way:

1. If the current directory is a part of a Git repo and if there is a `.sublime-project` file among its ancestor directories, the command opens up that sublime project.
1. If the current directory is a part of a Git repo but there isn't a `.sublime-project` file among its ancestor directories, the command opens up the root of the repo.
1. If the current directory is not a part of a Git repo, the command opens up the current directory.