### PR TITLE
Display suvash prompt w/o Ruby; refactor code

### DIFF
--- a/themes/suvash.zsh-theme
+++ b/themes/suvash.zsh-theme
@@ -5,26 +5,30 @@ function prompt_char {
 }
 
 function virtualenv_info {
-    [ $VIRTUAL_ENV ] && echo '('`basename $VIRTUAL_ENV`') '
+    [[ -n "$VIRTUAL_ENV" ]] && echo '('${VIRTUAL_ENV:t}') '
 }
 
-function collapse_pwd {
-    echo $(pwd | sed -e "s,^$HOME,~,")
+function ruby_prompt {
+    if (( $+commands[rvm-prompt] )); then
+        print -n $ZSH_THEME_RUBY_PROMPT_PREFIX
+        print -n $(~/.rvm/bin/rvm-prompt)
+        print -n $ZSH_THEME_RUBY_PROMPT_SUFFIX
+    elif (( $+commands[rbenv] )); then
+        print -n $ZSH_THEME_RUBY_PROMPT_PREFIX
+        print -n $(rbenv version | sed -e "s/ (set.*$//")
+        print -n $ZSH_THEME_RUBY_PROMPT_SUFFIX
+    fi
+    return 0
 }
 
-if which rvm-prompt &> /dev/null; then
-  PROMPT='%{$fg[magenta]%}%n%{$reset_color%} at %{$fg[yellow]%}%m%{$reset_color%} in %{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) using %{$reset_color%}%{$fg[red]%}$(~/.rvm/bin/rvm-prompt)%{$reset_color%} 
-$(virtualenv_info)$(prompt_char) '
-else
-  if which rbenv &> /dev/null; then
-    PROMPT='%{$fg[magenta]%}%n%{$reset_color%} at %{$fg[yellow]%}%m%{$reset_color%} in %{$fg_bold[green]%}${PWD/#$HOME/~}%{$reset_color%}$(git_prompt_info) using %{$reset_color%}%{$fg[red]%}$(rbenv version | sed -e "s/ (set.*$//")%{$reset_color%} 
-$(virtualenv_info)$(prompt_char) '
-  fi
-fi
+PROMPT='%F{magenta}%n%f at %F{yellow}%m%f in %B%F{green}%~%f%b$(git_prompt_info)$(ruby_prompt)
+$(virtualenv_info) $(prompt_char) '
 
+ZSH_THEME_GIT_PROMPT_PREFIX=' on %F{magenta}'
+ZSH_THEME_GIT_PROMPT_SUFFIX='%f'
+ZSH_THEME_GIT_PROMPT_DIRTY='%F{green}!'
+ZSH_THEME_GIT_PROMPT_UNTRACKED='%F{green}?'
+ZSH_THEME_GIT_PROMPT_CLEAN=''
 
-ZSH_THEME_GIT_PROMPT_PREFIX=" on %{$fg[magenta]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[green]%}!"
-ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[green]%}?"
-ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_RUBY_PROMPT_PREFIX=' using %F{red}'
+ZSH_THEME_RUBY_PROMPT_SUFFIX='%f'


### PR DESCRIPTION
Refactors theme code:
* Use `${var:t}` instead of `basename $var`.
* Use `[[ -n "$var" ]]` instead of `[ $var ]`.
* Use `(( $+commands[cmd] ))` instead of `cmd >/dev/null 2>&1`.
* Use `%F{color}text%f` and `%Btext%b` for color and boldness.
* Use a single Ruby prompt function instead of multiple prompt definitions. This also fixes #5514.