### PR TITLE
iTerm2 v3 tab commands syntax error fix

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -44,7 +44,7 @@ EOF
 
   elif [[ "$the_app" == 'iTerm2' ]]; then
       osascript <<EOF
-        tell application "iTerm"
+        tell application "iTerm2"
           tell current window
             create tab with default profile
             tell current session to write text "${command}"
@@ -81,7 +81,7 @@ EOF
 
   elif [[ "$the_app" == 'iTerm2' ]]; then
       osascript <<EOF
-        tell application "iTerm"
+        tell application "iTerm2"
           tell current session of first window
             set newSession to (split vertically with same profile)
             tell newSession
@@ -121,7 +121,7 @@ EOF
 
   elif [[ "$the_app" == 'iTerm2' ]]; then
       osascript <<EOF
-        tell application "iTerm"
+        tell application "iTerm2"
           tell current session of first window
             set newSession to (split horizontally with same profile)
             tell newSession


### PR DESCRIPTION
Fixes the "syntax error: expected line end ..." (-2741) errors that occur when using the tab, split_tab, and vsplit_tab commands in iTerm2 v3