### PR TITLE
Fix up search process for aws_zsh_completer.sh in the non-brew case.

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -29,9 +29,11 @@ compctl -K aws_profiles asp
 
 if _homebrew-installed && _awscli-homebrew-installed ; then
   _aws_zsh_completer_path=$(brew --prefix awscli)/libexec/bin/aws_zsh_completer.sh
+elif [ -e /usr/share/zsh/site-functions/aws_zsh_completer.sh ]; then
+  _aws_zsh_completer_path=/usr/share/zsh/site-functions/aws_zsh_completer.sh
 else
   _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi
 
-[ -x $_aws_zsh_completer_path ] && source $_aws_zsh_completer_path
+[ -e "$_aws_zsh_completer_path" ] && source "$_aws_zsh_completer_path"
 unset _aws_zsh_completer_path


### PR DESCRIPTION
When "which" returns nothing, lack of quotes around variable was
causing a syntax error.  Quotes are also needed in
the (admittedly unusual) case of a filename with spaces in it.
The test should be for existence, not executability, since the
file is sourced, and therefore need not be marked executable.

Which also means that the "which" command isn't really a great
way to find the file.  It might not be in a place that's on
normal PATHs.  So this commit adds a check for one common place
to look: the location of the completer file on Amazon Linux - seems
reasonable to make sure the aws command has nice completion on
aws machines!
