### PR TITLE
Implement a lockfile to alleviate update prompt in multiple terminals

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -10,10 +10,19 @@ function _update_zsh_update() {
   echo "LAST_EPOCH=$(_current_epoch)" >! ~/.zsh-update
 }
 
+function _create_lock() {
+  touch ~/.zsh-update.lock
+}
+function _remove_lock() {
+  rm ~/.zsh-update.lock
+}
+
 function _upgrade_zsh() {
+  _create_lock
   env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
+  _remove_lock
 }
 
 epoch_target=$UPDATE_ZSH_DAYS
@@ -21,6 +30,9 @@ if [[ -z "$epoch_target" ]]; then
   # Default to old behavior
   epoch_target=13
 fi
+
+# Cancel upgrade if upgrade is already in progress
+[[ ! -f ~/.zsh-update.lock ]] || return 0
 
 # Cancel upgrade if the current user doesn't have write permissions for the
 # oh-my-zsh directory.


### PR DESCRIPTION
This prevents the "Would you like to check for updates?" prompt from showing up after starting the upgrade process and opening a new shell.

Fixes #3766. I'm aware of the comments on that issue but I really don't think it's worth making this a lot more complex for an extremely rare race condition with no impact.

![Current situation](https://cloud.githubusercontent.com/assets/1312973/17134497/f684cacc-532a-11e6-8af1-46f8672c8371.gif)
