### PR TITLE
Fix dotenv plugin accepted file format and clarify README

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -2,19 +2,19 @@
 
 Automatically load your project ENV variables from `.env` file when you `cd` into project root directory.
 
-Storing configuration in the environment is one of the tenets of a [twelve-factor app](http://www.12factor.net). Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
+Storing configuration in the environment is one of the tenets of a [twelve-factor app](http://www.12factor.net). Anything that is likely to change between deployment environments, such as resource handles for databases or credentials for external services, should be extracted from the code into environment variables.
 
 ## Installation
 
 Just add the plugin to your `.zshrc`:
 
 ```sh
-plugins=(git man dotenv)
+plugins=(... dotenv)
 ```
 
 ## Usage
 
-Create `.env` file inside your project directory and put your local ENV variables there.
+Create `.env` file inside your project root directory and put your ENV variables there.
 
 For example:
 ```sh
@@ -30,5 +30,16 @@ SECRET_KEY=7c6c72d959416d5aa368a409362ec6e2ac90d7f
 MONGO_URI=mongodb://127.0.0.1:27017
 PORT=3001
 ```
+You can even mix both formats, although it's probably a bad idea.
 
-**It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it supposed to be local only.
+## Version Control
+
+**It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it's supposed to be local only.
+
+## Disclaimer
+
+This plugin only sources the `.env` file. Nothing less, nothing more. It doesn't do any checks. It's designed to be the fastest and simplest option. You're responsible for the `.env` file content. You can put some code (or weird symbols) there, but do it on your own risk. `dotenv` is the basic tool, yet it does the job.
+
+If you need more advanced and feature-rich ENV management, check out these awesome projects:
+* [direnv](https://github.com/direnv/direnv)
+* [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv)

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -2,7 +2,13 @@
 
 source_env() {
   if [[ -f .env ]]; then
-    source .env
+    if [[ -o a ]]; then
+      source .env
+    else
+      set -a
+      source .env
+      set +a
+    fi
   fi
 }
 


### PR DESCRIPTION
FIxes #6083, closes #6074, #6075

This PR fixes a bug reported in #6083, when in most cases `dotenv` plugin ignored lines without `export`. Now it recognises them by temporarily enabling `set -a` option. If this option was enabled before, it stays unmodified:

```sh
if [[ -o a ]]; then
  source .env
else
  set -a
  source .env
  set +a
fi
```
Now the plugin accepts both file formats as was stated.

Also, clarified the README and added disclaimer about plugin's capabilites, while offering alternative solutions, which should close #6074 and #6075 issues.