### PR TITLE
Removing the user name and the Host name

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -80,7 +80,7 @@ prompt_end() {
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)$USER@%m"
+#    prompt_segment black default "%(!.%{%F{yellow}%}.)$USER@%m"
   fi
 }
 


### PR DESCRIPTION
As for me and many other developers, without the username and the
hostname is much much better and cleaner bash screen, any one can have
them back by just uncommenting them by removing the “#” from the
begining of the line.