### PR TITLE
Add file completions for lein

### DIFF
--- a/plugins/lein/lein.plugin.zsh
+++ b/plugins/lein/lein.plugin.zsh
@@ -33,6 +33,8 @@ function _lein_commands() {
           "version:print leiningen's version"
         )
         _describe -t subcommands 'leiningen subcommands' subcommands && ret=0
+        ;;
+      *) _files
     esac
 
     return ret


### PR DESCRIPTION
I often run lein on files, like `lein run -m some-class/some-fn
<path-to-some-file`, and it would be useful to be able to have file name
completions to make that `<path-to-some-file>` easier.