### PR TITLE
Update shrink-path to use cd -q for bypassing the chpwd callbacks

### DIFF
--- a/plugins/shrink-path/shrink-path.plugin.zsh
+++ b/plugins/shrink-path/shrink-path.plugin.zsh
@@ -94,13 +94,12 @@ shrink_path () {
         (( tilde )) && dir=${dir/$HOME/\~}
         tree=(${(s:/:)dir})
         (
-                unfunction chpwd 2> /dev/null
                 if [[ $tree[1] == \~* ]] {
-                        cd ${~tree[1]}
+                        cd -q ${~tree[1]}
                         result=$tree[1]
                         shift tree
                 } else {
-                        cd /
+                        cd -q /
                 }
                 for dir in $tree; {
                         if (( lastfull && $#tree == 1 )) {
@@ -117,7 +116,7 @@ shrink_path () {
                                 (( short )) && break
                         done
                         result+="/$part"
-                        cd $dir
+                        cd -q $dir
                         shift tree
                 }
                 echo ${result:-/}


### PR DESCRIPTION
As shown in here: http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html

This is a more consistent way of bypassing the chpwd callbacks. I ran into this because shrink-path seems to cause the virtualenvwrapper plugin (if autocd is enabled) to deactivate and re-activate the virtualenv on each cd (even if you stay inside a project).