### PR TITLE
[plugin][mercurial] Optimize in_hg and hg_get_branch_name

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -18,25 +18,44 @@ alias hgca='hg commit --amend'
 # list unresolved files (since hg does not list unmerged files in the status command)
 alias hgun='hg resolve --list'
 
+function hg_get_dir() {
+  # Defines path as current directory
+  local current_dir=$PWD
+  # While current path is not root path
+  while [[ $current_dir != '/' ]]; do
+    if [[ -d "${current_dir}/.hg" ]]; then
+      echo "${current_dir}/.hg"
+      return
+    fi
+    # Defines path as parent directory and keeps looking for
+    current_dir="${current_dir:h}"
+  done
+}
+
 function in_hg() {
-  if [[ -d .hg ]] || $(hg summary > /dev/null 2>&1); then
+  if [[ $(hg_get_dir) != "" ]]; then
     echo 1
   fi
 }
 
 function hg_get_branch_name() {
-  if [ $(in_hg) ]; then
-    echo $(hg branch)
+  local hg_dir=$(hg_get_dir)
+  if [[ $hg_dir != "" ]]; then
+    if [[ -f "${hg_dir}/branch" ]]; then
+      echo $(<"${hg_dir}/branch")
+    else
+      echo "default"
+    fi
   fi
 }
 
 function hg_prompt_info {
-  if [ $(in_hg) ]; then
-    _DISPLAY=$(hg_get_branch_name)
+  local branch=$(hg_get_branch_name)
+  if [[ $branch != "" ]]; then
     echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_PREFIX\
-$ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_PROMPT_BASE_COLOR$(hg_dirty)$ZSH_THEME_HG_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR"
-    unset _DISPLAY
-  fi
+$ZSH_THEME_REPO_NAME_COLOR${display}$ZSH_PROMPT_BASE_COLOR\
+$ZSH_PROMPT_BASE_COLOR$(hg_dirty)$ZSH_THEME_HG_PROMPT_SUFFIX\
+$ZSH_PROMPT_BASE_COLOR"
 }
 
 function hg_dirty_choose {
@@ -57,9 +76,9 @@ function hg_dirty {
 }
 
 function hgic() {
-    hg incoming "$@" | grep "changeset" | wc -l
+  hg incoming "$@" | grep "changeset" | wc -l
 }
 
 function hgoc() {
-    hg outgoing "$@" | grep "changeset" | wc -l
+  hg outgoing "$@" | grep "changeset" | wc -l
 }


### PR DESCRIPTION
When not in the repo root dir `in_hg` used `hg summary` which is terribly slow on big repositories, and `hg_get_branch_name` called `hg branch` which is also pretty slow as well.

Based on the [branch](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/branch) plugin, I created the function `hg_get_dir` that fetch the `.hg` directory if it exists, going up in the directory tree. From there, we know if we're in an HG repository if `in_hg` returns a non empty string, and we can simply get the branch name from the content of the `.hg/branch` file.

### Benchmarks

Based on 10 calls to `hg_get_branch_name` in subdir (so that the old `hg summary` is called), here are the average times:
* Before: `/tmp/test.zsh  0.08s user 0.04s system 96% cpu 0.133 total`
* After: `/tmp/test.zsh  0.00s user 0.00s system 71% cpu 0.008 total`

It's faster and it uses less CPU!

The other changes after that are purely esthetic (fit in 80 columns and indentation fix).