### PR TITLE
Add an alias that allows calling emacs WITHOUT the emacsclient

### DIFF
--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -11,6 +11,8 @@
 
 
 if "$ZSH/tools/require_tool.sh" emacs 24 2>/dev/null ; then
+    export REAL_EMACS_PATH=$(which emacs)
+
     export EMACS_PLUGIN_LAUNCHER="$ZSH/plugins/emacs/emacsclient.sh"
 
     # set EDITOR if not already defined.
@@ -26,6 +28,8 @@ if "$ZSH/tools/require_tool.sh" emacs 24 2>/dev/null ; then
     # create a new X frame
     alias eframe='emacsclient --alternate-editor "" --create-frame'
 
+    alias emacsnc="$REAL_EMACS_PATH"
+    alias enc="$REAL_EMACS_PATH"
 
     # Write to standard output the path to the file
     # opened in the current buffer.


### PR DESCRIPTION
For situations where a separate instance of emacs is desired. For
instance configuration testing