### PR TITLE
add keybinds for vi-mode

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -27,6 +27,8 @@ bindkey '^N' down-history
 bindkey '^?' backward-delete-char
 bindkey '^h' backward-delete-char
 bindkey '^w' backward-kill-word
+bindkey '^k' kill-line
+bindkey '^y' yank
 
 # allow ctrl-r to perform backward search in history
 bindkey '^r' history-incremental-search-backward
@@ -34,6 +36,10 @@ bindkey '^r' history-incremental-search-backward
 # allow ctrl-a and ctrl-e to move to beginning/end of line
 bindkey '^a' beginning-of-line
 bindkey '^e' end-of-line
+
+# char movement
+bindkey '^b' backward-char
+bindkey '^f' forward-char
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then


### PR DESCRIPTION
to fix #5905 

Bind frequently used `ctrl-b`, `ctrl`f`, `ctrl-k`, `ctrl-y` when in insert mode in `vi` key binding