### PR TITLE
plugins: node modules path

### DIFF
--- a/plugins/node-modules-path/README.md
+++ b/plugins/node-modules-path/README.md
@@ -1,0 +1,42 @@
+# node-modules-path
+
+This plugin listens to pwd updates and searches for a node_modules directory in
+current directory and upwards. For the first node_modules folder found (the
+deepest one), we automatically add its .bin folder to PATH (node_modules/.bin).
+
+## motivation
+
+We try to keep project dependencies as isolated as possible and we avoid
+installing them globally to our machines. One such dependency is
+[Flow](https://flow.org/). Editors with Flow extensions search for the `flow`
+binary on path. Thus, before opening our editor, we must first remember to add
+the project's node_module/.bin folder to path.
+
+The reason we created this plugin was automate this step to safe little time
+when doing our development.
+
+## example
+
+	➜  ~ tree ~/project
+	/Users/hlysig/project
+	├── node_modules
+	│   └── flow
+		 ...
+	├── package.json
+	├── src
+	│   └── server
+	│       └── index.js
+	└── yarn.lock
+	
+	➜  ~ cd ~/project/src/server
+	Found node_modules in /Users/hlysig/project, adding to path
+	➜  server which flow
+	/Users/hlysig/project/node_modules/.bin/flow
+
+## requirements
+
+This plugin uses Python and works with Python 2.6 and upwards.
+
+## authors
+
+- Hlynur Sigurthorsson ([hlysig@gmail.com](mailto:hlysig@gmail.com))

--- a/plugins/node-modules-path/README.md
+++ b/plugins/node-modules-path/README.md
@@ -8,7 +8,7 @@ deepest one), we automatically add its .bin folder to PATH (node_modules/.bin).
 
 We try to keep project dependencies as isolated as possible and we avoid
 installing them globally to our machines. One such dependency is
-[Flow](https://flow.org/). Editors with Flow extensions search for the `flow`
+[Flow](https://flow.org/). Text editors with Flow extensions search for the `flow`
 binary on path. Thus, before opening our editor, we must first remember to add
 the project's node_module/.bin folder to path.
 

--- a/plugins/node-modules-path/node-modules-path.plugin.zsh
+++ b/plugins/node-modules-path/node-modules-path.plugin.zsh
@@ -1,0 +1,39 @@
+SCRIPT_PATH=${0:a:h}
+NODE_MODULES_PATH=""
+
+# Removes applied path from PATH.
+function remove_from_path {
+  PATH=${PATH/":$1"/}
+  PATH=${PATH/"$1:"/}
+}
+
+# Checks if given string is found in PATH.
+function is_on_path {
+  if [[ "$1" ]]; then
+    echo $PATH | grep "$1" >/dev/null
+  else
+    return 1
+  fi
+}
+
+chpwd_handler() {
+  nearest_found_nm=`/usr/bin/env python $SCRIPT_PATH/path_check.py $PWD`
+
+  if [[ "$nearest_found_nm" ]] && is_on_path "$nearest_found_nm/node_modules/.bin"; then
+    return
+  fi
+
+  if [[ "$NODE_MODULES_PATH" ]]; then
+    remove_from_path "$NODE_MODULES_PATH/node_modules/.bin"
+    export NODE_MODULES_PATH=""
+  fi
+
+  if [[ "$nearest_found_nm" ]]; then
+    echo "\033[1;34mFound node_modules in $nearest_found_nm, adding to path\033[0m"
+    PATH="$PATH:$nearest_found_nm/node_modules/.bin"
+    NODE_MODULES_PATH="$nearest_found_nm"
+  fi
+}
+
+chpwd_functions=(${chpwd_functions[@]} "chpwd_handler")
+chpwd_handler

--- a/plugins/node-modules-path/path_check.py
+++ b/plugins/node-modules-path/path_check.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+def get_subpaths(path):
+    paths = []
+    dirs = path.split('/')[1:]
+
+    for i in range(len(dirs), 0, -1):
+        p = os.path.join(*dirs[0:i])
+        yield p
+
+def has_modules_folder(path):
+    check_path = os.path.join('/', path, 'node_modules')
+    return os.path.exists(check_path) and os.path.isdir(check_path)
+
+def get_closes_path_dir(path):
+    for p in get_subpaths(path):
+        if has_modules_folder(p):
+            return '/' + p
+    return ''
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        sys.exit(1)
+    else:
+        path = sys.argv[1]
+        print get_closes_path_dir(path)
+        sys.exit(0)


### PR DESCRIPTION
Adding a plugin that I have been using locally for some time and wanted to share 
with you if you are interested.

This plugin listens to pwd updates and searches for a node_modules directory in
current directory and upwards. For the first node_modules folder found (the
deepest one), we automatically add its .bin folder to PATH (node_modules/.bin).

## motivation

We try to keep project dependencies as isolated as possible and we avoid
installing them globally to our machines. One such dependency is
[Flow](https://flow.org/). Text editors with Flow extensions search for the `flow`
binary on path. Thus, before opening our editor, we must first remember to add
the project's node_module/.bin folder to path.

The reason we created this plugin was automate this step to safe little time
when doing our development.

## example

	➜  ~ tree ~/project
	/Users/hlysig/project
	├── node_modules
	│   └── flow
		 ...
	├── package.json
	├── src
	│   └── server
	│       └── index.js
	└── yarn.lock

	➜  ~ cd ~/project/src/server
	Found node_modules in /Users/hlysig/project, adding to path
	➜  server which flow
	/Users/hlysig/project/node_modules/.bin/flow