### PR TITLE
Default installer to clone git origin master

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -62,7 +62,7 @@ main() {
     fi
   fi
   # if running from the git repo use git's origin
-  [-d .git]&& env git clone --depth=1 origin master || env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  [ -d .git ]&& env git clone --depth=1 origin master || env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,7 +61,8 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  # if running from the git repo use git's origin
+  [-d .git]&& env git clone --depth=1 origin master || env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }


### PR DESCRIPTION
#5628 I wrote this because many zsh users (like myself) have forks of oh-my-zsh that we use instead of the official version. This way someone with a fork can clone the repo they own and install their own version of oh-my-zsh.

Please let me know if you would like me to change anything as I am a total neophyte a contributing to open source.