### PR TITLE
Implement a locking mechanism to avoid multiple update prompts

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -29,31 +29,36 @@ fi
 # Cancel upgrade if git is unavailable on the system
 whence git >/dev/null || return 0
 
-if [ -f ~/.zsh-update ]
+if mkdir "$ZSH/log/update.lock" 2>/dev/null
 then
-  . ~/.zsh-update
-
-  if [[ -z "$LAST_EPOCH" ]]; then
-    _update_zsh_update && return 0;
-  fi
-
-  epoch_diff=$(($(_current_epoch) - $LAST_EPOCH))
-  if [ $epoch_diff -gt $epoch_target ]
+  if [ -f ~/.zsh-update ]
   then
-    if [ "$DISABLE_UPDATE_PROMPT" = "true" ]
+    . ~/.zsh-update
+
+    if [[ -z "$LAST_EPOCH" ]]; then
+      _update_zsh_update && return 0;
+    fi
+
+    epoch_diff=$(($(_current_epoch) - $LAST_EPOCH))
+    if [ $epoch_diff -gt $epoch_target ]
     then
-      _upgrade_zsh
-    else
-      echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
-      read line
-      if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
+      if [ "$DISABLE_UPDATE_PROMPT" = "true" ]
+      then
         _upgrade_zsh
       else
-        _update_zsh_update
+        echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
+        read line
+        if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
+          _upgrade_zsh
+        else
+          _update_zsh_update
+        fi
       fi
     fi
+  else
+    # create the zsh file
+    _update_zsh_update
   fi
-else
-  # create the zsh file
-  _update_zsh_update
+
+  rm -r $ZSH/log/update.lock
 fi

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -60,5 +60,5 @@ then
     _update_zsh_update
   fi
 
-  rm -r $ZSH/log/update.lock
+  rmdir $ZSH/log/update.lock
 fi

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -29,10 +29,8 @@ fi
 # Cancel upgrade if git is unavailable on the system
 whence git >/dev/null || return 0
 
-if mkdir "$ZSH/log/update.lock" 2>/dev/null
-then
-  if [ -f ~/.zsh-update ]
-  then
+if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
+  if [ -f ~/.zsh-update ]; then
     . ~/.zsh-update
 
     if [[ -z "$LAST_EPOCH" ]]; then
@@ -40,10 +38,8 @@ then
     fi
 
     epoch_diff=$(($(_current_epoch) - $LAST_EPOCH))
-    if [ $epoch_diff -gt $epoch_target ]
-    then
-      if [ "$DISABLE_UPDATE_PROMPT" = "true" ]
-      then
+    if [ $epoch_diff -gt $epoch_target ]; then
+      if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then
         _upgrade_zsh
       else
         echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"


### PR DESCRIPTION
This would fix #3766 and is a better solution than #5430 because it avoids even the rare race condition mentioned in the discussion there by using a proper, atomic locking mechanism (mkdir).

See http://mywiki.wooledge.org/BashFAQ/045 for reference.

Related: #5257.

Fixes #3766.
Closes #5430.