### PR TITLE
 Fix peepcode theme ruby prompt info

### DIFF
--- a/themes/peepcode.zsh-theme
+++ b/themes/peepcode.zsh-theme
@@ -41,10 +41,4 @@ PROMPT='
 %~
 ${smiley}  %{$reset_color%}'
 
-if [[ -d ~/.rvm ]] && [[ -e ~/.rvm/bin/rvm-prompt ]]; then
-    rvm_prompt='$(~/.rvm/bin/rvm-prompt)'
-else
-    rvm_prompt=''
-fi
-
-RPROMPT='%{$fg[white]%} $rvm_prompt$(git_prompt)%{$reset_color%}'
+RPROMPT='%{$fg[white]%} $(ruby_prompt_info)$(git_prompt)%{$reset_color%}'


### PR DESCRIPTION
The ruby prompt info was not interpolating properly in the "peepcode" theme. Switching to use `ruby_prompt_info` helper. This addresses the interpolation issue and addresses part of https://github.com/robbyrussell/oh-my-zsh/issues/4182.

Before:
![image](https://cloud.githubusercontent.com/assets/12796/17950207/f929563c-6a16-11e6-80dd-6faacc53e968.png)

After:
![image](https://cloud.githubusercontent.com/assets/12796/17950213/006c5598-6a17-11e6-9fbb-e7031a831d26.png)
