### PR TITLE
Add non 0 exit code for missing jump targets

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -9,7 +9,7 @@
 export MARKPATH=$HOME/.marks
 
 jump() {
-	cd -P "$MARKPATH/$1" 2>/dev/null || echo "No such mark: $1"
+	cd -P "$MARKPATH/$1" 2>/dev/null || (echo "No such mark: $1"; return 1)
 }
 
 mark() {

--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -9,7 +9,7 @@
 export MARKPATH=$HOME/.marks
 
 jump() {
-	cd -P "$MARKPATH/$1" 2>/dev/null || (echo "No such mark: $1"; return 1)
+	cd -P "$MARKPATH/$1" 2>/dev/null || {echo "No such mark: $1"; return 1}
 }
 
 mark() {


### PR DESCRIPTION
This allows for the user to combine the jump command with
something else. In my example cd and jump are now combined
like this:

```bash
jumpcd() {
        jump $1 > /dev/null || cd $1
}
alias cd="jumpcd"
```