### PR TITLE
Refactor zsh_reload plugin

### DIFF
--- a/plugins/zsh_reload/README.md
+++ b/plugins/zsh_reload/README.md
@@ -1,0 +1,23 @@
+# zsh_reload plugin
+
+The zsh_reload plugin defines a function to reload the zsh session with
+just a few keystrokes.
+
+To use it, add `zsh_reload` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... zsh_reload)
+```
+
+## Usage
+
+To reload the zsh session, just run `src`:
+
+```zsh
+$ vim ~/.zshrc  # enabled a plugin
+$ src
+re-compiling /home/user/.zshrc.zwc: succeeded
+re-compiling /home/user/.oh-my-zsh/cache/zcomp-host.zwc: succeeded
+
+# you now have a fresh zsh session. happy hacking!
+```

--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,13 +1,11 @@
-# reload zshrc
-function src()
-{
-  local cache=$ZSH_CACHE_DIR
-  autoload -U compinit zrecompile
-  compinit -d "$cache/zcomp-$HOST"
+src() {
+	local cache="$ZSH_CACHE_DIR"
+	autoload -U compinit zrecompile
+	compinit -d "$cache/zcomp-$HOST"
 
-  for f in ~/.zshrc "$cache/zcomp-$HOST"; do
-    zrecompile -p $f && command rm -f $f.zwc.old
-  done
+	for f in ~/.zshrc "$cache/zcomp-$HOST"; do
+		zrecompile -p $f && command rm -f $f.zwc.old
+	done
 
-  source ~/.zshrc
+	source ~/.zshrc
 }

--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,7 +1,7 @@
 src() {
 	local cache="$ZSH_CACHE_DIR"
 	autoload -U compinit zrecompile
-	compinit -d "$cache/zcomp-$HOST"
+	compinit -i -d "$cache/zcomp-$HOST"
 
 	for f in ~/.zshrc "$cache/zcomp-$HOST"; do
 		zrecompile -p $f && command rm -f $f.zwc.old

--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -7,5 +7,6 @@ src() {
 		zrecompile -p $f && command rm -f $f.zwc.old
 	done
 
-	source ~/.zshrc
+	# Use $SHELL if available; remove leading dash if login shell
+	[[ -n "$SHELL" ]] && exec ${SHELL#-} || exec zsh
 }


### PR DESCRIPTION
- Use `exec zsh` instead of `source ~/.zshrc` which is a bad practice because it can have side effects.
- Ignore insecure files on `compinit`.
- Add README.
- Fix code style.

Motivated by https://github.com/robbyrussell/oh-my-zsh/issues/5243#issuecomment-256362806.
cc @toddmbloom