### PR TITLE
add subcommand deintegrate to pod's autocomplete plugin

### DIFF
--- a/plugins/pod/_pod
+++ b/plugins/pod/_pod
@@ -649,10 +649,25 @@ case "$words[2]" in
       ;;
     esac
   ;;
+  deintegrate)
+    case "$words[3]" in
+      *) # pod deintegrate
+        _options=(
+          "--help:Show help banner of specified command"
+          "--no-ansi:Show output without ANSI codes"
+          "--silent:Show nothing"
+          "--verbose:Show more debugging information"
+        )
+        _describe -t options "pod deintegrate options" _options
+      ;;
+    esac
+  ;;
+
   *) # pod
     _subcommands=(
       "help:Show help for the given command."
       "ipc:Inter-process communication"
+      "env:Display pod environment"
       "init:Generate a Podfile for the current directory."
       "install:Install project dependencies"
       "lib:Develop pods"
@@ -667,6 +682,7 @@ case "$words[2]" in
       "trunk:Interact with the CocoaPods API (e.g. publishing new specs)"
       "try:Try a Pod!"
       "update:Update outdated project dependencies"
+      "deintegrate:Deintegrate CocoaPods from your project( \$gem install cocoapods-deintegrate)"
     )
     _describe -t commands "pod subcommands" _subcommands
     _options=(


### PR DESCRIPTION
https://github.com/CocoaPods/cocoapods-deintegrate
cocoapods-deintegrate is a very useful plugin for cocoapods.

After install this plugin, there is a new subcommand added to pod command.