### PR TITLE
Disable zsh file globbing when running pip

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -76,3 +76,6 @@ zsh-pip-test-clean-packages() {
         echo "the djangopypi2 index is fine"
     fi
 }
+
+alias pip="noglob pip" # allows square brackets for pip command invocation
+


### PR DESCRIPTION
Certain pip install commands which involve square brackets such as `pip install requests[security]
` or `pip install -e .[testing]` fails with the following error: `zsh: no matches found:`

This patch disables globbing for the pip command, and makes the pip command works for such cases.