### PR TITLE
Droplr Plugin: Fix regex for optional http(s), and variable reference inside osascript.

### DIFF
--- a/plugins/droplr/droplr.plugin.zsh
+++ b/plugins/droplr/droplr.plugin.zsh
@@ -7,8 +7,8 @@ droplr() {
         return 1
     fi
 
-    if [[ "$1" =~ ^http[|s]:// ]]; then
-        osascript -e "tell app 'Droplr' to shorten '$1'"
+    if [[ "$1" =~ ^https?:// ]]; then
+        osascript -e 'tell app "Droplr" to shorten "'"$1"'"'
     else
         open -ga /Applications/Droplr.app "$1"
     fi


### PR DESCRIPTION
This plugin wasn't working for me on MacOS.
- Sierra 10.12
- Droplr 4.6.3

See commit for changes to get the plugin working.


