### PR TITLE
Increase HISTSIZE and SAVEHIST by a factor of 10

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -3,8 +3,8 @@ if [ -z "$HISTFILE" ]; then
     HISTFILE=$HOME/.zsh_history
 fi
 
-HISTSIZE=10000
-SAVEHIST=10000
+HISTSIZE=100000
+SAVEHIST=100000
 
 # Show history
 case $HIST_STAMPS in


### PR DESCRIPTION
My $HOME/.zsh_history file is full and around 6 Kb. So increasing that size to a maximum of 60 Kb shouldn't hurt.

Increasing it by a factor of 100 might be even better since the file would still be less than 1 Mb. Although that might make starting a new shell slow -- I'm not sure if there is a relation.
  