### PR TITLE
Fix git emptiness check in dogenpunk theme

### DIFF
--- a/themes/dogenpunk.zsh-theme
+++ b/themes/dogenpunk.zsh-theme
@@ -37,7 +37,7 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[cyan]%}"
 function git_time_since_commit() {
     if git rev-parse --git-dir > /dev/null 2>&1; then
         # Only proceed if there is actually a commit.
-        if [[ $(git log 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
+        if git log -n 1  > /dev/null 2>&1; then
             # Get the last commit.
             last_commit=`git log --pretty=format:'%at' -1 2> /dev/null`
             now=`date +%s`


### PR DESCRIPTION
The parsing output for full git log output too slow so it replaced
with last commit show request, wich cause error if repository is empty