### PR TITLE
Add gcpa and gcpc aliases to git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -75,6 +75,8 @@ alias gco='git checkout'
 alias gcount='git shortlog -sn'
 compdef gcount=git
 alias gcp='git cherry-pick'
+alias gcpa='git cherry-pick --abort'
+alias gcpc='git cherry-pick --continue'
 alias gcs='git commit -S'
 
 alias gd='git diff'


### PR DESCRIPTION
Similar to `grba` and `grbc`, this adds `gcpa` and `gcpc` aliases to the git plugin.

/cc @ncanceill @mcornella 