### PR TITLE
Fix battery.plugin when acpi writes to stderr

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -72,7 +72,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
-      echo "$(acpi | cut -f2 -d ',' | tr -cd '[:digit:]')"
+      echo "$(acpi 2&>/dev/null | cut -f2 -d ',' | tr -cd '[:digit:]')"
     fi
   }
 
@@ -86,7 +86,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_time_remaining() {
     if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
-      echo $(acpi | cut -f3 -d ',')
+      echo $(acpi 2&>/dev/null | cut -f3 -d ',')
     fi
   }
 

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -67,12 +67,12 @@ if [[ "$OSTYPE" = darwin* ]] ; then
 elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_is_charging() {
-    ! [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]]
+    ! [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]]
   }
 
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
-      echo "$(acpi 2&>/dev/null | cut -f2 -d ',' | tr -cd '[:digit:]')"
+      echo "$(acpi 2>/dev/null | cut -f2 -d ',' | tr -cd '[:digit:]')"
     fi
   }
 
@@ -85,14 +85,14 @@ elif [[ $(uname) == "Linux"  ]] ; then
   }
 
   function battery_time_remaining() {
-    if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
-      echo $(acpi 2&>/dev/null | cut -f3 -d ',')
+    if [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
+      echo $(acpi 2>/dev/null | cut -f3 -d ',')
     fi
   }
 
   function battery_pct_prompt() {
     b=$(battery_pct_remaining) 
-    if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
+    if [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
       if [ $b -gt 50 ] ; then
         color='green'
       elif [ $b -gt 20 ] ; then


### PR DESCRIPTION
I have a machine which outputs the following when `acpi` is run:
```
❯ acpi
No support for device type: power_supply
```

This ends up showing everywhere I include `battery_pct()` - including my prompt!  It's an easy fix - just make it consistent which arguments we're passing to `acpi` in the battery plugin.