### PR TITLE
Comment about export being optional in dotenv plugin is misleading.

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -14,7 +14,7 @@ plugins=(git man dotenv)
 
 ## Usage
 
-Create `.env` file inside your project directory and put your local ENV variables there.
+Create `.env` file inside your project directory and put your local ENV variables there. The contents of `.env` are run in the context of the current shell session. Do not forget to `export` the variables, otherwise they will only be available within the current shell session and not be part of ENV (unless they were already in ENV beforehand).
 
 For example:
 ```sh

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -23,12 +23,5 @@ export SECRET_KEY=7c6c72d959416d5aa368a409362ec6e2ac90d7f
 export MONGO_URI=mongodb://127.0.0.1:27017
 export PORT=3001
 ```
-`export` is optional. This format works as well:
-```sh
-AWS_S3_TOKEN=d84a83539134f28f412c652b09f9f98eff96c9a
-SECRET_KEY=7c6c72d959416d5aa368a409362ec6e2ac90d7f
-MONGO_URI=mongodb://127.0.0.1:27017
-PORT=3001
-```
 
 **It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it supposed to be local only.


### PR DESCRIPTION
@arteezy `dotenv` does not automatically set environment variables from the contents of `.env` but only sources it into the current shell sessio. Therefore it may very well be necessary to export variables explicitly in many cases, otherwise they will not actually be available in the environment of subsequently started programs. 

 Stating that `export` is optional may lead to confusion, for example this question on StackOverflow: https://stackoverflow.com/q/43878291/2992551