### PR TITLE
feat: no CI on WIP commits

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -237,4 +237,4 @@ alias gupv='git pull --rebase -v'
 alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
-alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip--"'
+alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip-- [skip ci]"'


### PR DESCRIPTION
I've been working with my team using ohmyzsh for a couple months now and it's going great! 

One problem is that since we pair program a lot, we find ourselves `gwip`ing and `gunwip`ing frequently to share WIP and switch drivers etc. This leads to a lot of CI resources being used unnecessarily. Since `[skip ci]` is used by the likes of TravisCI, CircleCI, GitLab CI and others I think it's fair to include here. Feedback is welcome! And if not mergeable, we'll probably just put this in our aliases ourselves, but I thought others could benefit. 

Thanks!