### PR TITLE
Restore ssh-agent variables if found alive gpg-agent

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -15,7 +15,15 @@ function start_agent_withssh {
 }
 
 # check if another agent is running
-if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
+if gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
+    # source settings of old agent, if applicable
+    if [ -f "${GPG_ENV}" ] && [ -z "${SSH_AGENT_PID}" ]; then
+        . ${GPG_ENV} > /dev/null
+        export GPG_AGENT_INFO
+        export SSH_AUTH_SOCK
+        export SSH_AGENT_PID
+    fi
+else
     # source settings of old agent, if applicable
     if [ -f "${GPG_ENV}" ]; then
         . ${GPG_ENV} > /dev/null


### PR DESCRIPTION
Those changes fix working with gpg-agent instead of ssh-agent when first one was run outside zsh.

(instead of #4798)