### PR TITLE
Added 'gbd' alias for 'git branch -d'

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -46,6 +46,7 @@ alias gapa='git add --patch'
 
 alias gb='git branch'
 alias gba='git branch -a'
+alias gbd='git branch -d'
 alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*(master|develop|dev)\s*$)" | command xargs -n 1 git branch -d'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'


### PR DESCRIPTION
- Simple addition to the set of aliases available for `git`.
- Wondered why it was not available by default (let me know if there is a special reason).
- No other `git` alias has the same string (`gbd`) defined for it.