### PR TITLE
Add a React Native itself alias, and to start the web server

### DIFF
--- a/plugins/react-native/README.md
+++ b/plugins/react-native/README.md
@@ -1,18 +1,23 @@
-# React Native
+# React Native plugin
 
-**Maintainers:**
-[BilalBudhani](https://github.com/BilalBudhani)
-[MauroPorrasP](https://github.com/mauroporrasp)
+This plugin adds completion for [`react-native`](https://facebook.github.io/react-native/).
+It also defines a few [aliases](#aliases) for the commands more frequently used.
 
-### List of Aliases
+To enable, add `react-native` to your `plugins` array in your zshrc file:
 
-Alias | React Native command
-------|---------------------
-**rn** | *react-native*
-**rns** | *react-native start*
-**rnand** | *react-native run-android*
-**rnios** | *react-native run-ios*
-**rnios4s** | *react-native run-ios --simulator "iPhone 4s"*
-**rnios5** | *react-native run-ios --simulator "iPhone 5"*
-**rnios5s** | *react-native run-ios --simulator "iPhone 5s"*
+```zsh
+plugins=(... react-native)
+```
 
+## Aliases
+
+| Alias       | React Native command                           |
+|:------------|:-----------------------------------------------|
+| **rn**      | `react-native`                                 |
+| **rns**     | `react-native start`                           |
+| _App testing_                                                |
+| **rnand**   | `react-native run-android`                     |
+| **rnios**   | `react-native run-ios`                         |
+| **rnios4s** | `react-native run-ios --simulator "iPhone 4s"` |
+| **rnios5**  | `react-native run-ios --simulator "iPhone 5"`  |
+| **rnios5s** | `react-native run-ios --simulator "iPhone 5s"` |

--- a/plugins/react-native/README.md
+++ b/plugins/react-native/README.md
@@ -1,11 +1,15 @@
-# React Native 
+# React Native
 
-**Maintainer:** [BilalBudhani](https://github.com/BilalBudhani)
+**Maintainers:**
+[BilalBudhani](https://github.com/BilalBudhani)
+[MauroPorrasP](https://github.com/mauroporrasp)
 
 ### List of Aliases
 
 Alias | React Native command
 ------|---------------------
+**rn** | *react-native*
+**rns** | *react-native start*
 **rnand** | *react-native run-android*
 **rnios** | *react-native run-ios*
 **rnios4s** | *react-native run-ios --simulator "iPhone 4s"*

--- a/plugins/react-native/README.md
+++ b/plugins/react-native/README.md
@@ -15,9 +15,12 @@ plugins=(... react-native)
 |:------------|:-----------------------------------------------|
 | **rn**      | `react-native`                                 |
 | **rns**     | `react-native start`                           |
+| **rnlink**  | `react-native link`                            |
 | _App testing_                                                |
 | **rnand**   | `react-native run-android`                     |
 | **rnios**   | `react-native run-ios`                         |
 | **rnios4s** | `react-native run-ios --simulator "iPhone 4s"` |
 | **rnios5**  | `react-native run-ios --simulator "iPhone 5"`  |
 | **rnios5s** | `react-native run-ios --simulator "iPhone 5s"` |
+| **rnios6**  | `react-native run-ios --simulator "iPhone 6"`  |
+| **rnios6s** | `react-native run-ios --simulator "iPhone 6s"` |

--- a/plugins/react-native/react-native.plugin.zsh
+++ b/plugins/react-native/react-native.plugin.zsh
@@ -1,11 +1,11 @@
 alias rn='react-native'
 alias rns='react-native start'
+alias rnlink='react-native link'
+
 alias rnand='react-native run-android'
+alias rnios='react-native run-ios'
 alias rnios4s='react-native run-ios --simulator "iPhone 4s"'
 alias rnios5='react-native run-ios --simulator "iPhone 5"'
 alias rnios5s='react-native run-ios --simulator "iPhone 5s"'
 alias rnios6='react-native run-ios --simulator "iPhone 6"'
 alias rnios6s='react-native run-ios --simulator "iPhone 6s"'
-alias rnios='react-native run-ios'
-alias rnlink='react-native link'
-

--- a/plugins/react-native/react-native.plugin.zsh
+++ b/plugins/react-native/react-native.plugin.zsh
@@ -1,3 +1,5 @@
+alias rn='react-native'
+alias rns='react-native start'
 alias rnand='react-native run-android'
 alias rnios4s='react-native run-ios --simulator "iPhone 4s"'
 alias rnios5='react-native run-ios --simulator "iPhone 5"'


### PR DESCRIPTION
Adds a couple of aliases:
- `rn` for `react-native`
- `rns` for `react-native start`

Also fixes the README and organises the rest of the aliases in the plugin.