### PR TITLE
Use HTTPS for manual git clone to avoid  MITM

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export ZSH="$HOME/.dotfiles/oh-my-zsh"; sh -c "$(curl -fsSL https://raw.githubus
 ##### 1. Clone the repository:
 
 ```shell
-git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
+git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 ```
 
 ##### 2. *Optionally*, backup your existing `~/.zshrc` file:


### PR DESCRIPTION
The git:// transport is completely unauthenticated. An attacker on the local or upstream network can easily man-in-the-middle an oh-my-zsh update and get remote code execution on your system. Only the https:// git transport should be used.