### PR TITLE
Replace /bin/sh with sh for portability

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -3,11 +3,11 @@ function zsh_stats() {
 }
 
 function uninstall_oh_my_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/uninstall.sh
+  env ZSH=$ZSH sh $ZSH/tools/uninstall.sh
 }
 
 function upgrade_oh_my_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
 }
 
 function take() {

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -11,7 +11,7 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
 }


### PR DESCRIPTION
This makes things work even on system lacking /bin/sh, such as on non-rooted Android systems (with [Termux](https://termux.com/) being my use case here).