### PR TITLE
Add envy plugin for easy profile switching

### DIFF
--- a/plugins/envy/README.md
+++ b/plugins/envy/README.md
@@ -1,0 +1,22 @@
+# envy - oh-my-zsh plugin
+
+Easily switch between shell profiles using one command.
+
+Profiles are simple files just like .bashrc or .zshrc, located in separate directory. You can load them on demand, any time you want.
+
+[![asciicast](https://asciinema.org/a/brayiwehsfqt5gg5dzse28p38.png)](https://asciinema.org/a/brayiwehsfqt5gg5dzse28p38)
+
+## Usage
+
+Create first profile by executing `envy create work`. This will put empty file under `$HOME/.envy/work`. You can put there aliases, environment variables, functions or any shell logic.
+
+To load profile -- `envy work`.
+
+By default, when loading zsh envy loads `default` profile if it finds it.
+
+## Options
+
+You can customize envy by putting these env vars in .zshrc (or .bashrc):
+
+* `ENVY_CONFIG_DIR` - directory which contains profile files (default: $HOME/.envy)
+* `ENVY_DEFAULT_ENV` - profile to be loaded when zsh starts (default: default)

--- a/plugins/envy/envy.plugin.zsh
+++ b/plugins/envy/envy.plugin.zsh
@@ -6,29 +6,41 @@ function _envy_start() {
 }
 
 function _envy_load() {
-	local new_env_path="${ENVY_CONFIG_DIR}/${1}"
+	local new_profile_path="${ENVY_CONFIG_DIR}/${1}"
 
-	if [[ ! -f ${new_env_path} ]]; then
-		echo "Cannot find envy file '${new_env_path}'"
+	if [[ ! -f ${new_profile_path} ]]; then
+		echo "Cannot find envy file '${new_profile_path}'"
 		return 1
 	fi
 
-	source ${new_env_path}
+	source ${new_profile_path}
 }
 
 function _envy_create() {
-	local new_env_path="${ENVY_CONFIG_DIR}/${1}"
+	local new_profile_path="${ENVY_CONFIG_DIR}/${1}"
 
 	[[ -z "${1}" ]] && echo "No profile name argument" && return 1
 	[[ ! -d "${ENVY_CONFIG_DIR}" ]] && mkdir -p ${ENVY_CONFIG_DIR}
-	echo "#!/bin/bash" > ${new_env_path}
-	echo "Created empty profile: ${new_env_path}"
+	echo "#!/bin/bash" > ${new_profile_path}
+	echo "Created empty profile: ${new_profile_path}"
+}
+
+function _envy_edit() {
+	local profile_path="${ENVY_CONFIG_DIR}/${1}"
+
+	[[ -z "${1}" ]] && echo "No profile name argument" && return 1
+	[[ ! -f "${profile_path}" ]] && echo "Profile does not exists" && return 1
+	${EDITOR} ${profile_path}
 }
 
 function envy() {
 	case "${1}" in
 		create)
 			_envy_create ${2}
+			;;
+
+		edit)
+			_envy_edit ${2}
 			;;
 
 		*)

--- a/plugins/envy/envy.plugin.zsh
+++ b/plugins/envy/envy.plugin.zsh
@@ -1,0 +1,39 @@
+ENVY_CONFIG_DIR="${ENVY_CONFIG_DIR:-${HOME}/.envy}"
+ENVY_DEFAULT_ENV="${ENVY_DEFAULT_ENV:-default}"
+
+function _envy_start() {
+	_envy_load ${ENVY_DEFAULT_ENV} &>/dev/null || true
+}
+
+function _envy_load() {
+	local new_env_path="${ENVY_CONFIG_DIR}/${1}"
+
+	if [[ ! -f ${new_env_path} ]]; then
+		echo "Cannot find envy file '${new_env_path}'"
+		return 1
+	fi
+
+	source ${new_env_path}
+}
+
+function _envy_create() {
+	local new_env_path="${ENVY_CONFIG_DIR}/${1}"
+
+	[[ -z "${1}" ]] && echo "No profile name argument" && return 1
+	[[ ! -d "${ENVY_CONFIG_DIR}" ]] && mkdir -p ${ENVY_CONFIG_DIR}
+	echo "#!/bin/bash" > ${new_env_path}
+	echo "Created empty profile: ${new_env_path}"
+}
+
+function envy() {
+	case "${1}" in
+		create)
+			_envy_create ${2}
+			;;
+
+		*)
+			_envy_load ${1}
+	esac
+}
+
+_envy_start


### PR DESCRIPTION
# envy - oh-my-zsh plugin

Easily switch between shell profiles using one command.

Profiles are simple files just like .bashrc or .zshrc, located in separate directory. You can load them on demand, any time you want.

[![asciicast](https://asciinema.org/a/brayiwehsfqt5gg5dzse28p38.png)](https://asciinema.org/a/brayiwehsfqt5gg5dzse28p38)

## Usage

Create first profile by executing `envy create work`. This will put empty file under `$HOME/.envy/work`. You can put there aliases, environment variables, functions or any shell logic.

To load profile -- `envy work`.

By default, when loading zsh envy loads `default` profile if it finds it.

## Options

You can customize envy by putting these env vars in .zshrc (or .bashrc):

* `ENVY_CONFIG_DIR` - directory which contains profile files (default: $HOME/.envy)
* `ENVY_DEFAULT_ENV` - profile to be loaded when zsh starts (default: default)