### PR TITLE
Thefuck: homebrew install documentation and thefuck repo link

### DIFF
--- a/plugins/thefuck/thefuck.plugin.zsh
+++ b/plugins/thefuck/thefuck.plugin.zsh
@@ -1,5 +1,5 @@
 if [[ -z $commands[thefuck] ]]; then
-    echo 'thefuck is not installed, you should "pip install thefuck" first'
+    echo 'thefuck is not installed, you should "pip install thefuck" or "brew install thefuck" first. See https://github.com/nvbn/thefuck#installation'
     return -1
 fi
 

--- a/plugins/thefuck/thefuck.plugin.zsh
+++ b/plugins/thefuck/thefuck.plugin.zsh
@@ -1,6 +1,7 @@
 if [[ -z $commands[thefuck] ]]; then
-    echo 'thefuck is not installed, you should "pip install thefuck" or "brew install thefuck" first. See https://github.com/nvbn/thefuck#installation'
-    return -1
+    echo 'thefuck is not installed, you should "pip install thefuck" or "brew install thefuck" first.'
+    echo 'See https://github.com/nvbn/thefuck#installation'
+    return 1
 fi
 
 # Register alias


### PR DESCRIPTION
The `thefuck` plugin currently directly users who don't have `thefuck` to install it with `pip`. This pr adds a note about installing via `homebrew`, the route `thefuck` recommends for macOS (which oob doesn't have `pip`)