### PR TITLE
Silent exit when virtualenvwrapper is not found

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -14,8 +14,6 @@ elif [[ -f "/etc/bash_completion.d/virtualenvwrapper" ]]; then
     source "/etc/bash_completion.d/virtualenvwrapper"
   }
 else
-  print "[oh-my-zsh] virtualenvwrapper plugin: Cannot find ${virtualenvwrapper}.\n"\
-        "Please install with \`pip install virtualenvwrapper\`" >&2
   return
 fi
 if ! type workon &>/dev/null; then


### PR DESCRIPTION
I think this is a better behavior to just exit because virtualenvwrapper is not installed. It's kind of annoying when some machine does not have virtualenvwrapper and the error message keeps popping up.