### PR TITLE
Add more docker compose aliases

### DIFF
--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -5,9 +5,16 @@
 
 # Aliases ###################################################################
 
-alias dcup='docker-compose up'
+# Use dco as alias for docker-compose, since dc on *nix is 'dc - an arbitrary precision calculator'
+# https://www.gnu.org/software/bc/manual/dc-1.05/html_mono/dc.html
+
+alias dco='docker-compose'
+
 alias dcb='docker-compose build'
-alias dcrm='docker-compose rm'
+alias dce='docker-compose exec'
 alias dcps='docker-compose ps'
-alias dcstop='docker-compose stop'
 alias dcrestart='docker-compose restart'
+alias dcrm='docker-compose rm'
+alias dcr='docker-compose run'
+alias dcstop='docker-compose stop'
+alias dcup='docker-compose up'


### PR DESCRIPTION
Adds the following aliases:

```zsh
alias dco='docker-compose'
alias dcr='docker-compose run'
alias dce='docker-compose exec'
```

And sorts the aliases similar to `docker-compose help` order