### PR TITLE
gcob alias (checkout new branch)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -76,6 +76,7 @@ alias gcm='git checkout master'
 alias gcd='git checkout develop'
 alias gcmsg='git commit -m'
 alias gco='git checkout'
+alias gcob='git checkout -b'
 alias gcount='git shortlog -sn'
 compdef _git gcount
 alias gcp='git cherry-pick'


### PR DESCRIPTION
I prefer to use gco -b to create a new branch and check it out in one fell swoop.  This alias would enable that with `gcob`.