### PR TITLE
PHP suffix alias should be removed

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -54,7 +54,7 @@ alias mv='mv -i'
 # depends on the SUFFIX :)
 if is-at-least 4.2.0; then
   # open browser on urls
-  _browser_fts=(htm html de org net com at cx nl se dk dk php)
+  _browser_fts=(htm html de org net com at cx nl se dk dk)
   for ft in $_browser_fts ; do alias -s $ft=$BROWSER ; done
 
   _editor_fts=(cpp cxx cc c hh h inl asc txt TXT tex)


### PR DESCRIPTION
PHP can be executed as CLI script but due to the automated attempt
to add browser support to that extension such ability is prevented
in certain circumstances.

For example if I have the following file named as `hello-world.php` and with `+x` attribute:
```php
#!/usr/bin/env php
<?php

echo 'Hello World!' . PHP_EOL;
exit(0);
```
when I try to execute it using the following notation:
```bash
~ ./hello-world.php
```
ZSH hangs and start running at 100% CPU. 

The cause is that the $BROWSER variable might not be defined and if so, because the suffix alias has priority on the shebang header, the shell doesn't know what to do.
