### PR TITLE
rename ubuntu plugin ag alias to age (conflicts with ag-silversearcher)

### DIFF
--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -27,7 +27,7 @@ compdef _afu afu='sudo apt-file update'
 alias ppap='sudo ppa-purge'
 compdef _ppap ppap='sudo ppa-purge'
 
-alias ag='sudo apt-get'            # age - but without sudo
+alias age='sudo apt-get'
 alias aga='sudo apt-get autoclean' # aac
 alias agar='sudo apt-get autoremove'
 alias agb='sudo apt-get build-dep' # abd


### PR DESCRIPTION
The 'ag' alias in the ubuntu plugin conflicts with the insanely popular ag-silversearcher.

https://github.com/ggreer/the_silver_searcher

I suggest just going 'age' instead.
