### PR TITLE
Fix cp plugin completion

### DIFF
--- a/plugins/cp/README.md
+++ b/plugins/cp/README.md
@@ -30,5 +30,3 @@ The enabled options for rsync are:
 * `-e /dev/null`: only work on local files (disable remote shells).
 
 * `--progress`: display progress.
-
-* `--`: everything after this is an argument, even if it starts with a hyphen.

--- a/plugins/cp/README.md
+++ b/plugins/cp/README.md
@@ -21,6 +21,8 @@ The enabled options for rsync are:
 
 * `-b`: make a backup of the original file instead of overwriting it, if it exists.
 
+* `-r`: recurse directories.
+
 * `-hhh`: outputs numbers in human-readable format, in units of 1024 (K, M, G, T).
 
 * `--backup-dir=/tmp/rsync`: move backup copies to "/tmp/rsync".

--- a/plugins/cp/README.md
+++ b/plugins/cp/README.md
@@ -1,0 +1,32 @@
+# cp plugin
+
+This plugin defines a `cpv` function that uses `rsync` so that you
+get the features and security of this command.
+
+To enable, add `cp` to your `plugins` array in your zshrc file:
+
+```zsh
+plugins=(... cp)
+```
+
+## Description
+
+The enabled options for rsync are:
+
+- `-p`: preserves permissions.
+
+- `-o`: preserves owner.
+
+* `-g`: preserves group.
+
+* `-b`: make a backup of the original file instead of overwriting it, if it exists.
+
+* `-hhh`: outputs numbers in human-readable format, in units of 1024 (K, M, G, T).
+
+* `--backup-dir=/tmp/rsync`: move backup copies to "/tmp/rsync".
+
+* `-e /dev/null`: only work on local files (disable remote shells).
+
+* `--progress`: display progress.
+
+* `--`: everything after this is an argument, even if it starts with a hyphen.

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -11,4 +11,7 @@
 #  -e /dev/null - only work on local files
 #  -- - everything after this is an argument, even if it looks like an option
 
-alias cpv="rsync -poghb --backup-dir=/tmp/rsync -e /dev/null --progress --"
+cpv() {
+    rsync -poghb --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
+}
+compdef _files cpv

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,4 +1,4 @@
 cpv() {
-    rsync -pogb -hhh --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
+    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
 }
 compdef _files cpv

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,4 +1,4 @@
 cpv() {
-    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
+    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --progress "$@"
 }
 compdef _files cpv

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,16 +1,3 @@
-#Show progress while file is copying
-
-# Rsync options are:
-#  -p - preserve permissions
-#  -o - preserve owner
-#  -g - preserve group
-#  -h - output in human-readable format
-#  --progress - display progress
-#  -b - instead of just overwriting an existing file, save the original
-#  --backup-dir=/tmp/rsync - move backup copies to "/tmp/rsync"
-#  -e /dev/null - only work on local files
-#  -- - everything after this is an argument, even if it looks like an option
-
 cpv() {
     rsync -pogb -hhh --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
 }

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -12,6 +12,6 @@
 #  -- - everything after this is an argument, even if it looks like an option
 
 cpv() {
-    rsync -poghb --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
+    rsync -pogb -hhh --backup-dir=/tmp/rsync -e /dev/null --progress -- "$@"
 }
 compdef _files cpv


### PR DESCRIPTION
Fixes #5420.

- Changed `-h` for `-hhh` which shows numbers in units of 1024 (k, M, G, T).
- Added `-r` to recurse directories.
- Removed `--`: use only if needed. That way we can do `cpv --help` and other combinations.