### PR TITLE
update alias of get a list of packages installed locally

### DIFF
--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -63,7 +63,7 @@ alias kclean='sudo aptitude remove -P ?and(~i~nlinux-(ima|hea) \
 
 # Misc. #####################################################################
 # print all installed packages
-alias allpkgs='aptitude search -F "%p" --disable-columns ~i'
+alias allpkgs='dpkg --get-selections | grep -v deinstall'
 
 # Create a basic .deb package
 alias mydeb='time dpkg-buildpackage -rfakeroot -us -uc'


### PR DESCRIPTION
Use of alias  `allpkgs` =`aptitude search -F "%p" --disable-columns ~i`
 is deprecated and exits with an error <br/>
The script new script `dpkg --get-selections | grep -v deinstall` works perfectly ok
