### PR TITLE
completion for maven wrapper

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -187,4 +187,4 @@ function listMavenCompletions {
     ); 
 }
 
-compctl -K listMavenCompletions mvn
+compctl -K listMavenCompletions mvn mvnw


### PR DESCRIPTION
[Maven wrapper](https://github.com/takari/maven-wrapper) fetches and runs the correct version of maven to build a java project. It is executed as mvnw in the project root. This pull request, allows the same completion as the mvn command.