### PR TITLE
Refactor of ssh-agent plugin

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -1,0 +1,38 @@
+# ssh-agent plugin
+
+This plugin starts automatically `ssh-agent` to set up and load whichever
+credentials you want for ssh connections.
+
+To enable it, add `ssh-agent` to your plugins:
+
+```zsh
+plugins=(... ssh-agent)
+```
+
+## Instructions
+
+To enable **agent forwarding support** add the following to your zshrc file:
+
+```zsh
+zstyle :omz:plugins:ssh-agent agent-forwarding on
+```
+
+To **load multiple identities** use the `identities` style, For example:
+
+```zsh
+zstyle :omz:plugins:ssh-agent identities id_rsa id_rsa2 id_github
+```
+
+To **set the maximum lifetime of the identities**, use the `lifetime` style.
+The lifetime may be specified in seconds or as described in sshd_config(5)
+(see _TIME FORMATS_). If left unspecified, the default lifetime is forever.
+
+```zsh
+zstyle :omz:plugins:ssh-agent lifetime 4h
+```
+
+## Credits
+
+Based on code from Joseph M. Reagle: http://www.cygwin.com/ml/cygwin/2001-06/msg00537.html
+
+Agent-forwarding support based on ideas from Florent Thoumie and Jonas Pfenniger

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/ssh-add $HOME/.ssh/${^identities}
+  /usr/bin/env ssh-add $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -1,32 +1,3 @@
-#
-# INSTRUCTIONS
-#
-#   To enable agent forwarding support add the following to
-#   your .zshrc file:
-#
-#     zstyle :omz:plugins:ssh-agent agent-forwarding on
-#
-#   To load multiple identities use the identities style, For
-#   example:
-#
-#     zstyle :omz:plugins:ssh-agent identities id_rsa id_rsa2 id_github
-#
-#   To set the maximum lifetime of the identities, use the
-#   lifetime style. The lifetime may be specified in seconds
-#   or as described in sshd_config(5) (see TIME FORMATS)
-#   If left unspecified, the default lifetime is forever.
-#
-#     zstyle :omz:plugins:ssh-agent lifetime 4h
-#
-# CREDITS
-#
-#   Based on code from Joseph M. Reagle
-#   http://www.cygwin.com/ml/cygwin/2001-06/msg00537.html
-#
-#   Agent forwarding support based on ideas from
-#   Florent Thoumie and Jonas Pfenniger
-#
-
 local _plugin__ssh_env
 local _plugin__forwarding
 
@@ -76,4 +47,3 @@ fi
 unfunction _plugin__start_agent
 unset _plugin__forwarding
 unset _plugin__ssh_env
-

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -37,7 +37,7 @@ function _plugin__start_agent()
   zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
   # start ssh-agent and setup environment
-  /usr/bin/env ssh-agent ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! ${_plugin__ssh_env}
+  ssh-agent ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! ${_plugin__ssh_env}
   chmod 600 ${_plugin__ssh_env}
   . ${_plugin__ssh_env} > /dev/null
 
@@ -45,7 +45,7 @@ function _plugin__start_agent()
   zstyle -a :omz:plugins:ssh-agent identities identities
   echo starting ssh-agent...
 
-  /usr/bin/env ssh-add $HOME/.ssh/${^identities}
+  ssh-add $HOME/.ssh/${^identities}
 }
 
 # Get the filename to store/lookup the environment from

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -7,7 +7,7 @@ function _start_agent() {
 	# start ssh-agent and setup environment
 	zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
-	ssh-agent ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! $_ssh_env_cache
+	ssh-agent -s ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! $_ssh_env_cache
 	chmod 600 $_ssh_env_cache
 	. $_ssh_env_cache > /dev/null
 

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -30,7 +30,7 @@ if [[ $_agent_forwarding == "yes" && -n "$SSH_AUTH_SOCK" ]]; then
 elif [[ -f "$_ssh_env_cache" ]]; then
 	# Source SSH settings, if applicable
 	. $_ssh_env_cache > /dev/null
-	ps x | grep $SSH_AGENT_PID | grep ssh-agent > /dev/null || {
+	ps -o cmd -p $SSH_AGENT_PID | grep -q ssh-agent || {
 		_start_agent
 	}
 else


### PR DESCRIPTION
- Repost of #5261: deletes useless `/usr/bin/env` calls.
- Adds a README file.
- Formats to tabs, renames local variables and fixes needlessly complex variable syntax.
- Simplify PID check of last ssh-agent.
- Uses `ssh-agent -s` to force Bourne-style syntax on systems that have Csh-like default shells (for example, colleges or workplace).

Close #5261.