### PR TITLE
(git): Add gpsup alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -148,6 +148,8 @@ compdef _git ggpush=git-checkout
 
 alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 
+alias gpsup='git push --set-upstream origin $(git_current_branch)'
+
 alias gignore='git update-index --assume-unchanged'
 alias gignored='git ls-files -v | grep "^[[:lower:]]"'
 alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'


### PR DESCRIPTION
Add alias to push new branch to origin, and set up local branch to track it.

I can update the Wiki if this change is accepted.

/cc @ncanceill as you're set up as maintainer.