### PR TITLE
Changed dsa --> rsa in zshrc.zsh-template file

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -73,7 +73,7 @@ source $ZSH/oh-my-zsh.sh
 # export ARCHFLAGS="-arch x86_64"
 
 # ssh
-# export SSH_KEY_PATH="~/.ssh/dsa_id"
+# export SSH_KEY_PATH="~/.ssh/rsa_id"
 
 # Set personal aliases, overriding those provided by oh-my-zsh libs,
 # plugins, and themes. Aliases can be placed here, though oh-my-zsh


### PR DESCRIPTION
# Reasoning
OpenSSH 7.0 [disabled DSA keys by default](https://www.gentoo.org/support/news-items/2015-08-13-openssh-weak-keys.html) for a wide variety of reasons that are discussed [here](http://security.stackexchange.com/a/112818). This PR is merely updating the template for `.zshrc` file to use the now-standard `~/.ssh/rsa_id`.