### PR TITLE
znt: Update to v2.2.7

### DIFF
--- a/plugins/zsh-navigation-tools/NEWS
+++ b/plugins/zsh-navigation-tools/NEWS
@@ -1,0 +1,17 @@
+-------------------------------------
+CHANGES FROM PREVIOUS VERSIONS OF ZNT
+-------------------------------------
+
+Changes from 2.2.1 to 2.2.7
+---------------------------
+
+Tmux integration has been added – bind file znt-tmux.zsh in Tmux as
+described in README.md and e.g. run local history on remote hosts. Tmux
+opens new window with n-history, and pastes selected history entry into
+immediate previous window (e.g. a remote session). Fixed plugin.zsh file
+to not use (outer scope) positional parameters. This fixes problem with
+Grlm's Zsh configuration. The file now doesn't use "test" builtin (but
+[[ instead), because it can be shadowed by alias or command. Private
+history has been fixed to not overwrite its history file with the same
+content. This improves performance when switching to private history
+view.

--- a/plugins/zsh-navigation-tools/README.md
+++ b/plugins/zsh-navigation-tools/README.md
@@ -34,6 +34,60 @@ want to copy your previous data (from e.g. ~/.zhistory) into the new location.
 
 ## News
 
+* 06-10-2016
+  - Tmux-integration – Ctrl-b-h in Tmux to open n-history in new window.
+    Then select history entry, it will be copied to the original Tmux window.
+    Use this to execute local commands on remote hosts. All that is needed is
+    this line added to ~/.tmux.conf:
+
+    bind h run-shell -b "$ZNT_REPO_DIR/znt-tmux.zsh"
+
+* 16-05-2016
+  - n-kill has completion. It proposes *words* from what's in `ps -A`. Giving n-kill
+    arguments means grepping – it will start only with matching `ps` entries.
+
+* 15-05-2016
+  - Fixed problem where zsh-syntax-highlighting could render n-history slow (for
+    long history entries).
+
+* 14-05-2016
+  - Configuration can be set from zshrc. Example:
+
+    znt_list_instant_select=1
+    znt_list_border=0
+    znt_list_bold=1
+    znt_list_colorpair="green/black"
+    znt_functions_keywords=( "zplg" "zgen" "match" )
+    znt_cd_active_text="underline"
+    znt_env_nlist_coloring_color=$'\x1b[00;33m'
+    znt_cd_hotlist=( "~/.config/znt" "/usr/share/zsh/site-functions" "/usr/share/zsh"
+                     "/usr/local/share/zsh/site-functions" "/usr/local/share/zsh"
+                     "/usr/local/bin" )
+
+* 10-05-2016
+  - Search query rotation – use Ctrl-A to rotate entered words right.
+    Words `1 2 3` become `3 1 2`.
+
+* 09-05-2016
+  - New feature: n-help tool, available also from n-history via H key. It
+    displays help screen with various information on ZNT.
+
+* 08-05-2016
+  - Approximate matching – pressing f or Ctrl-F will enter FIX mode, in
+    which 1 or 2 errors are allowed in what is searched. This utilizes
+    original Zsh approximate matching features and is intended to be used
+    after entering search query, when a typo is discovered.
+
+* 06-05-2016
+  - Private history can be edited. Use e key or Ctrl-E for that when in
+    n-history. Your $EDITOR will start. This is a way to have handy set
+    of bookmarks prepared in private history's file.
+  - Border can be disabled. Use following snippet in ~/.config/znt/n-list.conf
+    or any other tool-targetted config file:
+
+    # Should draw the border?
+    local border=0
+
 * 30-04-2016
   - New feature: color themes. Use Ctrl-T and Ctrl-G to browse predefined
     themes. They are listed in ~/.config/znt/n-list.conf. Use the file to

--- a/plugins/zsh-navigation-tools/n-history
+++ b/plugins/zsh-navigation-tools/n-history
@@ -307,7 +307,7 @@ while (( 1 )); do
     elif [ "$active_view" = "1" ]; then
         if [ -s "$private_history_db" ]; then
             local title=$'\x1b[00;32m'"Private history:"$'\x1b[00;00m\0'
-            () { fc -ap -R "$private_history_db"; list=( "$title" ${history[@]} ) }
+            () { fc -Rap "$private_history_db" 20000 0; list=( "$title" ${history[@]} ) }
         else
             list=( "Private history - history entries selected via this tool will be put here" )
         fi
@@ -335,21 +335,37 @@ done
 
 if [ "$REPLY" -gt 0 ]; then
     selected="$reply[REPLY]"
+
+    # Append to private history
+    if [[ "$active_view" = "0" ]]; then
+        local newline=$'\n'
+        local selected_ph="${selected//$newline/\\$newline}"
+        print -r -- "$selected_ph" >> "$private_history_db"
+    fi
+
+    # TMUX?
+    if [[ "$ZNT_TMUX_MODE" = "1" ]]; then
+        tmux send -t "$ZNT_TMUX_ORIGIN_SESSION:$ZNT_TMUX_ORIGIN_WINDOW.$ZNT_TMUX_ORIGIN_PANE" "$selected"
+        tmux kill-window
+        return 0
     # ZLE?
-    if [ "${(t)CURSOR}" = "integer-local-special" ]; then
+    elif [ "${(t)CURSOR}" = "integer-local-special" ]; then
         zle .redisplay
         zle .kill-buffer
         LBUFFER+="$selected"
-
-        # Append to private history
-        local newline=$'\n'
-        selected="${selected//$newline/\\$newline}"
-        [ "$active_view" = "0" ] && print -r -- "$selected" >> "$private_history_db"
     else
         print -zr -- "$selected"
     fi
 else
-    [ "${(t)CURSOR}" = "integer-local-special" ] && zle redisplay
+    # TMUX?
+    if [[ "$ZNT_TMUX_MODE" = "1" ]]; then
+        tmux kill-window
+    # ZLE?
+    elif [[ "${(t)CURSOR}" = "integer-local-special" ]]; then
+        zle redisplay
+    fi
 fi
+
+return 0
 
 # vim: set filetype=zsh:

--- a/plugins/zsh-navigation-tools/n-list
+++ b/plugins/zsh-navigation-tools/n-list
@@ -310,8 +310,9 @@ while (( 1 )); do
                         colsearch_pattern="${search_buffer// ##/|(#a2)}"
                         list=( "${(@M)list:#(#ia2)*$~search_pattern*}" )
                     else
-                        # Patterns will be *foo*~^*bar* and (foo|bar)
+                        # Pattern will be *foo*~^*bar* (inventor: Mikael Magnusson)
                         search_pattern="${search_buffer// ##/*~^*}"
+                        # Pattern will be (foo|bar)
                         colsearch_pattern="${search_buffer// ##/|}"
                         list=( "${(@M)list:#(#i)*$~search_pattern*}" )
                     fi

--- a/plugins/zsh-navigation-tools/znt-tmux.zsh
+++ b/plugins/zsh-navigation-tools/znt-tmux.zsh
@@ -1,0 +1,50 @@
+#!/usr/bin/env zsh
+
+# Copyright (c) 2016, Zsolt Lengyel
+# Modifications copyright (c) 2016, Sebastian Gniazdowski
+
+#
+# This script opens a new, temporary tmux pane and runs n-history. When
+# a selection is made, the result (history entry) is pasted back into
+# original tmux pane, and the temporary pane is closed. This allows to
+# use local history on remote machines.
+#
+# To use, put this line to your ~/.tmux.conf. The tool is invoked with:
+# Ctrl+b h
+#
+# bind h run-shell -b "$ZNT_REPO_DIR/znt-tmux.zsh"
+#
+
+# get and save the current active tmux pane id
+active_pane=$(tmux display -p -F ':#{session_id}:#I:#P:#{pane_active}:#{window_active}:#{session_attached}' )
+a_active_pane=("${(@s/:/)active_pane}")
+
+active_session=${a_active_pane[2]//$}
+active_window=$a_active_pane[3]
+active_pane=$a_active_pane[4]
+
+# set variables for upcoming window
+tmux setenv -t $active_session:$active_window.$active_pane "ZNT_TMUX_MODE" 1
+tmux setenv -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_SESSION" "$active_session"
+tmux setenv -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_WINDOW" "$active_window"
+tmux setenv -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_PANE" "$active_pane"
+
+# create a new window in the active session and call it znt-hist
+tmux new-window -t $active_session: -n znt-hist
+
+# unset the variables, so only above single window has them
+tmux setenv -u -t $active_session:$active_window.$active_pane "ZNT_TMUX_MODE"
+tmux setenv -u -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_SESSION"
+tmux setenv -u -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_WINDOW"
+tmux setenv -u -t $active_session:$active_window.$active_pane "ZNT_TMUX_ORIGIN_PANE"
+
+# znt's session id
+znt_active_pane=$(tmux display -p -F ':#{session_id}:#I:#P:#{pane_active}:#{window_active}:#{session_attached}' )
+znt_a_active_pane=("${(@s/:/)znt_active_pane}")
+
+znt_active_session=${znt_a_active_pane[2]//$}
+znt_active_window=$znt_a_active_pane[3]
+znt_active_pane=$znt_a_active_pane[4]
+
+# call znt
+tmux send -t "$znt_active_session:$znt_active_window.$znt_active_pane" n-history ENTER

--- a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+++ b/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
@@ -1,38 +1,43 @@
 #!/usr/bin/env zsh
 
-REPO_DIR="${0%/*}"
-CONFIG_DIR="$HOME/.config/znt"
+0="${(%):-%N}" # this gives immunity to functionargzero being unset
+export ZNT_REPO_DIR="${0%/*}"
+export ZNT_CONFIG_DIR="$HOME/.config/znt"
 
 #
 # Copy configs
 #
 
-if ! test -d "$HOME/.config"; then
-    mkdir "$HOME/.config"
+if [[ ! -d "$HOME/.config" ]]; then
+    command mkdir "$HOME/.config"
 fi
 
-if ! test -d "$CONFIG_DIR"; then
-    mkdir "$CONFIG_DIR"
+if [[ ! -d "$ZNT_CONFIG_DIR" ]]; then
+    command mkdir "$ZNT_CONFIG_DIR"
 fi
 
 # 9 files
-set n-aliases.conf n-env.conf n-history.conf n-list.conf n-panelize.conf n-cd.conf n-functions.conf n-kill.conf n-options.conf
+unset __ZNT_CONFIG_FILES
+typeset -ga __ZNT_CONFIG_FILES
+set +A __ZNT_CONFIG_FILES n-aliases.conf n-env.conf n-history.conf n-list.conf n-panelize.conf n-cd.conf n-functions.conf n-kill.conf n-options.conf
 
 # Check for random 2 files if they exist
 # This will shift 0 - 7 elements
-shift $(( RANDOM % 8 ))
-if ! test -f "$CONFIG_DIR/$1" || ! test -f "$CONFIG_DIR/$2"; then
+shift $(( RANDOM % 8 )) __ZNT_CONFIG_FILES
+if [[ ! -f "$ZNT_CONFIG_DIR/${__ZNT_CONFIG_FILES[1]}" || ! -f "$ZNT_CONFIG_DIR/${__ZNT_CONFIG_FILES[2]}" ]]; then
     # Something changed - examine every file
-    set n-aliases.conf n-env.conf n-history.conf n-list.conf n-panelize.conf n-cd.conf n-functions.conf n-kill.conf n-options.conf
-    for i; do
-        if ! test -f "$CONFIG_DIR/$i"; then
-            cp "$REPO_DIR/.config/znt/$i" "$CONFIG_DIR"
+    set +A __ZNT_CONFIG_FILES n-aliases.conf n-env.conf n-history.conf n-list.conf n-panelize.conf n-cd.conf n-functions.conf n-kill.conf n-options.conf
+    unset __ZNT_CONFIG_FILE
+    typeset -g __ZNT_CONFIG_FILE
+    for __ZNT_CONFIG_FILE in "${__ZNT_CONFIG_FILES[@]}"; do
+        if [[ ! -f "$ZNT_CONFIG_DIR/$__ZNT_CONFIG_FILE" ]]; then
+            command cp "$ZNT_REPO_DIR/.config/znt/$__ZNT_CONFIG_FILE" "$ZNT_CONFIG_DIR"
         fi
     done
+    unset __ZNT_CONFIG_FILE
 fi
 
-# Don't leave positional parameters being set
-set --
+unset __ZNT_CONFIG_FILES
 
 #
 # Load functions


### PR DESCRIPTION
Hello,
Tmux integration has been added – bind file znt-tmux.zsh in Tmux as described in README.md and e.g. run local history on remote hosts. Tmux opens new window with n-history, and pastes selected history entry into immediate previous window (e.g. a remote session). Fixed plugin.zsh file to not use (outer scope) positional parameters. Also, the file now doesn't use "test" builtin (but [[ instead), because it can be shadowed by alias or command. Private history has been fixed to not overwrite its history file with the same content. This improves performance when switching to private history view.
