### PR TITLE
Add old-omz-completion plugin

### DIFF
--- a/plugins/old-omz-completion/README.md
+++ b/plugins/old-omz-completion/README.md
@@ -1,0 +1,9 @@
+## Description
+
+This plugin restores the original oh-my-zsh completion.  Hyphen, underscore and dot are treated as wildcards.
+
+For example `cd /etc/i.d TAB` would expand to `/etc/init.d`.  The new completion (introduced last year) breaks this completion stlye.
+
+For more info see:
+
+https://github.com/robbyrussell/oh-my-zsh/issues/5560

--- a/plugins/old-omz-completion/old-omz-completion.plugin.zsh
+++ b/plugins/old-omz-completion/old-omz-completion.plugin.zsh
@@ -1,0 +1,1 @@
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'


### PR DESCRIPTION
Provides a simple way to use the old omz completion

https://github.com/robbyrussell/oh-my-zsh/issues/5560