### PR TITLE
git_prompt_info: show the tag name

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -2,7 +2,8 @@
 function git_prompt_info() {
   local ref
   if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
-    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git symbolic-ref --short HEAD 2>/dev/null) || \
+    ref=$(command git describe --tags --exact-match HEAD 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi


### PR DESCRIPTION
Now the `git_prompt_info` will show the tag name instead of show the `sha1` commit.

before: `git:(35d6f37a3)`
now:`git:(v1.3.6)`