### PR TITLE
Fix git_prompt_status() not showing ahead/behind/diverged status correctly

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -165,13 +165,13 @@ function git_prompt_status() {
   if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
   fi
-  if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^## [^ ]\+ .*ahead' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
   fi
-  if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^## [^ ]\+ .*behind' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
   fi
-  if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^## [^ ]\+ .*diverged' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
   fi
   echo $STATUS


### PR DESCRIPTION
It seems that `git_prompt_status()` does not show the current branch's ahead/behind/diverged status correctly when branch or remote names contain `ahead`, `behind`, or `diverged`.
For example when the current branch name is `behind-foobar` and is not behind but ahead the upstream branch, output of `git status --porcelain -b` is like:
```console
## behind-foobar...remote/master [ahead 1]
```
The first line contains `behind` so the current branch is recognized as behind by mistake.

This PR makes branch and remote names ignored when checking ahead/behind/diverged status.