### PR TITLE
Add more golang aliases

### DIFF
--- a/plugins/golang/golang.plugin.zsh
+++ b/plugins/golang/golang.plugin.zsh
@@ -179,5 +179,15 @@ __go_tool_complete() {
 
 compdef __go_tool_complete go
 
-# aliases
-alias gfa='go fmt . ./...'
+# aliases: go<~>
+alias gob='go build'
+alias goc='go clean'
+alias god='go doc'
+alias gof='go fmt'
+alias gofa='go fmt . ./...'
+alias gog='go get'
+alias goi='go install'
+alias gol='go list'
+alias gor='go run'
+alias got='go test'
+alias gov='go vet'


### PR DESCRIPTION
*  Also gfa conflicts with git shortcut - `gfa=git fetch --all --prune`

Fixes #4919. Fixes #5214. Fixes #5288.