### PR TITLE
ssh-agent plugin: add check for .ssh folder

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -1,6 +1,6 @@
 if [[ ! -d $HOME/.ssh ]]; then
-    echo $HOME/.ssh not found, exiting...
-    return 1
+    echo "$HOME/.ssh not found, creating now..."
+    mkdir ~/.ssh && chmod 700 ~/.ssh
 fi
 
 typeset _agent_forwarding _ssh_env_cache

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -1,3 +1,8 @@
+if [[ ! -d $HOME/.ssh ]]; then
+    echo $HOME/.ssh not found, exiting...
+    return 1
+fi
+
 typeset _agent_forwarding _ssh_env_cache
 
 function _start_agent() {


### PR DESCRIPTION
If `$HOME/.ssh` doesn't exist, echo `$HOME/.ssh not found, exiting..."
and return 1 instead of running the rest of the plugin.

This will fix #5128
