### PR TITLE
add "svn_get_repo_url" function in the svn plugin

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -30,6 +30,12 @@ function svn_get_repo_name() {
   fi
 }
 
+function svn_get_repo_url() {
+  if in_svn; then
+    svn info | sed -n "s/^URL:\ //p"
+  fi
+}
+
 function svn_get_branch_name() {
   local _DISPLAY=$(
     svn info 2> /dev/null | \


### PR DESCRIPTION
The svn_get_repo_url function echoes the full path to the current repo URL.