### PR TITLE
refresh .rake-tasks after changing anything inside lib/tasks

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -12,13 +12,18 @@ _rake_does_task_list_need_generating () {
 }
 
 _is_rails_app () {
-  [[ -e "bin/rails" ]] || [ -e "script/rails" ]
+  [[ -e "bin/rails" ]] || [[ -e "script/rails" ]]
 }
 
 _tasks_changed () {
-  local is_changed=1
-  for file in lib/tasks/**/*.rake; do
-    if [[ $file -nt .rake_tasks ]]; then is_changed=0; fi
+  local is_changed paths
+  is_changed=1
+  paths=(lib/tasks lib/tasks/**/*(:f))
+  for path in $paths; do
+    if [[ $path -nt .rake_tasks ]]; then
+      is_changed=0
+      break
+    fi
   done
   return is_changed
 }


### PR DESCRIPTION
This PR introduces some fixes to the previous #5111.
Now it compares timestamp of anything inside of `lib/tasks` directory (and the directory itself) against `.rake_tasks`.
So removing anything would result in updating `.rake_tasks`.

I think test case might look like the following:
```
$ touch lib/tasks/baz.rake # update existing file
$ rake [tab] # should reload tasks

$ mkdir lib/tasks/foo
$ touch lib/tasks/foo/bar.rake  # create new file
$ rake [tab] # should reload tasks

$ rm -f lib/tasks/foo/bar.rake # remove .rake file in subfolder
$ rake [tab] # should reload tasks

$ rm -f lib/tasks/baz.rake # remove .rake file in root
$ rake [tab] # should reload tasks
```