### PR TITLE
Improve UX for Spotify quit command in osx plugin

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -416,7 +416,7 @@ function spotify() {
         if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
           cecho "Spotify was not running."
         else
-          cecho "Quitting Spotify.";
+          cecho "Closing Spotify.";
           osascript -e 'tell application "Spotify" to quit';
         fi
         break ;;

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -323,7 +323,7 @@ function spotify() {
   if [ $# = 0 ]; then
     showHelp;
   else
-    if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
+    if [ "$1" != "quit" ] && [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
       osascript -e 'tell application "Spotify" to activate'
       sleep 2
     fi
@@ -414,8 +414,12 @@ function spotify() {
 
       "quit"    )
         cecho "Quitting Spotify.";
-        osascript -e 'tell application "Spotify" to quit';
-        exit 1 ;;
+        if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
+          cecho "Spotify was not running."
+        else
+          osascript -e 'tell application "Spotify" to quit';
+        fi
+        break ;;
 
       "next"    )
         cecho "Going to next track." ;
@@ -470,7 +474,7 @@ function spotify() {
       "pos"   )
         cecho "Adjusting Spotify play position."
         osascript -e "tell application \"Spotify\" to set player position to $2";
-        break;;
+        break ;;
 
       "status" )
         showStatus;

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -413,10 +413,10 @@ function spotify() {
         break ;;
 
       "quit"    )
-        cecho "Quitting Spotify.";
         if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
           cecho "Spotify was not running."
         else
+          cecho "Quitting Spotify.";
           osascript -e 'tell application "Spotify" to quit';
         fi
         break ;;


### PR DESCRIPTION
Spotify command UX is a little weak for people who live and work almost entirely in shells.
- `spotify quit` should not open Spotify if it is not already running. Should confirm that Spotify is indeed not running.
- `spotify quit` should not blow away the user's shell once Spotify is quit. This can be a disruption to work flow.

This PR looks to add a few little checks which will help improve this experience.
This PR also adds a space to line 477 between `break` and `;;` for consistency. Doesn't seem like a big enough change to put in its own PR.