### PR TITLE
Add pyenv default path when installed by hombrew.

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -7,7 +7,7 @@ _pyenv-from-homebrew-installed() {
 }
 
 FOUND_PYENV=0
-pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
+pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/usr/local/opt/pyenv" "/opt/pyenv")
 if _homebrew-installed && _pyenv-from-homebrew-installed ; then
     pyenvdirs=($(brew --prefix pyenv) "${pyenvdirs[@]}")
 fi


### PR DESCRIPTION
Hombrew use `/usr/local/opt/` as a `prefix`. So pyenv directory should be `/usr/local/opt/pyenv`