### PR TITLE
Adds ability to comma-delimit the ZSH_THEME variable

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -102,12 +102,19 @@ if [ "$ZSH_THEME" = "random" ]; then
   echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
 else
   if [ ! "$ZSH_THEME" = ""  ]; then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    # Split by commas and randomly select a theme
+    themes=("${(s/,/)ZSH_THEME}")
+    N=${#themes[@]}
+    ((N=(RANDOM%N)+1))
+    SELECTED_THEME=${themes[$N]}
+  
+    if [ -f "$ZSH_CUSTOM/$SELECTED_THEME.zsh-theme" ]; then
+      source "$ZSH_CUSTOM/$SELECTED_THEME.zsh-theme"
+    elif [ -f "$ZSH_CUSTOM/themes/$SELECTED_THEME.zsh-theme" ]; then
+      source "$ZSH_CUSTOM/themes/$SELECTED_THEME.zsh-theme"
+    else  
+      source "$ZSH/themes/$SELECTED_THEME.zsh-theme"
     fi
-  fi
+  fi                                                                                                                                                                                                             
 fi
+

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -115,6 +115,6 @@ else
     else  
       source "$ZSH/themes/$SELECTED_THEME.zsh-theme"
     fi
-  fi                                                                                                                                                                                                             
+  fi
 fi
 

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -6,6 +6,8 @@ export ZSH=$HOME/.oh-my-zsh
 
 # Set name of the theme to load. Optionally, if you set this to "random"
 # it'll load a random theme each time that oh-my-zsh is loaded.
+# You may provide multiple theme names delimited by commas "," and one 
+# will be randomly selected each time that oh-my-zsh is loaded.
 # See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
 ZSH_THEME="robbyrussell"
 


### PR DESCRIPTION
In reference to https://github.com/robbyrussell/oh-my-zsh/issues/5918

With:
`ZSH_THEME="muse,cloud,edvardm"`
![zsh-1](https://cloud.githubusercontent.com/assets/7936439/23383227/10bc23a6-fd0b-11e6-8fd4-d3f19f8cac5f.PNG)


With:
`ZSH_THEME="nicoulaj"`
![zsh-2](https://cloud.githubusercontent.com/assets/7936439/23383260/399604fe-fd0b-11e6-99ba-d0be0152abde.PNG)


(Tell me what to change this behavior to if this is undesirable)
With:
`ZSH_THEME="nicoulaj,"`
![zsh-3](https://cloud.githubusercontent.com/assets/7936439/23383322/7ed4d54a-fd0b-11e6-8733-0b28f5ddb154.PNG)




