### PR TITLE
Add gsize command for git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -95,6 +95,8 @@ alias gf='git fetch'
 alias gfa='git fetch --all --prune'
 alias gfo='git fetch origin'
 
+alias gsize='git count-objects -vH'
+
 function gfg() { git ls-files | grep $@ }
 compdef _grep gfg
 


### PR DESCRIPTION
In case that you have not know about it, following are sample output for the new `gsize` alias: 
```sh
$ git count-objects -vH
count: 1414
size: 5.92 MiB
in-pack: 180
packs: 2
size-pack: 46.68 KiB
prune-packable: 0
garbage: 0
size-garbage: 0 bytes
```

@Stibbons, @ncanceill, please review.