### PR TITLE
Fix empty Git empty repo check

### DIFF
--- a/themes/dogenpunk.zsh-theme
+++ b/themes/dogenpunk.zsh-theme
@@ -37,7 +37,7 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[cyan]%}"
 function git_time_since_commit() {
     if git rev-parse --git-dir > /dev/null 2>&1; then
         # Only proceed if there is actually a commit.
-        if [[ $(git log 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
+        if [[ $(git log -n 1  2>&1 > /dev/null | grep -Ec "^fatal: bad default revision") == 0 ]]; then
             # Get the last commit.
             last_commit=`git log --pretty=format:'%at' -1 2> /dev/null`
             now=`date +%s`

--- a/themes/dogenpunk.zsh-theme
+++ b/themes/dogenpunk.zsh-theme
@@ -37,7 +37,7 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[cyan]%}"
 function git_time_since_commit() {
     if git rev-parse --git-dir > /dev/null 2>&1; then
         # Only proceed if there is actually a commit.
-        if [[ $(git log -n 1  2>&1 > /dev/null | grep -Ec "^fatal: bad default revision") == 0 ]]; then
+        if git log -n 1  > /dev/null 2>&1; then
             # Get the last commit.
             last_commit=`git log --pretty=format:'%at' -1 2> /dev/null`
             now=`date +%s`


### PR DESCRIPTION
In theme dogenpunk method for check Git repository empties  do not work in Linux and too slow for big repository, like kernel.

The default `grep` in Linux do not extend regular expressions so pattern for check not match. 

The `git log | grep "^fatal: ...."` is to slow for big repository. The limited log give the same result.