### PR TITLE
Added Atom plugin for Mac OS X

### DIFF
--- a/plugins/atom/atom.plugin.zsh
+++ b/plugins/atom/atom.plugin.zsh
@@ -1,0 +1,13 @@
+if  [[ "$OSTYPE" = darwin* ]]; then
+    local _atom_darwin_paths > /dev/null 2>&1
+    _atom_darwin_paths=(
+        "/Applications/Atom.app"
+        "$HOME/Applications/Atom.app"
+    )
+    for _atom_path in $_atom_darwin_paths; do
+        if [[ -a $_atom_path ]]; then
+            alias atom="open -a '$_atom_path'"
+            break
+        fi
+    done
+fi


### PR DESCRIPTION
This plugin adds the `atom` alias to ZSH to open the [Atom editor](https://atom.io).

**Only works on Mac OS X** at the moment