### PR TITLE
agnoster: add guard to bzr prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -128,6 +128,7 @@ prompt_git() {
 }
 
 prompt_bzr() {
+    (( $+commands[bzr] )) || return
     if (bzr status >/dev/null 2>&1); then
         status_mod=`bzr status | head -n1 | grep "modified" | wc -m`
         status_all=`bzr status | head -n1 | wc -m`


### PR DESCRIPTION
Depending on the exit code of 'bzr status' is not enough,
as some command_not_found_handler could be used which
would then override that code.
Use the associative list of commands from zsh/param instead.

In my case, I use the command_not_found hook to search my package database;
https://github.com/falconindy/pkgfile/blob/master/extra/command-not-found.zsh

Without this fix, my prompt is currently set to:
```/data/git/oh-my-zsh   patch-1  bzr@  extra/bzr 2.7.0-1     /usr/bin/bzr```
Where the 'bzr@  extra/bzr 2.7.0-1     /usr/bin/bzr' is the output of pkgfile for bzr (called by the hook).