### PR TITLE
Fix last working directory plugin not working

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -16,8 +16,8 @@ lwd() {
 
 # Jump to last directory automatically unless:
 # - this isn't the first time the plugin is loaded
-# - it's not in $HOME directory
+# - it's in $HOME directory
 [[ -n "$ZSH_LAST_WORKING_DIRECTORY" ]] && return
-[[ "$PWD" != "$HOME" ]] && return
+[[ "$PWD" == "$HOME" ]] && return
 
 lwd 2>/dev/null && ZSH_LAST_WORKING_DIRECTORY=1 || true


### PR DESCRIPTION
This patch will fix last working directory plugin, 
I believe it's not working because of this 

```
[[ "$PWD" != "$HOME" ]] && return
```

I think we need to use equality operator to check if we're in home directory.

Tested manually