### PR TITLE
Corrected key/value split when value contains a `:`.

### DIFF
--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -354,9 +354,8 @@ fi
 typeset -A points
 while read -r line
 do
-    arr=(${(s,:,)line})
-    key=${arr[1]}
-    val=${arr[2]}
+    key=${line%%:*}
+    val=${line#*:}
 
     points[$key]=$val
 done < $WD_CONFIG


### PR DESCRIPTION
When the path in a wd contains a `:`, the wd plugin does not read the path past the `:` character.  This change makes the key all of the string up to the first colon (as before) but the value as all of the string after the first colon.