### PR TITLE
Add nohup plugin

### DIFF
--- a/plugins/nohup/README.md
+++ b/plugins/nohup/README.md
@@ -4,7 +4,7 @@ Add `nohup` to the current command pressing the `Ctrl + H` shortcut
 
 ### Usage
 
- * If the command line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out` (and vice-versa).
+ * If the command line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out &!` (and vice-versa).
 
  * If the command line is empty, the last command will be recalled.
 

--- a/plugins/nohup/README.md
+++ b/plugins/nohup/README.md
@@ -1,0 +1,10 @@
+## bbedit
+
+Plugin to prefix the current command with `nohup` using the `Ctrl+H` shortcut
+
+
+### Usage
+
+ * If them corrent termina line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out` and vice-versa
+
+ * If no command is existing, the last submitted command will be recalled

--- a/plugins/nohup/README.md
+++ b/plugins/nohup/README.md
@@ -1,10 +1,9 @@
-## bbedit
+## nohup
 
-Plugin to prefix the current command with `nohup` using the `Ctrl+H` shortcut
-
+Add `nohup` to the current command pressing the `Ctrl + H` shortcut
 
 ### Usage
 
- * If them corrent termina line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out` and vice-versa
+ * If the command line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out` (and vice-versa).
 
- * If no command is existing, the last submitted command will be recalled
+ * If the command line is empty, the last command will be recalled.

--- a/plugins/nohup/README.md
+++ b/plugins/nohup/README.md
@@ -7,3 +7,5 @@ Add `nohup` to the current command pressing the `Ctrl + H` shortcut
  * If the command line is `test 1 2 3` it will be transformed to `nohup test 1 2 3 &> test.out` (and vice-versa).
 
  * If the command line is empty, the last command will be recalled.
+
+PS. If you use `zsh-syntax-highlighting`, be sure that it is the last in the plugins list

--- a/plugins/nohup/nohup.plugin.zsh
+++ b/plugins/nohup/nohup.plugin.zsh
@@ -18,14 +18,12 @@ nohup-command-line() {
         BUFFER="${BUFFER#nohup }"
         BUFFER="${BUFFER%\ &\>*}"
     else
-		tokens_slash=("${(@s|/|)BUFFER}")
+		base="${BUFFER#sudo }"
+		tokens_slash=("${(@s|/|)base}")
 		tokens_space=("${(@s/ /)tokens_slash[-1]}")
-		i=1
-		if [[ $tokens_slash[1] == sudo ]]; then
-		    (( i++ ))
-		fi
+		command=("$tokens_space[1]")
 		
-		BUFFER="nohup $BUFFER &> $tokens_space[$i].out &"
+		BUFFER="nohup $BUFFER &> $command.out &"
     fi
 }
 zle -N nohup-command-line

--- a/plugins/nohup/nohup.plugin.zsh
+++ b/plugins/nohup/nohup.plugin.zsh
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+# nohup will be inserted before the command and a redirect will be appended
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+# * Michele Renda <michele.renda@gmail.com>
+#
+# ------------------------------------------------------------------------------
+
+nohup-command-line() {
+    [[ -z $BUFFER ]] && zle up-history
+    if [[ $BUFFER == nohup\ * ]]; then
+        LBUFFER="${LBUFFER#nohup }"
+        LBUFFER="${LBUFFER%\ &\>*}"
+    else
+		tokens=("${(@s/ /)LBUFFER}")
+		i=1
+		if [[ $tokens[1] == sudo ]]; then
+		    (( i++ ))
+		fi
+		
+		LBUFFER="nohup $LBUFFER &> $tokens[$i].out &"
+    fi
+}
+zle -N nohup-command-line
+# Defined shortcut keys: [Ctrl] [h]
+bindkey "\Ch" nohup-command-line

--- a/plugins/nohup/nohup.plugin.zsh
+++ b/plugins/nohup/nohup.plugin.zsh
@@ -15,16 +15,17 @@
 nohup-command-line() {
     [[ -z $BUFFER ]] && zle up-history
     if [[ $BUFFER == nohup\ * ]]; then
-        LBUFFER="${LBUFFER#nohup }"
-        LBUFFER="${LBUFFER%\ &\>*}"
+        BUFFER="${BUFFER#nohup }"
+        BUFFER="${BUFFER%\ &\>*}"
     else
-		tokens=("${(@s/ /)LBUFFER}")
+		tokens_slash=("${(@s|/|)BUFFER}")
+		tokens_space=("${(@s/ /)tokens_slash[-1]}")
 		i=1
-		if [[ $tokens[1] == sudo ]]; then
+		if [[ $tokens_slash[1] == sudo ]]; then
 		    (( i++ ))
 		fi
 		
-		LBUFFER="nohup $LBUFFER &> $tokens[$i].out &"
+		BUFFER="nohup $BUFFER &> $tokens_space[$i].out &"
     fi
 }
 zle -N nohup-command-line

--- a/plugins/nohup/nohup.plugin.zsh
+++ b/plugins/nohup/nohup.plugin.zsh
@@ -23,7 +23,7 @@ nohup-command-line() {
 		tokens_space=("${(@s/ /)tokens_slash[-1]}")
 		command=("$tokens_space[1]")
 		
-		BUFFER="nohup $BUFFER &> $command.out &"
+		BUFFER="nohup $BUFFER &> $command.out &!"
     fi
 }
 zle -N nohup-command-line


### PR DESCRIPTION
Adding a new pluging. When pressing Ctrl + H it will prefix the current command with nohup and will add &> `command_name`.out at the end (and vice versa).

It is very useful when launching a lot of background scripts