### PR TITLE
Clone repo silently

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,7 +61,7 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  env git clone --depth=1 --quiet https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }


### PR DESCRIPTION
Currently the git clone will write the following to stderr:

    Cloning into '/${HOME}/.oh-my-zsh'...

This silences that message.

References #3251