### PR TITLE
bgnotify issue - it is no more automatically closing. Adding a timeout

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -36,7 +36,7 @@ bgnotify () { ## args: (title, subtitle)
     [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] && term_id='com.apple.terminal';
     ## now call terminal-notifier, (hopefully with $term_id!)
     [ -z "$term_id" ] && terminal-notifier -message "$2" -title "$1" >/dev/null ||
-    terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" >/dev/null
+    terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" -timeout 5 >/dev/null
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m "$1" "$2"
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!


### PR DESCRIPTION
On OSX when using terminal-notifier from julienXX the notification does not automatically close (from about 1.5month).
This fix the problem with a timeout option