### PR TITLE
workaround for localized strings

### DIFF
--- a/plugins/svn/README.md
+++ b/plugins/svn/README.md
@@ -10,13 +10,14 @@ svn repsitiory. See http://subversion.apache.org/ for the full svn documentation
 |svn_prompt_info         | prompt for some themes                  |
 |in_svn                  | within svn directory                    |
 |svn_get_repo_name       |                                         |
-|svn_get_branch_name     | branch name (bug: returns the first path element if branches not used) |
+|svn_get_branch_name     | branch name (see caveats)              |
 |svn_get_rev_nr          | revision number                         |
 |svn_dirty               | changes in this subversion repo         |
 
 ## Caveats
 
-The plugin expects the first directory to be the current branch / tag / trunk.
+The plugin expects the first directory to be the current branch / tag / trunk. So, it returns
+the first path element if you don't use branches.
 
 ## Usage
 

--- a/plugins/svn/README.md
+++ b/plugins/svn/README.md
@@ -1,0 +1,10 @@
+## svn
+
+**Maintainer:** 
+
+This plugin adds some useful functions.
+
+### Usage
+
+See the [wiki](https://github.com/robbyrussell/oh-my-zsh/wiki/Plugin:svn) for a list of functions provided by the plugin.
+

--- a/plugins/svn/README.md
+++ b/plugins/svn/README.md
@@ -1,6 +1,7 @@
 # `svn` plugin
 
-This plugin adds some utility functions to display additional information regarding your current svn reositiory. See http://subversion.apache.org/ for the full svn documentation
+This plugin adds some utility functions to display additional information regarding your current
+svn repsitiory. See http://subversion.apache.org/ for the full svn documentation.
 
 ## Functions
 

--- a/plugins/svn/README.md
+++ b/plugins/svn/README.md
@@ -1,10 +1,62 @@
-## svn
+# `svn` plugin
 
-**Maintainer:** 
+This plugin adds some utility functions to display additional information regarding your current svn reositiory. See http://subversion.apache.org/ for the full svn documentation
 
-This plugin adds some useful functions.
+## Functions
 
-### Usage
+| Command                | Description                             |
+|:-----------------------|:----------------------------------------|
+|svn_prompt_info         | prompt for some themes                  |
+|in_svn                  | within svn directory                    |
+|svn_get_repo_name       |                                         |
+|svn_get_branch_name     | branch name (bug: returns the first path element if branches not used) |
+|svn_get_rev_nr          | revision number                         |
+|svn_dirty               | changes in this subversion repo         |
 
-See the [wiki](https://github.com/robbyrussell/oh-my-zsh/wiki/Plugin:svn) for a list of functions provided by the plugin.
+## Caveats
+
+The plugin expects the first directory to be the current branch / tag / trunk.
+
+## Usage
+
+To use it, add `svn` to your plugins array:
+```sh
+plugins=(... svn)
+```
+
+### Agnoster theme git-like prompt
+
+Enable the svn plugin and add the followind lines to your ```~/.zshrc```
+
+```shell
+prompt_svn() {
+    local rev branch
+    if in_svn; then
+        rev=$(svn_get_rev_nr)
+        branch=$(svn_get_branch_name)
+        if [ `svn_dirty_choose_pwd 1 0` -eq 1 ]; then
+            prompt_segment yellow black
+            echo -n "$rev@$branch"
+            echo -n "±"
+        else
+            prompt_segment green black
+            echo -n "$rev@$branch"
+        fi
+    fi
+}
+```
+
+override the agnoster build_prompt() function:
+
+```shell
+build_prompt() {
+    RETVAL=$?
+    prompt_status
+    prompt_context
+    prompt_dir
+    prompt_git
+    prompt_svn
+    prompt_end
+}
+```
 

--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -25,7 +25,7 @@ function in_svn() {
 
 function svn_get_repo_name() {
   if in_svn; then
-    LANG=C svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
+    LANG=C svn info | sed -n 's/^Repository\ Root:\ .*\///p' | read SVN_ROOT
     LANG=C svn info | sed -n "s/^URL:\ .*$SVN_ROOT\///p"
   fi
 }

--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -25,14 +25,14 @@ function in_svn() {
 
 function svn_get_repo_name() {
   if in_svn; then
-    svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
-    svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p"
+    LANG=C svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
+    LANG=C svn info | sed -n "s/^URL:\ .*$SVN_ROOT\///p"
   fi
 }
 
 function svn_get_branch_name() {
   local _DISPLAY=$(
-    svn info 2> /dev/null | \
+    LANG=C svn info 2> /dev/null | \
       awk -F/ \
       '/^URL:/ { \
         for (i=0; i<=NF; i++) { \
@@ -54,13 +54,13 @@ function svn_get_branch_name() {
 
 function svn_get_rev_nr() {
   if in_svn; then
-    svn info 2> /dev/null | sed -n 's/Revision:\ //p'
+    LANG=C svn info 2> /dev/null | sed -n 's/Revision:\ //p'
   fi
 }
 
 function svn_dirty_choose() {
   if in_svn; then
-    local root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
+    local root=`LANG=C svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
     if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1


### PR DESCRIPTION
add: README.md

fix: set LANG=C before svn info | grep something