### PR TITLE
speed up chruby plugin by eliminating(as much as possible) calls to brew

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -1,9 +1,24 @@
 _homebrew-installed() {
   type brew &> /dev/null
+  _xit=$?
+  if [ $_xit -eq 0 ];then
+        # ok , we have brew installed
+        # speculatively we check default brew prefix
+        if [ -h  /usr/local/opt/awscli ];then
+                _brew_prefix="/usr/local/opt/awscli"
+        else
+                # ok , it is not default prefix
+                # this call to brew is expensive ( about 400 ms ), so at least let's make it only once
+                _brew_prefix=$(brew --prefix awscli)
+        fi
+        return 0
+   else
+        return $_xit
+   fi
 }
 
 _awscli-homebrew-installed() {
-  brew list awscli &> /dev/null
+  [ -r $_brew_prefix/libexec/bin/aws_zsh_completer.sh ] &> /dev/null
 }
 
 export AWS_HOME=~/.aws
@@ -28,7 +43,7 @@ function aws_profiles {
 compctl -K aws_profiles asp
 
 if _homebrew-installed && _awscli-homebrew-installed ; then
-  _aws_zsh_completer_path=$(brew --prefix awscli)/libexec/bin/aws_zsh_completer.sh
+  _aws_zsh_completer_path=$_brew_prefix/libexec/bin/aws_zsh_completer.sh
 else
   _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi

--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -16,12 +16,28 @@
 # rvm and rbenv plugins also provide this alias
 alias rubies='chruby'
 
+
 _homebrew-installed() {
     whence brew &> /dev/null
+    _xit=$?
+    if [ $_xit -eq 0 ];then
+    	# ok , we have brew installed
+	# speculatively we check default brew prefix
+        if [ -h  /usr/local/opt/chruby ];then
+		_brew_prefix="/usr/local/opt/chruby"
+	else
+		# ok , it is not default prefix 
+		# this call to brew is expensive ( about 400 ms ), so at least let's make it only once
+		_brew_prefix=$(brew --prefix chruby)
+	fi
+	return 0
+   else
+        return $_xit
+   fi
 }
 
 _chruby-from-homebrew-installed() {
-  [ -r $(brew --prefix chruby) ] &> /dev/null
+  [ -r _brew_prefix ] &> /dev/null
 }
 
 _ruby-build_installed() {
@@ -64,8 +80,8 @@ _chruby_dirs() {
 }
 
 if _homebrew-installed && _chruby-from-homebrew-installed ; then
-    source $(brew --prefix chruby)/share/chruby/chruby.sh
-    source $(brew --prefix chruby)/share/chruby/auto.sh
+    source $_brew_prefix/share/chruby/chruby.sh
+    source $_brew_prefix/share/chruby/auto.sh
     _chruby_dirs
 elif [[ -r "/usr/local/share/chruby/chruby.sh" ]] ; then
     source /usr/local/share/chruby/chruby.sh


### PR DESCRIPTION
We don't need to call 'brew --prefix' 3 times.
In worst case we need to call it once or in case of default brew installation - never.
Single call to brew is about 200-400 ms , so we save almost a second of shell startup time in worst case.
