### PR TITLE
Remove wrong whitespace in bira theme

### DIFF
--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -10,7 +10,7 @@ else
     local user_symbol='$'
 fi
 
-local current_dir='%{$terminfo[bold]$fg[blue]%} %~%{$reset_color%}'
+local current_dir='%{$terminfo[bold]$fg[blue]%}%~%{$reset_color%}'
 local rvm_ruby=''
 if which rvm-prompt &> /dev/null; then
   rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)›%{$reset_color%}'


### PR DESCRIPTION
The whitespace in line 13 creates a double whitespace when combined with line 24. Therefore 2 whitespaces appear between ${user_host} and ${current_dir}.