### PR TITLE
add custom tab title cmd ignore pattern support

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -68,8 +68,12 @@ function omz_termsupport_preexec {
     return
   fi
 
+  local cmd_ignore_pattern="*=*|sudo|ssh|mosh|rake|-*"
+  if [[ -n "$TABTITLE_CUSTOM_IGNORE_PATTERN" ]]; then
+	  cmd_ignore_pattern="$cmd_ignore_pattern|$TABTITLE_CUSTOM_IGNORE_PATTERN"
+  fi
   # cmd name only, or if this is sudo or ssh, the next cmd
-  local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
+  local CMD=${1[(wr)^($cmd_ignore_pattern)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
 
   title '$CMD' '%100>...>$LINE%<<'


### PR DESCRIPTION
Currently, commands like `ssh` or `sudo` could be ignored as term tab title. Sometimes, user may want to ignore some other commands as the title.

This pull request supports user to define their own command ignore pattern.