### PR TITLE
Add alias for 'git checkout -t' in git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -81,6 +81,7 @@ alias gcp='git cherry-pick'
 alias gcpa='git cherry-pick --abort'
 alias gcpc='git cherry-pick --continue'
 alias gcs='git commit -S'
+alias gct='git checkout -t'
 
 alias gd='git diff'
 alias gdca='git diff --cached'


### PR DESCRIPTION
As far as I can see, there is no alias for this.
Please decline if I am mistaken.