### PR TITLE
Check dircolors settings before using gls on darwin

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -4,6 +4,8 @@ autoload -U colors && colors
 # Enable ls colors
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
+# TODO organise this chaotic logic
+
 if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
   # Find the option for using colors in ls, depending on the version
   if [[ "$OSTYPE" == netbsd* ]]; then
@@ -18,7 +20,12 @@ if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
     gls --color -d . &>/dev/null && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null && alias ls='colorls -G'
   elif [[ "$OSTYPE" == darwin* ]]; then
-    gls --color -d . &>/dev/null && alias ls='gls --color=tty' || alias ls='ls -G'
+    # this is a good alias, it works by default just using $LSCOLORS
+    alias ls='ls -G'
+
+    # only use coreutils ls if there is a dircolors customization present ($LS_COLORS or .dircolors file)
+    # otherwise, gls will use the default color scheme which is ugly af
+    [[ -n "$LS_COLORS" || -f "$HOME/.dircolors" ]] && gls --color -d . &>/dev/null && alias ls='gls --color=tty'
   else
     # For GNU ls, we use the default ls color theme. They can later be overwritten by themes.
     if [[ -z "$LS_COLORS" ]]; then


### PR DESCRIPTION
`gls` seems to be installed by default or on most macOS systems, but its default color scheme sucks. This fix will make sure to only use it if it has been customised prior to running OMZ.

Fixes #5552

Related: #5516, #5520.
