### PR TITLE
Add check for git and bzr to agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -86,7 +86,7 @@ prompt_context() {
 
 # Git: branch/detached head, dirty status
 prompt_git() {
-
+  (( $+commands[git] )) || return
   local PL_BRANCH_CHAR
   () {
     local LC_ALL="" LC_CTYPE="en_US.UTF-8"
@@ -128,6 +128,7 @@ prompt_git() {
 }
 
 prompt_bzr() {
+    (( $+commands[bzr] )) || return
     if (bzr status >/dev/null 2>&1); then
         status_mod=`bzr status | head -n1 | grep "modified" | wc -m`
         status_all=`bzr status | head -n1 | wc -m`


### PR DESCRIPTION
Plugin command-not-found on Arch returns 0 if git or bzr is found in repos, hence outputting unwanted pkgfile output.
Checking if the commands exist first fixes all such issues. It unifies the check with hg_prompt (where it is already implemented)