### PR TITLE
Docker-machine aliases

### DIFF
--- a/plugins/docker-machine/README.md
+++ b/plugins/docker-machine/README.md
@@ -1,0 +1,2 @@
+# Docker-machine plugin for Oh my zsh
+

--- a/plugins/docker-machine/docker-machine.plugin.zsh
+++ b/plugins/docker-machine/docker-machine.plugin.zsh
@@ -1,0 +1,19 @@
+# Authors:
+# https://github.com/HaraldNordgren
+#
+# Docker-machine related zsh aliases
+
+alias dm='docker-machine'
+
+alias dmc='docker-machine create'
+alias dmls='docker-machine ls'
+alias dmrestart='docker-machine restart'
+alias dmrm='docker-machine rm'
+alias dmstart='docker-machine start'
+alias dmstop='docker-machine stop'
+alias dmst='docker-machine status'
+
+function dmenv {
+    eval "$(docker-machine env $1)"
+}
+


### PR DESCRIPTION
Useful aliases for `docker-machine`. Inspired by docker-compose/docker-compose.plugin.zsh.