### PR TITLE
Add environment variable LANG=C to gitstatus

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -30,7 +30,7 @@ def get_tagname_or_hash():
 
 # `git status --porcelain --branch` can collect all information
 # branch, remote_branch, untracked, staged, changed, conflicts, ahead, behind
-po = Popen(['git', 'status', '--porcelain', '--branch'], stdout=PIPE, stderr=PIPE)
+po = Popen(['git', 'status', '--porcelain', '--branch'], env={"LANG": "C"}, stdout=PIPE, stderr=PIPE)
 stdout, sterr = po.communicate()
 if po.returncode != 0:
     sys.exit(0)  # Not a git repository


### PR DESCRIPTION
As described in #6086 there will be an error when one set another
language than default (Unix: LANG=C).

Now setting the default language to english by the environment variable
LANG.

Fixes #6086.