### PR TITLE
Fix ls colouring for Darwin.

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -6,7 +6,7 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
 if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
   # Find the option for using colors in ls, depending on the version
-  if [[ "$(uname -s)" == "NetBSD" ]]; then
+  if [[ "$(uname -s)" == "NetBSD" ]] || [[ "$(uname -s)" == "Darwin" ]]; then
     # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null && alias ls='gls --color=tty'


### PR DESCRIPTION
This change fixes the following error on OS X Sierra:

`ls: illegal option -- -
usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]`