### PR TITLE
nvm plugin improvements

### DIFF
--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,6 +1,6 @@
 # get the node.js version
 function nvm_prompt_info() {
-  [ -f "$HOME/.nvm/nvm.sh" ] || return
+  [[ -f "$NVM_DIR/nvm.sh" ]] || return
   local nvm_prompt
   nvm_prompt=$(node -v 2>/dev/null)
   [[ "${nvm_prompt}x" == "x" ]] && return

--- a/plugins/nvm/_nvm
+++ b/plugins/nvm/_nvm
@@ -1,7 +1,7 @@
 #compdef nvm
 #autoload
 
-[[ -s ~/.nvm/nvm.sh ]] || return 0
+[[ -f "$NVM_DIR/nvm.sh" ]] || return 0
 
 local -a _1st_arguments
 _1st_arguments=(

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,3 +1,5 @@
-# The addition 'nvm install' attempts in ~/.profile
+# Set NVM_DIR if it isn't already defined
+[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
 
-[[ -s ~/.nvm/nvm.sh ]] && . ~/.nvm/nvm.sh
+# Load nvm if it exists
+[[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
`nvm` isn't always installed in ~/.nvm. These changes allows nvm to be installed in any directory. It also now properly exports the `$NVM_DIR` env var if it hasn't been set and checks it in the completion and `nvm_prompt_info` rather than assuming `nvm` is in ~/.nvm.

Fixes #5270