### PR TITLE
Use $+commands to check the existence of a command in clipboard.zsh.

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -31,13 +31,13 @@ function clipcopy() {
       cat $file > /dev/clipboard
     fi
   else
-    if which xclip &>/dev/null; then
+    if (( $+commands[xclip] )); then
       if [[ -z $file ]]; then
         xclip -in -selection clipboard
       else
         xclip -in -selection clipboard $file
       fi
-    elif which xsel &>/dev/null; then
+    elif (( $+commands[xsel] )); then
       if [[ -z $file ]]; then
         xsel --clipboard --input 
       else
@@ -74,9 +74,9 @@ function clippaste() {
   elif [[ $OSTYPE == cygwin* ]]; then
     cat /dev/clipboard
   else
-    if which xclip &>/dev/null; then
+    if (( $+commands[xclip] )); then
       xclip -out -selection clipboard
-    elif which xsel &>/dev/null; then
+    elif (( $+commands[xsel] )); then
       xsel --clipboard --output
     else
       print "clipcopy: Platform $OSTYPE not supported or xclip/xsel not installed" >&2


### PR DESCRIPTION
For better speed. There are a lot of other using of `which`, but this is in `lib` thus more impacting...