### PR TITLE
Add OPAM

### DIFF
--- a/plugins/opam/opam.plugin.zsh
+++ b/plugins/opam/opam.plugin.zsh
@@ -1,0 +1,2 @@
+# OPAM configuration
+. $HOME/.opam/opam-init/init.sh > /dev/null 2> /dev/null || true


### PR DESCRIPTION
This is the basic lines added automatically in the shell configuration file when we use `opam init`. It's mandatory.
