### PR TITLE
always source settings of old pgp-agent, if applicable

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -14,26 +14,24 @@ function start_agent_withssh {
     export SSH_AGENT_PID
 }
 
+# source settings of old agent, if applicable
+if [ -f "${GPG_ENV}" ]; then
+    . ${GPG_ENV} > /dev/null
+    export GPG_AGENT_INFO
+    export SSH_AUTH_SOCK
+    export SSH_AGENT_PID
+fi
+
 # check if another agent is running
 if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
-    # source settings of old agent, if applicable
-    if [ -f "${GPG_ENV}" ]; then
-        . ${GPG_ENV} > /dev/null
-        export GPG_AGENT_INFO
-        export SSH_AUTH_SOCK
-        export SSH_AGENT_PID
-    fi
 
-    # check again if another agent is running using the newly sourced settings
-    if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
-        # check for existing ssh-agent
-        if ssh-add -l > /dev/null 2> /dev/null; then
-            # ssh-agent running, start gpg-agent without ssh support
-            start_agent_nossh;
-        else
-            # otherwise start gpg-agent with ssh support
-            start_agent_withssh;
-        fi
+    # check for existing ssh-agent
+    if ssh-add -l > /dev/null 2> /dev/null; then
+        # ssh-agent running, start gpg-agent without ssh support
+        start_agent_nossh;
+    else
+        # otherwise start gpg-agent with ssh support
+        start_agent_withssh;
     fi
 fi
 


### PR DESCRIPTION
Fixes the problem that the `GPG_AGENT_INFO` environment variable is only exported,
if no `gpg-agent` instance is already running.
