### PR TITLE
Add /usr/local/bin to autoenv search path

### DIFF
--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -1,7 +1,7 @@
 # Activates autoenv or reports its failure
 () {
 if ! type autoenv_init >/dev/null; then
-  for d (~/.autoenv /usr/local/opt/autoenv); do
+  for d (~/.autoenv /usr/local/opt/autoenv /usr/local/bin); do
     if [[ -e $d/activate.sh ]]; then
       autoenv_dir=$d
       break


### PR DESCRIPTION
The current list of directories to search for autoenv on misses the default location on Ubuntu systems if you just do a normal `pip install autoenv` - [it will place](https://github.com/kennethreitz/autoenv/blob/master/setup.py#L16) `activate.sh` in `/usr/local/bin` unless you manually override the `--prefix` or something.

The `/usr/local/opt/autoenv` is fine for macOS/homebrew installations but it would be nice not to have to manually patch on Linux :)