### PR TITLE
Add a flag to prevent the "launch" of zsh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -110,7 +110,12 @@ main() {
   echo 'p.p.s. Get stickers and t-shirts at http://shop.planetargon.com.'
   echo ''
   printf "${NORMAL}"
-  env zsh
+
+  # Check if the user wants to switch into zsh right after the installation
+  # (! $1 = "--no-env-zsh")
+  if [ ! $1 = "--no-env-zsh" ]; then
+    env zsh
+  fi
 }
 
 main


### PR DESCRIPTION
For me personally, it is very annoying when I install a fresh copy
of linux and I run my script to install everything but it gets stuck
at the installation of oh-my-zsh because it waits for zsh to exit.
Because of that I added the flag "--no-env-zsh", and yes I know that
it's a dumb name, to prevent the installer from "starting" zsh if the
user specifies the "--no-env-zsh" flag.
I didn't find a PR like this or a way to prevent the installer from
launching zsh in the script. I also don't know if it's useful for anyone
except me.