### PR TITLE
Add alias to git plugin - gdcaw

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -85,6 +85,7 @@ alias gcs='git commit -S'
 alias gd='git diff'
 alias gdca='git diff --cached'
 alias gdct='git describe --tags `git rev-list --tags --max-count=1`'
+alias gdcaw='git diff --cached --word-diff'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
 alias gdw='git diff --word-diff'
 


### PR DESCRIPTION
Combination of both `gdca` + `gdw` aliases.

Performs a git diff on cached items with the `--word-diff` flag.