### PR TITLE
Add "system" to the completion list for plugin "chruby"

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -95,5 +95,11 @@ function chruby_prompt_info() {
 }
 
 # complete on installed rubies
-_chruby() { compadd $(chruby | tr -d '* ') }
+_chruby() {
+    compadd $(chruby | tr -d '* ')
+    local default_path='/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+    if PATH=${default_path} type ruby &> /dev/null; then
+        compadd system
+    fi
+}
 compdef _chruby chruby


### PR DESCRIPTION
Detect system Ruby in default `PATH`, and provide "system" completion if Ruby is found. Tested with [the Dockerfile](https://gist.github.com/franklinyu/b8deda6a5093a17b575679b5808b371f).
