### PR TITLE
Fix check for VIRTUAL_ENV_DISABLE_PROMPT with the agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -193,7 +193,7 @@ prompt_dir() {
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
+  if [[ -n $virtualenv_path && -z $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
     prompt_segment blue black "(`basename $virtualenv_path`)"
   fi
 }


### PR DESCRIPTION
I had the problem using the agnoster theme and have Python virtualenv in place. I set the environment variable VIRTUAL_ENV_DISABLE_PROMPT and this should prevent the prompt to show the virtualenv Environment. The check was bad because with -n the variable is true if the variable is set. I fixed it to use -z and it works for me.