### PR TITLE
add conditions to open module specific node documentation

### DIFF
--- a/plugins/node/node.plugin.zsh
+++ b/plugins/node/node.plugin.zsh
@@ -1,5 +1,9 @@
 # Open the node api for your current version to the optional section.
 # TODO: Make the section part easier to use.
 function node-docs {
-  open_command "http://nodejs.org/docs/$(node --version)/api/all.html#all_$1"
+  if [ $# -eq 0 ]; then
+    open_command "http://nodejs.org/docs/$(node --version)/api/all.html"
+  else
+    open_command "http://nodejs.org/docs/$(node --version)/api/$1.html"
+  fi
 }

--- a/plugins/node/node.plugin.zsh
+++ b/plugins/node/node.plugin.zsh
@@ -1,9 +1,6 @@
 # Open the node api for your current version to the optional section.
 # TODO: Make the section part easier to use.
 function node-docs {
-  if [ $# -eq 0 ]; then
-    open_command "http://nodejs.org/docs/$(node --version)/api/all.html"
-  else
-    open_command "http://nodejs.org/docs/$(node --version)/api/$1.html"
-  fi
+  local section=${1:-all}
+  open_command "http://nodejs.org/docs/$(node --version)/api/$section.html"
 }


### PR DESCRIPTION
This would be easy for a user who wants to refer modules in specific, Module will be passed as an argument. For example,  **node-docs fs** will result in opening https://nodejs.org/docs/v6.7.0/api/fs.html. If no argument is passed it will open https://nodejs.org/docs/v6.7.0/api/all.html

*note I'm using node version 6.7.0 
