### PR TITLE
Set $SHELL to correct value after install

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -110,7 +110,7 @@ main() {
   echo 'p.p.s. Get stickers and t-shirts at http://shop.planetargon.com.'
   echo ''
   printf "${NORMAL}"
-  env zsh
+  env SHELL=$(which zsh) zsh
 }
 
 main


### PR DESCRIPTION
This fixes a problem where `$SHELL` would equal f.ex `/bin/bash` after
running `env zsh`, breaking scripts that rely on `$SHELL` being set.

For example, GtiHub's hub [would think the login shell was set to bash, not zsh](https://github.com/github/hub/blob/713fd93b145e420e69884d7e12dd54426bd457bd/commands/alias.go#L44).

To illustrate:
```
bash $ env zsh
zsh  $ echo $SHELL
/bin/bash
zsh  $ exit
bash $ env SHELL=$(which zsh) zsh
zsh  $ echo $SHELL
/usr/local/bin/zsh
```

On further thought, this should only set `$SHELL` if `chsh` was successful.