### PR TITLE
Update README.MD to fix invalid characters issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ git clone https://github.com/powerline/fonts
 cd fonts
 ./install.sh
 ```
-finally change your font preferences eg. iTerm2 -> Preferences -> Change Font -> 12pt Meslo LG S DZ Regular for Powerline
+finally change your font preferences eg. iTerm2 -> Preferences -> Profiles -> Text -> Change Font -> Family[12pt Meslo LG S DZ Regular for Powerline
 
 
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ If you have any hiccups installing, here are a few common fixes.
 * You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after switching to `oh-my-zsh`.
 * If you installed manually or changed the install location, check the `ZSH` environment variable in `~/.zshrc`.
 
+### Troubleshooting 
+
+If you are seeing invalid symbols like question mark after installation, you may want to update powerline fonts.
+
+```shell
+git clone https://github.com/powerline/fonts
+cd fonts
+./install.sh
+```
+finally change your font preferences eg. iTerm2 -> Preferences -> Change Font -> 12pt Meslo LG S DZ Regular for Powerline
+
+
+
 ### Custom Plugins and Themes
 
 If you want to override any of the default behaviors, just add a new file (ending in `.zsh`) in the `custom/` directory.


### PR DESCRIPTION
A few invalid symbols in 'agnoster.zsh-theme' :
https://github.com/robbyrussell/oh-my-zsh/issues/1906#issuecomment-275799694

this issue got introduced in 2013 and people are still confused and don't know right way to fix it.
It would be awesome if we can put this in README.md

Thanks & Regards,
Pradeep