### PR TITLE
AppUp plugin, vagrant and docker-compose commands

### DIFF
--- a/plugins/appup/README.md
+++ b/plugins/appup/README.md
@@ -1,0 +1,13 @@
+## AppUp
+
+**Maintainers:** [mdeboer](https://github.com/mdeboer)
+
+This plugins adds `start`, `stop`, `up` and `down` commands when it detects a docker-compose or Vagrant file in the current directory (e.g. your application). Just run `up` and get coding!
+
+### Docker
+
+Aside from simply running `up`, you can also extend your configuration by running `up <name>`, which will run `docker-compose` with both `docker-compose.yml` and extend it with `docker-compose.<name>.yml`. For more on extending please see the official docker documentation: https://docs.docker.com/compose/extends. Additional arguments will be directly supplied to the docker-compose.
+
+### Vagrant
+
+Vagrant doesn't have a `down`, `start` or `stop` commands natively but don't worry, that's been taken care of and running those commands will actually run vagrant's equivalent commands. Additional arguments will be directly supplied to vagrant.

--- a/plugins/appup/appup.plugin.zsh
+++ b/plugins/appup/appup.plugin.zsh
@@ -1,0 +1,70 @@
+# Docker
+_appup_docker () {
+    if type docker-compose >/dev/null 2>&1; then
+        # <cmd> <project name> will look for docker-compose.<project name>.yml
+        if [ -n "$2" -a -e "docker-compose.$2.yml" ]; then
+            project=$(source ".env.$2"; echo $COMPOSE_PROJECT_NAME)
+
+            if [ -n $project ]; then
+                docker-compose -p "${project}" -f docker-compose.yml -f "docker-compose.${2}.yml" $1 "${@:3}"
+                return
+            fi
+
+            docker-compose -f docker-compose.yml -f "docker-compose.${2}.yml" $1 "${@:3}"
+            return
+        fi
+
+        docker-compose $1 "${@:2}"
+    else
+        echo >&2 "Docker compose file found but docker-compose is not installed."
+    fi
+}
+
+# Vagrant
+_appup_vagrant () {
+    if type vagrant >/dev/null 2>&1; then
+        vagrant $1 "${@:2}"
+    else
+        echo >&2 "Vagrant file found but vagrant is not installed."
+    fi
+}
+
+up () {
+    if [ -e "docker-compose.yml" ]; then
+        _appup_docker up "$@"
+    elif [ -e "Vagrantfile" ]; then
+        _appup_vagrant up "$@"
+    elif hash up >/dev/null 2>&1; then
+        env up "$@"
+    fi
+}
+
+down () {
+    if [ -e "docker-compose.yml" ]; then
+        _appup_docker down "$@"
+    elif [ -e "Vagrantfile" ]; then
+        _appup_vagrant destroy "$@"
+    elif hash down >/dev/null 2>&1; then
+        env down "$@"
+    fi
+}
+
+start () {
+    if [ -e "docker-compose.yml" ]; then
+        _appup_docker start "$@"
+    elif [ -e "Vagrantfile" ]; then
+        _appup_vagrant resume "$@"
+    elif hash start >/dev/null 2>&1; then
+        env start "$@"
+    fi
+}
+
+stop () {
+    if [ -e "docker-compose.yml" ]; then
+        _appup_docker stop "$@"
+    elif [ -e "Vagrantfile" ]; then
+        _appup_vagrant suspend "$@"
+    elif hash stop >/dev/null 2>&1; then
+        env stop "$@"
+    fi
+}


### PR DESCRIPTION
This plugins adds `start`, `stop`, `up` and `down` commands when it detects a docker-compose or Vagrant file in the current directory (e.g. your application). Just run `up` and get coding!

### Docker

Aside from simply running `up`, you can also extend your configuration by running `up <name>`, which will run `docker-compose` with both `docker-compose.yml` and extend it with `docker-compose.<name>.yml`. For more on extending please see the official docker documentation: https://docs.docker.com/compose/extends. Additional arguments will be directly supplied to the docker-compose.

### Compatibility

It does not interfere with any other docker/vagrant plugins as far as I know. 