### PR TITLE
Add an alias for Rails console sandbox

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -36,6 +36,7 @@ alias -g RET='RAILS_ENV=test'
 
 # Rails aliases
 alias rc='rails console'
+alias rcs='rails console --sandbox'
 alias rd='rails destroy'
 alias rdb='rails dbconsole'
 alias rg='rails generate'


### PR DESCRIPTION
The command `rails console —sandbox` loads our Rails application, connects to the database and automatically starts a database transaction. All database operations performed within this console
session are rolled back upon leaving the console. Reference -
https://www.codeschool.com/blog/2014/06/17/rails-console-sandbox/