### PR TITLE
Reference alias `gref` for unkown git aliases

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -200,6 +200,7 @@ alias grbc='git rebase --continue'
 alias grbi='git rebase -i'
 alias grbm='git rebase master'
 alias grbs='git rebase --skip'
+alias gref='alias | grep git | grep' # Reference for unkown git aliases
 alias grh='git reset HEAD'
 alias grhh='git reset HEAD --hard'
 alias grmv='git remote rename'


### PR DESCRIPTION
- Added alias `gref` to `plugins/git/git.plugin.zsh`.
- Looks through aliases and greps those that include `git`.
- Then **greps again** for a custom string provided by the user.
- `gref` does **not** clash with any other alias or command within `oh-my-zsh`.
- **Increases productivity** and **speeds up references** to aliases directly related to git.
- Recently rebased (09/24/2016, 1:58 AM) with `robbyrussell/oh-my-zsh master`
