### PR TITLE
Update pip plugin to last stable release

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -1,7 +1,8 @@
 #compdef pip pip2 pip-2.7 pip3 pip-3.2 pip-3.3 pip-3.4
 #autoload
 
-# pip zsh completion, based on homebrew completion
+# pip zsh completion, based on last stable release (pip8)
+# homebrew completion and backwards compatibility
 
 _pip_all() {
   # we cache the list of packages (originally from the macports plugin)
@@ -17,30 +18,43 @@ _pip_installed() {
 
 local -a _1st_arguments
 _1st_arguments=(
-  'bundle:create pybundles (archives containing multiple packages)'
-  'freeze:output all currently installed packages (exact versions) to stdout'
-  'help:show available commands'
-  'show:show information about installed packages'
   'install:install packages'
-  'search:search PyPI'
+  'download:download packages'
   'uninstall:uninstall packages'
-  'unzip:unzip individual packages'
-  'zip:zip individual packages'
+  'freeze:output all currently installed packages (exact versions) to stdout'
+  'list:list installed packages'
+  'show:show information about installed packages'
+  'search:search PyPI'
+  'wheel:build individual wheel archives for your requirements and dependencies'
+  'hash:compute a hash of a local package archive'
+  'help:show available commands'
+  'bundle:create pybundles (archives containing multiple packages)(deprecated)'
+  'unzip:unzip individual packages(deprecated)'
+  'zip:zip individual packages(deprecated)'
 )
 
 local expl
 local -a all_pkgs installed_pkgs
 
 _arguments \
-  '(--version)--version[show version number of program and exit]' \
   '(-h --help)'{-h,--help}'[show help]' \
-  '(-E --environment)'{-E,--environment}'[virtualenv environment to run pip in]' \
-  '(-s --enable-site-packages)'{-s,--enable-site-packages}'[include site-packages in virtualenv]' \
+  '(--isolated)--isolated[run pip in isolated mode, ignores environment variables and user configuration]' \
   '(-v --verbose)'{-v,--verbose}'[give more output]' \
+  '(-V --version)'{-V,--version}'[show version number of program and exit]' \
   '(-q --quiet)'{-q,--quiet}'[give less output]' \
   '(--log)--log[log file location]' \
   '(--proxy)--proxy[proxy in form user:passwd@proxy.server:port]' \
+  '(--retries)--retries[max number of retries per connection (default 5 times)]' \
   '(--timeout)--timeout[socket timeout (default 15s)]' \
+  '(--exists-action)--exists-action[default action when a path already exists: (s)witch, (i)gnore, (w)ipe, (b)ackup]' \
+  '(--trusted-host)--trusted-host[mark this host as trusted]' \
+  '(--cert)--cert[path to alternate CA bundle]' \
+  '(--client-cert)--client-cert[path to SSL client certificate]' \
+  '(--cache-dir)--cache-dir[store the cache data in specified directory]' \
+  '(--no-cache-dir)--no-cache-dir[disable de cache]' \
+  '(--disable-pip-version-check)--disable-pip-version-check[do not check periodically for new pip version downloads]' \
+  '(-E --environment)'{-E,--environment}'[virtualenv environment to run pip in (deprecated)]' \
+  '(-s --enable-site-packages)'{-s,--enable-site-packages}'[include site-packages in virtualenv (deprecated)]' \
   '*:: :->subcmds' && return 0
 
 if (( CURRENT == 1 )); then
@@ -56,7 +70,7 @@ case "$words[1]" in
     _arguments \
       '(-l --local)'{-l,--local}'[report only virtualenv packages]' ;;
   install)
-  	_arguments \
+    _arguments \
       '(-U --upgrade)'{-U,--upgrade}'[upgrade all packages to the newest available version]' \
       '(-f --find-links)'{-f,--find-links}'[URL for finding packages]' \
       '(-r --requirement)'{-r,--requirement}'[Requirements file for packages to install]:File:_files' \


### PR DESCRIPTION
As noticed several times before, pip plugin is outdated, @kottenator was the last one addressing this in issue #5337. Fixes #5337.

I didn't want to break backwards compatibility, so it is just commented as (deprecated). It is still missing all new second level arguments (--something) for the newly added first level arguments.