### PR TITLE
Fix handling spaces in $ZSH

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,7 +61,7 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git "$ZSH" || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }


### PR DESCRIPTION
the $ZSH variable has a problem with PATHs having spaces in them.

eg: automatic cloning to /home/Michael Wilcox/.oh-my-zsh
fails due to the variable being set to /home/Michael

This fixes the problem.
(Tested on [Cygwin](http://www.starlig.ht))