### PR TITLE
templates/zshrc.zsh-template: add default zstyle

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -9,6 +9,9 @@ export ZSH=$HOME/.oh-my-zsh
 # See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
 ZSH_THEME="robbyrussell"
 
+# Set zstyle
+zstyle ':completion:*' format 'Completing %d'
+
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 


### PR DESCRIPTION
The zstyle completion format is needed to correctly display
the _messages tag

Without zstyle ':completion:*' format 'Completing %d':

![out](https://cloud.githubusercontent.com/assets/5586796/21979094/be1c8c60-dbdd-11e6-85d6-150d5b9947cc.gif)

With zstyle ':completion:*' format 'Completing %d':
![out2](https://cloud.githubusercontent.com/assets/5586796/21979123/e45d6ef8-dbdd-11e6-90b9-aeb9f3403e2d.gif)


You can see the 
```
Completing head
Completing commit object name
```
messages.
