### PR TITLE
Use proper config bin directory

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -49,4 +49,4 @@ alias cgr='composer global require'
 alias cget='curl -s https://getcomposer.org/installer | php'
 
 # Add Composer's global binaries to PATH
-export PATH=$PATH:~/.composer/vendor/bin
+export PATH=$PATH:$(composer global config bin-dir --absolute) 2>/dev/null


### PR DESCRIPTION
Add the proper config bin directory to `PATH` instead of the previously (incorrect) fixed `~/.composer/vendor/bin`. Nowadays the right config dir is `~/.config/composer/vendor/bin`.