### PR TITLE
fix(knife): make autocomplete for cookbooks to work

### DIFF
--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -219,7 +219,7 @@ _chef_cookbooks_local() {
     fi
     local cookbook_path=${KNIFE_COOKBOOK_PATH:-$(grep cookbook_path $knife_rb | awk 'BEGIN {FS = "[" }; {print $2}' | sed 's/\,//g' | sed "s/'//g" | sed 's/\(.*\)]/\1/' )}
   fi
-  (for i in $cookbook_path; do ls $i; done)
+  (for i in $(echo $cookbook_path); do ls $i; done)
 }
 
 # This function extracts the available cookbook versions on the chef server


### PR DESCRIPTION
I don't know if it come from my environment but without I have that :

```
 knife cookbook upload ls: cannot access '/Users/laurentcommarieu/src/iadvize/chef-repo/cookbooks /Users/laurentcommarieu/src/iadvize/chef-repo/site-cookbooks': No such file or directory
 --all
```

and with it works: 
```
-> knife cookbook upload
--all            build-essential  elasticsearch    limits           nginx            postfix          sudo             yum-epel
R                chef_handler     haproxy          logrotate        nodejs           redis            supervisor
README.md        composer         homebrew         logstash         npm              remote_syslog    timezone
apache2          debian-base      hostsfile        memcached        ohai             rsyslog          webserver
apt              docker           iis              mirror           openssl          runit            windows
ark              docker-install   iptables         munin-node       pacman           rvm              xml
bluepill         dotdeb           java             mysql            php              ssh-keys         yum
```