### PR TITLE
The $HOME/.rbenv folder should have a bigger priority

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -7,6 +7,9 @@ rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv"
 if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null); then
     rbenvdirs=($rbenv_homebrew_path "${rbenvdirs[@]}")
     unset rbenv_homebrew_path
+    if [[ $RBENV_ROOT = '' ]]; then
+      RBENV_ROOT="$HOME/.rbenv"
+    fi
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
This folder should get the biggest priority because it should be default accordingly to rbenv documentation.

This is the pr based on [this](https://github.com/robbyrussell/oh-my-zsh/commit/baf2ab1bf1096b954a759739cc41c587fb0cf5b2#commitcomment-20133062) conversation.