### PR TITLE
Adding new path to look for activate.sh

### DIFF
--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -1,7 +1,7 @@
 # Activates autoenv or reports its failure
 () {
 if ! type autoenv_init >/dev/null; then
-  for d (~/.autoenv /usr/local/opt/autoenv /usr/local/bin); do
+  for d (~/.autoenv ~/.local/bin /usr/local/opt/autoenv /usr/local/bin); do
     if [[ -e $d/activate.sh ]]; then
       autoenv_dir=$d
       break


### PR DESCRIPTION
If autoenv was installed with pip and modifier --user, activate.sh will be at .local/bin