### PR TITLE
mix run takes file arguments

### DIFF
--- a/plugins/mix/_mix
+++ b/plugins/mix/_mix
@@ -86,6 +86,9 @@ case $state in
       (test)
          _files
          ;;
+      (run)
+         _files
+         ;;
     esac
   ;;
 esac


### PR DESCRIPTION
Fixes #5672

Allow file completion when using the `mix run` command