### PR TITLE
No need to set PS1 by default.

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -32,9 +32,6 @@ else
     SCREEN_NO=""
 fi
 
-# Apply theming defaults
-PS1="%n@%m:%~%# "
-
 # git theming default: Variables for theming the git info prompt
 ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of the prompt, before the branch name
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt


### PR DESCRIPTION
Say I just want to add a simple line to `~/.zshrc` to inject my script.
Part of my `~/.zshrc` will be
```
# User configuration
source /path/to/my/config

source $ZSH/oh-my-zsh.sh
```

I set `PROMPT` in my script, but it will be overwritten by `PS1=`.
I don't like to add another line after `source $ZSH/oh-my-zsh.sh`, and I don't think `PS1` must be set defaultly. Therefore can we remove it, or add a condition checking for the setting?

Thank you!