### PR TITLE
fix alias conflict with command ag.

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -50,7 +50,7 @@ if [[ $use_sudo -eq 1 ]]; then
     alias adg='sudo $apt_pref update && sudo $apt_pref $apt_upgr'
     alias adu='sudo $apt_pref update && sudo $apt_pref dist-upgrade'
     alias afu='sudo apt-file update'
-    alias ag='sudo $apt_pref $apt_upgr'
+    alias au='sudo $apt_pref $apt_upgr'
     alias ai='sudo $apt_pref install'
     # Install all packages given on the command line while using only the first word of each line:
     # acs ... | ail


### PR DESCRIPTION
As we know ag is the most usefull command, it's faster than ack2 and grep.
So, I change the alias from ag to au, I think au is better for "sudo apt-get/aptitude  upgrade".
And let's use ag for the original command.