### PR TITLE
Allow batch mode installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/mas
 sh -c "$(wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
 ```
 
+#### Batch mode
+
+When installing using both approaches above, `zsh` will be launched at the end of the installation.
+This can be problematic if installing Oh My Zsh from a script, since nothing will be run after Oh My Zsh
+is started.
+
+To fix this, simply append `--batch` to the end of the previous commands, as an additional argument to the script.
+This will perform all the installation steps as before, except launching `zsh` at the end.
+
+For instance, with `curl`:
+
+```shell
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --batch && echo "Install complete!"
+```
+
 ## Using Oh My Zsh
 
 ### Plugins

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,4 +1,4 @@
-main() {
+init() {
   # Use colors, but only if connected to a terminal, and that terminal
   # supports them.
   if which tput >/dev/null 2>&1; then
@@ -23,7 +23,27 @@ main() {
   # Only enable exit-on-error after the non-critical colorization stuff,
   # which may fail on systems lacking tput or terminfo
   set -e
+}
 
+check_optional_args() {
+  # Set default values
+  LAUNCH_ZSH_AFTER=1
+
+  # Evaluate arguments
+  for arg in $@; do
+    case "$arg" in
+      --batch)
+        LAUNCH_ZSH_AFTER=0
+        printf "${BLUE}--batch:${NORMAL} zsh will not be started after installation\n"
+        ;;
+      *)
+        printf "${YELLOW}Unrecognized argument: ${BLUE}${arg}${NORMAL}\n"
+        ;;
+    esac
+  done
+}
+
+main() {
   CHECK_ZSH_INSTALLED=$(grep /zsh$ /etc/shells | wc -l)
   if [ ! $CHECK_ZSH_INSTALLED -ge 1 ]; then
     printf "${YELLOW}Zsh is not installed!${NORMAL} Please install zsh first!\n"
@@ -110,7 +130,14 @@ main() {
   echo 'p.p.s. Get stickers and t-shirts at http://shop.planetargon.com.'
   echo ''
   printf "${NORMAL}"
-  env zsh
+
+  # Launch zsh, unless defined otherwise
+  if [ $LAUNCH_ZSH_AFTER -eq 1 ]; then
+    env zsh
+  fi
 }
 
+init
+check_optional_args $@
 main
+


### PR DESCRIPTION
Installing Oh My Zsh is currently not possible as part of a batch script (see #5873).

This pull request adds a `--batch` argument to allow installation without launching `zsh` at the end, allowing the installation script to be combined with other scripts.