### PR TITLE
Clobber ssh environment regardless of setopt

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -37,7 +37,7 @@ function _plugin__start_agent()
   zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
   # start ssh-agent and setup environment
-  /usr/bin/env ssh-agent ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' > ${_plugin__ssh_env}
+  /usr/bin/env ssh-agent ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! ${_plugin__ssh_env}
   chmod 600 ${_plugin__ssh_env}
   . ${_plugin__ssh_env} > /dev/null
 


### PR DESCRIPTION
To prevent

```
_plugin__start_agent:7: file exists: $HOME/.ssh/environment-$HOST
starting ssh-agent...
Could not open a connection to your authentication agent.
```