### PR TITLE
ssh-agent: Use /usr/bin/env to find ssh-add

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/ssh-add $HOME/.ssh/${^identities}
+  /usr/bin/env ssh-add $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from


### PR DESCRIPTION
This change is important when ssh-add is not inside /usr/bin e.g.
on NixOS.

Signed-off-by: Maximilian Güntner <code@maschinenpsychologe.de>