### PR TITLE
Magento 2 plugin INIT

### DIFF
--- a/plugins/magento2/README.md
+++ b/plugins/magento2/README.md
@@ -1,0 +1,19 @@
+# Magento2 plugin
+
+This plugin adds completion and aliases for the `magento` command. More information at https://github.com/denisristic/oh-my-zsh.
+
+Enable magento2 plugin in your zshrc file:
+```
+plugins=(... magento2)
+```
+
+## Aliases
+
+| Alias       | Command                                   | Description                                                               |
+|-------------|-------------------------------------------|---------------------------------------------------------------------------|
+| `m2`        | `magento`                             | Magento command                                                               |
+| `m2clean`   | `magento cache:clean`                 | Cleans cache type(s)                                                          |
+| `m2reindex` | `magento indexer:reindex`             | Reindexes Data                                                                |
+| `m2compile` | `magento setup:di:compile`            | Generates DI configuration and all missing classes that can be auto-generated |
+| `m2upgrade` | `magento setup:upgrade`               | Upgrades the Magento application, DB data, and schema                         |
+| `m2sdeploy` | `magento setup:static-content:deploy` | Deploys static view files                                                     |

--- a/plugins/magento2/magento2.plugin.zsh
+++ b/plugins/magento2/magento2.plugin.zsh
@@ -4,9 +4,6 @@
 # Copyright (c) 2016 Denis Ristic <me@denisristic.com>
 # Depend of Oh My Zsh (https://github.com/robbyrussell/oh-my-zsh)
 #
-# Distributed under the GNU GPL v2. For full terms see the file LICENSE.
-#
-
 
 _magento2_console () {
   echo "php $(find . -maxdepth 2 -mindepth 1 -name 'magento' -type f | head -n 1)"

--- a/plugins/magento2/magento2.plugin.zsh
+++ b/plugins/magento2/magento2.plugin.zsh
@@ -1,0 +1,31 @@
+#
+# Magento2 oh-my-zsh plugin
+#
+# Copyright (c) 2016 Denis Ristic <me@denisristic.com>
+# Depend of Oh My Zsh (https://github.com/robbyrussell/oh-my-zsh)
+#
+# Distributed under the GNU GPL v2. For full terms see the file LICENSE.
+#
+
+
+_magento2_console () {
+  echo "php $(find . -maxdepth 2 -mindepth 1 -name 'magento' -type f | head -n 1)"
+}
+
+_magento2_get_command_list () {
+	`_magento2_console` --no-ansi | awk '/ ([a-z\:])*  .*/ { print $1 }'
+}
+
+_magento2 () {
+   compadd `_magento2_get_command_list`
+}
+
+compdef _magento2 '`_magento2_console`'
+
+#aliases
+alias m2='`_magento2_console`'
+alias m2clean='`_magento2_console` cache:clean'
+alias m2reindex='`_magento2_console` indexer:reindex'
+alias m2compile='`_magento2_console` setup:di:compile'
+alias m2upgrade='`_magento2_console` setup:upgrade'
+alias m2deploy='`_magento2_console` setup:static-content:deploy'


### PR DESCRIPTION
This plugin adds completion and aliases for the `magento` command. More information at https://github.com/denisristic/oh-my-zsh.