### PR TITLE
Change af-magic theme's branch color

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -27,7 +27,7 @@ else
 fi
 
 # git settings
-ZSH_THEME_GIT_PROMPT_PREFIX="$FG[078](branch:"
+ZSH_THEME_GIT_PROMPT_PREFIX="($FG[078]branch:"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[078])%{$reset_color%}"

--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -27,7 +27,7 @@ else
 fi
 
 # git settings
-ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075](branch:"
+ZSH_THEME_GIT_PROMPT_PREFIX="$FG[078](branch:"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"

--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -30,4 +30,4 @@ fi
 ZSH_THEME_GIT_PROMPT_PREFIX="$FG[078](branch:"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[078])%{$reset_color%}"

--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -27,7 +27,7 @@ else
 fi
 
 # git settings
-ZSH_THEME_GIT_PROMPT_PREFIX="($FG[078]branch:"
+ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075]($FG[078]"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[078])%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"


### PR DESCRIPTION
I love `af-magic` theme because of it's simplicity!
but its coloring is too simple to recognize which branch is now on.
so I changed branch color from 075, almost same color as path(prefix) color, to 078(same tone but green color)

And also I removed 'branch:' description for displaying branch information.
I think it is conceptually duplicated because the part is only for the branch status.

From
<img width="378" alt="2016-12-28 11 51 26" src="https://cloud.githubusercontent.com/assets/124808/21512778/27c56b80-ccf4-11e6-821f-da9c42329ba4.png">
To
<img width="447" alt="2017-01-09 12 40 20" src="https://cloud.githubusercontent.com/assets/124808/21756765/d59768ee-d668-11e6-9766-897225845c05.png">
