### PR TITLE
Fix newline issue on Ys theme

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -46,7 +46,7 @@ local exit_code="%(?,,C:%{$fg[red]%}%?%{$reset_color%})"
 #
 # % ys @ ys-mbp in ~/.oh-my-zsh on git:master x [21:47:42] C:0
 # $
-PROMPT="
+PROMPT="\
 %{$terminfo[bold]$fg[blue]%}#%{$reset_color%} \
 %(#,%{$bg[yellow]%}%{$fg[black]%}%n%{$reset_color%},%{$fg[cyan]%}%n) \
 %{$fg[white]%}@ \


### PR DESCRIPTION
Hello !
I've started using Ys theme very recently, and I've noticed one small issue I'm proposing to fix here : the first line break of the prompt was not escaped. This created a newline before each prompt, which is not very elegant (especially when a new terminal is created).

Cheers,
Alexandre.