### PR TITLE
Improved gradle options (arguments) completion

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -24,29 +24,29 @@ function _gradle_core_commands() {
 function _gradle_arguments() {
     _arguments -C \
     '-a[Do not rebuild project dependencies]' \
-    '-h[Help]' \
-    '-D[System property]' \
-    '-d[Log at the debug level]' \
-    '--gui[Launches the Gradle GUI app]' \
-    '--stop[Stop the Gradle daemon]' \
-    '--daemon[Use the Gradle daemon]' \
-    '--no-daemon[Do not use the Gradle daemon]' \
-    '--rerun-task [Specifies that any task optimization is ignored.]' \
-    '-i[Log at the info level]' \
-    '-m[Dry run]' \
-    '-P[Set a project property]' \
-    '-p[Specifies the start directory]' \
-    '--profile[Profile the build time]' \
-    '-q[Log at the quiet level (only show errors)]' \
-    '-v[Print the Gradle version info]' \
-    '-x[Specify a task to be excluded]' \
     '-b[Specifies the build file.]' \
     '-c[Specifies the settings file.]' \
-    '--continue[Continues task execution after a task failure.]' \
+    '-d[Log at the debug level]' \
     '-g[Specifies the Gradle user home directory.]' \
-    '-I[Specifies an initialization script.]' \
-    '--refresh-dependencies[Refresh the state of dependencies.]' \
+    '-h[Help]' \
+    '-i[Log at the info level]' \
+    '-m[Dry run]' \
+    '-p[Specifies the start directory]' \
+    '-q[Log at the quiet level (only show errors)]' \
     '-u[Don''t search in parent directories for a settings.gradle file.]' \
+    '-v[Print the Gradle version info]' \
+    '-x[Specify a task to be excluded]' \
+    '-D[System property]' \
+    '-I[Specifies an initialization script.]' \
+    '-P[Set a project property]' \
+    '--continue[Continues task execution after a task failure.]' \
+    '--daemon[Use the Gradle daemon]' \
+    '--gui[Launches the Gradle GUI app]' \
+    '--no-daemon[Do not use the Gradle daemon]' \
+    '--profile[Profile the build time]' \
+    '--refresh-dependencies[Refresh the state of dependencies.]' \
+    '--rerun-task [Specifies that any task optimization is ignored.]' \
+    '--stop[Stop the Gradle daemon]' \
     '*::command:->command' \
     && return 0
 }

--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -24,29 +24,60 @@ function _gradle_core_commands() {
 function _gradle_arguments() {
     _arguments -C \
     '-a[Do not rebuild project dependencies]' \
-    '-b[Specifies the build file.]' \
-    '-c[Specifies the settings file.]' \
+    '-b[Specifies the build file]' \
+    '-c[Specifies the settings file]' \
     '-d[Log at the debug level]' \
-    '-g[Specifies the Gradle user home directory.]' \
-    '-h[Help]' \
-    '-i[Log at the info level]' \
-    '-m[Dry run]' \
-    '-p[Specifies the start directory]' \
-    '-q[Log at the quiet level (only show errors)]' \
-    '-u[Don''t search in parent directories for a settings.gradle file.]' \
-    '-v[Print the Gradle version info]' \
+    '-g[Specifies the Gradle user home directory]' \
+    '-h[Shows a help message]' \
+    '-i[Set log level to INFO]' \
+    '-m[Runs the build with all task actions disabled]' \
+    '-p[Specifies the start directory for Gradle]' \
+    '-q[Log errors only]' \
+    '-s[Print out the stacktrace also for user exceptions]' \
+    '-t[Continuous mode. Automatically re-run build after changes]' \
+    '-u[Don''t search in parent directories for a settings.gradle file]' \
+    '-v[Prints Gradle version info]' \
     '-x[Specify a task to be excluded]' \
-    '-D[System property]' \
-    '-I[Specifies an initialization script.]' \
-    '-P[Set a project property]' \
-    '--continue[Continues task execution after a task failure.]' \
-    '--daemon[Use the Gradle daemon]' \
-    '--gui[Launches the Gradle GUI app]' \
-    '--no-daemon[Do not use the Gradle daemon]' \
-    '--profile[Profile the build time]' \
-    '--refresh-dependencies[Refresh the state of dependencies.]' \
-    '--rerun-task [Specifies that any task optimization is ignored.]' \
-    '--stop[Stop the Gradle daemon]' \
+    '-D[Set a system property]' \
+    '-I[Specifies an initialization script]' \
+    '-P[Sets a project property of the root project]' \
+    '-S[Print out the full (very verbose) stacktrace]' \
+    '--build-file[Specifies the build file]' \
+    '--configure-on-demand[Only relevant projects are configured]' \
+    '--console[Type of console output to generate (plain, auto, or rich)]' \
+    '--continue[Continues task execution after a task failure]' \
+    '--continuous[Continuous mode. Automatically re-run build after changes]' \
+    '--daemon[Use the Gradle Daemon]' \
+    '--debug[Log at the debug level]' \
+    '--dry-run[Runs the build with all task actions disabled]' \
+    '--exclude-task[Specify a task to be excluded]' \
+    '--full-stacktrace[Print out the full (very verbose) stacktrace]' \
+    '--gradle-user-home[Specifies the Gradle user home directory]' \
+    '--gui[Launches the Gradle GUI app (Deprecated)]' \
+    '--help[Shows a help message]' \
+    '--include-build[Run the build as a composite, including the specified build]' \
+    '--info[Set log level to INFO]' \
+    '--init-script[Specifies an initialization script]' \
+    '--max-workers[Set the maximum number of workers that Gradle may use]' \
+    '--no-daemon[Do not use the Gradle Daemon]' \
+    '--no-rebuild[Do not rebuild project dependencies]' \
+    '--no-search-upwards[Don''t search in parent directories for a settings.gradle file]' \
+    '--offline[Build without accessing network resources]' \
+    '--parallel[Build projects in parallel]' \
+    '--profile[Profile build time and create report]' \
+    '--project-cache-dir[Specifies the project-specific cache directory]' \
+    '--project-dir[Specifies the start directory for Gradle]' \
+    '--project-prop[Sets a project property of the root project]' \
+    '--quiet[Log errors only]' \
+    '--recompile-scripts[Forces scripts to be recompiled, bypassing caching]' \
+    '--refresh-dependencies[Refresh the state of dependencies]' \
+    '--rerun-task[Specifies that any task optimization is ignored]' \
+    '--settings-file[Specifies the settings file]' \
+    '--stacktrace[Print out the stacktrace also for user exceptions]' \
+    '--status[Print Gradle Daemon status]' \
+    '--stop[Stop all Gradle Daemons]' \
+    '--system-prop[Set a system property]' \
+    '--version[Prints Gradle version info]' \
     '*::command:->command' \
     && return 0
 }


### PR DESCRIPTION
This adds missing flags for gradle completion, reflecting what's in the [latest Gradle CLI docs](https://docs.gradle.org/3.2.1/userguide/gradle_command_line.html).

#### Before `gradle -[TAB]`
```
--continue              -- Continues task execution after a task failure.
--daemon                -- Use the Gradle daemon
--gui                   -- Launches the Gradle GUI app
--no-daemon             -- Do not use the Gradle daemon
--profile               -- Profile the build time
--refresh-dependencies  -- Refresh the state of dependencies.
--rerun-task            -- Specifies that any task optimization is ignored
--stop                  -- Stop the Gradle daemon
-D                      -- System property
-I                      -- Specifies an initialization script.
-P                      -- Set a project property
-a                      -- Do not rebuild project dependencies
-b                      -- Specifies the build file.
-c                      -- Specifies the settings file.
-d                      -- Log at the debug level
-g                      -- Specifies the Gradle user home directory.
-h                      -- Help
-i                      -- Log at the info level
-m                      -- Dry run
-p                      -- Specifies the start directory
-q                      -- Log at the quiet level (only show errors)
-u                      -- Dont search in parent directories for a setting
-v                      -- Print the Gradle version info
-x                      -- Specify a task to be excluded
```

#### After `gradle -[TAB]`
```
--build-file            -b  -- Specifies the build file
--configure-on-demand       -- Only relevant projects are configured
--console                   -- Type of console output to generate (plain, auto
--continue                  -- Continues task execution after a task failure
--continuous            -t  -- Continuous mode. Automatically re-run build aft
--daemon                    -- Use the Gradle Daemon
--debug                 -d  -- Log at the debug level
--dry-run               -m  -- Runs the build with all task actions disabled
--exclude-task          -x  -- Specify a task to be excluded
--full-stacktrace       -S  -- Print out the full (very verbose) stacktrace
--gradle-user-home      -g  -- Specifies the Gradle user home directory
--gui                       -- Launches the Gradle GUI app (Deprecated)
--help                  -h  -- Shows a help message
--include-build             -- Run the build as a composite, including the spe
--info                  -i  -- Set log level to INFO
--init-script           -I  -- Specifies an initialization script
--max-workers               -- Set the maximum number of workers that Gradle m
--no-daemon                 -- Do not use the Gradle Daemon
--no-rebuild            -a  -- Do not rebuild project dependencies
--no-search-upwards     -u  -- Dont search in parent directories for a setting
--offline                   -- Build without accessing network resources
--parallel                  -- Build projects in parallel
--profile                   -- Profile build time and create report
--project-cache-dir         -- Specifies the project-specific cache directory
--project-dir           -p  -- Specifies the start directory for Gradle
--project-prop          -P  -- Sets a project property of the root project
--quiet                 -q  -- Log errors only
--recompile-scripts         -- Forces scripts to be recompiled, bypassing cach
--refresh-dependencies      -- Refresh the state of dependencies
--rerun-task                -- Specifies that any task optimization is ignored
--settings-file         -c  -- Specifies the settings file
--stacktrace            -s  -- Print out the stacktrace also for user exceptio
--status                    -- Print Gradle Daemon status
--stop                      -- Stop all Gradle Daemons
--system-prop           -D  -- Set a system property
--version               -v  -- Prints Gradle version info
```