### PR TITLE
set better default colors for GNU ls instead of none.

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -5,7 +5,7 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 # Enable ls colors
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
-  # Find the option for using colors in ls, depending on the version: Linux or BSD
+  # Find the option for using colors in ls, depending on the version: GNU or BSD
   if [[ "$(uname -s)" == "NetBSD" ]]; then
     # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
@@ -18,6 +18,8 @@ then
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null 2>&1 && alias ls='colorls -G'
   else
+    # For GNU ls, we use the default ls color theme. They can later be overwritten by themes.
+    type dircolors >/dev/null 2>&1 && eval "$(dircolors)"
     ls --color -d . &>/dev/null 2>&1 && alias ls='ls --color=tty' || alias ls='ls -G'
   fi
 fi


### PR DESCRIPTION
GNU coreutils ship a color setup command by default which can be used to
set a good default color theme for ls:

  https://www.gnu.org/software/coreutils/manual/html_node/dircolors-invocation.html