### PR TITLE
Better app error handling in curl

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl -sL https://www.gitignore.io/api/${(j:,:)@} }
+function gi() { curl -fL https://www.gitignore.io/api/${(j:,:)@} }
 
 _gitignoreio_get_command_list() {
-  curl -sL https://www.gitignore.io/api/list | tr "," "\n"
+  curl -fL https://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignoreio () {


### PR DESCRIPTION
Deals with app error page, saving true error instead.

Upon app failure, Heroku returns HTML "Application Error" page.
Finding HTML page in .gitignore is confusing, so I replaced `-s` with `-f` in curl calls, which cuts such output (and errors with 22 instead, in Heroku case it also outputs the error message, so you know what happened if you scripted `gi` call or redirected it to a file).

Replace instead of addition as no progress meter outputs either.