### PR TITLE
Fixed bug with lib/git.zsh git_commits_* functions

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -76,7 +76,7 @@ function git_current_branch() {
 
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
-  if command git rev-parse --git-dir &>/dev/null; then
+  if [[ "$(command git rev-parse --git-dir &>/dev/null)" ]]; then
     local commits="$(git rev-list --count @{upstream}..HEAD)"
     if [[ "$commits" != 0 ]]; then
       echo "$ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX$commits$ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
@@ -86,7 +86,7 @@ function git_commits_ahead() {
 
 # Gets the number of commits behind remote
 function git_commits_behind() {
-  if command git rev-parse --git-dir &>/dev/null; then
+  if [[ "$(command git rev-parse --git-dir &>/dev/null)" ]]; then
     local commits="$(git rev-list --count HEAD..@{upstream})"
     if [[ "$commits" != 0 ]]; then
       echo "$ZSH_THEME_GIT_COMMITS_BEHIND_PREFIX$commits$ZSH_THEME_GIT_COMMITS_BEHIND_SUFFIX"


### PR DESCRIPTION
* When HEAD was in detached state, stderr was printing to console