### PR TITLE
Fully ignore the custom directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 custom
 
 # temp files directories
-cache
-log
+cache/
+log/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # custom files
-custom/
-!custom/plugins/example
-!custom/example.zsh
+custom
 
 # temp files directories
-cache/
-log/
+cache
+log


### PR DESCRIPTION
First of all these two lines force me to never delete any of the example files or I cannot take normal updates:

-!custom/plugins/example
-!custom/example.zsh

Second, custom/ means I cannot symlink the custom folder elsewhere (for example to include it in a backup or my .dotfiles).  By changing custom/ to custom we get full control of the custom directory while maintaining normal .oh-my-zsh updates.

Otherwise you get this:
```
~/.oh-my-zsh master
❯ upgrade_oh_my_zsh
Updating Oh My Zsh
error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.
There was an error updating. Try again later?
```