### PR TITLE
Add m4a format in the common aliases plugin

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -63,7 +63,7 @@ if is-at-least 4.2.0; then
   _image_fts=(jpg jpeg png gif mng tiff tif xpm)
   for ft in $_image_fts ; do alias -s $ft=$XIVIEWER; done
 
-  _media_fts=(ape avi flv mkv mov mp3 mpeg mpg ogg ogm rm wav webm)
+  _media_fts=(ape avi flv m4a mkv mov mp3 mpeg mpg ogg ogm rm wav webm)
   for ft in $_media_fts ; do alias -s $ft=mplayer ; done
 
   #read documents


### PR DESCRIPTION
The m4a file format can be opened in the command line with mplayer