### PR TITLE
Readded docker-compose aliases

### DIFF
--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -1,0 +1,13 @@
+# Authors:
+# https://github.com/tristola
+#
+# Docker-compose related zsh aliases
+
+# Aliases ###################################################################
+
+alias dcup='docker-compose up'
+alias dcb='docker-compose build'
+alias dcrm='docker-compose rm'
+alias dcps='docker-compose ps'
+alias dcstop='docker-compose stop'
+alias dcrestart='docker-compose restart'


### PR DESCRIPTION
Readded docker-compose aliases as asked here https://github.com/robbyrussell/oh-my-zsh/issues/5408.

They went missing in https://github.com/robbyrussell/oh-my-zsh/commit/0950f9c56da1f22bbddc45cf179a80a712908b19.

I just readded the plugin file as having a plugin file and a `_*` (completion) file seems to be common practice in most plugins.

Fixes #5408.