### PR TITLE
plugins: adds kops (kubernetes operations) plugin

### DIFF
--- a/plugins/kops/kops.plugin.zsh
+++ b/plugins/kops/kops.plugin.zsh
@@ -1,0 +1,9 @@
+# Autocompletion for kops (Kubernetes Operations),
+# the command line interface to get a production grade
+# Kubernetes cluster up and running
+
+# Author: https://github.com/nmrony
+
+if [ $commands[kops] ]; then
+  source <(kops completion zsh)
+fi


### PR DESCRIPTION
Hi @robbyrussell,
 This PR adds plugin for [Kops](https://github.com/kubernetes/kops "Kubernetes Operations") 