### PR TITLE
Add gpsuo git alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -190,6 +190,7 @@ alias gp='git push'
 alias gpd='git push --dry-run'
 alias gpoat='git push origin --all && git push origin --tags'
 compdef _git gpoat=git-push
+alias gpsuo='git push --set-upstream origin $(current_branch)'
 alias gpu='git push upstream'
 alias gpv='git push -v'
 


### PR DESCRIPTION
This alias is for pushing a new git branch to the origin remote. I find myself having to do this a lot in a pull request workflow, and it's easier to use this alias than doing a `gp` followed by a `fuck` to fix it.