### PR TITLE
Add shoryuken as a bundled command

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -26,9 +26,9 @@ bundled_commands=(
   rainbows
   rake
   rspec
+  shoryuken
   shotgun
   sidekiq
-  shoryuken
   spec
   spork
   spring

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -28,6 +28,7 @@ bundled_commands=(
   rspec
   shotgun
   sidekiq
+  shoryuken
   spec
   spork
   spring


### PR DESCRIPTION
Given that `shoryuken` besides the start command, now support AWS SQS commands, such as `ls`, `purge`, `mv` etc, would be cool to have it a bundled command.