### PR TITLE
debian & ubuntu plugins: use zgrep for `apt-history list`

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -192,7 +192,7 @@ apt-history () {
         awk '{print $4"="$5}'
       ;;
     list)
-      zcat $(ls -rt /var/log/dpkg*)
+      zgrep --no-filename '' $(ls -rt /var/log/dpkg*)
       ;;
     *)
       echo "Parameters:"

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -108,7 +108,7 @@ apt-history () {
         awk '{print $4"="$5}'
       ;;
     list)
-      zcat $(ls -rt /var/log/dpkg*)
+      zgrep --no-filename '' $(ls -rt /var/log/dpkg*)
       ;;
     *)
       echo "Parameters:"


### PR DESCRIPTION
Changing from `zcat` to `zgrep` because some `zcat` implementations do not work
if the file is not compressed.