### PR TITLE
uses the ./jq parser to show node specific info

### DIFF
--- a/plugins/jq-node/README.md
+++ b/plugins/jq-node/README.md
@@ -1,0 +1,24 @@
+## uses ./jq to show node specific info
+
+# pre-requisite
+
+install ./jq 
+
+download
+> https://stedolan.github.io/jq/
+
+or
+
+> `brew install jq`
+
+# API 
+
+### Show node project version
+
+While inside the root of a node project (containing a package.json file) type:
+
+`> pv`
+
+Displays the project version
+
+`v8.0.1`

--- a/plugins/jq-node/package-version.plugin.zsh
+++ b/plugins/jq-node/package-version.plugin.zsh
@@ -1,0 +1,15 @@
+# package-version.plugin.zsh
+# Shows the version of the package.json file in current directory
+package_version() {
+    if [[ -f ./package.json ]]
+    then
+        echo "v$(jq -r .version package.json)"
+    else
+        echo "no package.json file found"
+    fi
+}
+
+# shorts
+pv() {
+    package_version
+}


### PR DESCRIPTION
Uses the ./jq parser to show node specific info

At the moment the only function written is the `pv|package_version` function that shows the current node projects package.json version.

While inside the root of a node project (containing a package.json file) type:

`> pv`

or 

`> package_version`

Displays the project version

`v8.0.1`