### PR TITLE
Fix Standard Error Redirection for composer plugin

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -52,4 +52,4 @@ alias cgrm='composer global remove'
 alias cget='curl -s https://getcomposer.org/installer | php'
 
 # Add Composer's global binaries to PATH
-export PATH=$PATH:$(composer global config bin-dir --absolute) 2>/dev/null
+export PATH=$PATH:$(composer global config bin-dir --absolute 2>/dev/null)


### PR DESCRIPTION
The standard error redirection was redirecting the output from export instead of the output from composer. This would print the message `Changed current directory to /home/username/.composer` for every new shell.
Moving the redirection inside the parentheses fixes this.