### PR TITLE
Remove special handling of dirs for pyenv from homebrew

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,16 +1,5 @@
-_homebrew-installed() {
-    type brew &> /dev/null
-}
-
-_pyenv-from-homebrew-installed() {
-    brew --prefix pyenv &> /dev/null
-}
-
 FOUND_PYENV=0
 pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
-if _homebrew-installed && _pyenv-from-homebrew-installed ; then
-    pyenvdirs=($(brew --prefix pyenv) "${pyenvdirs[@]}")
-fi
 
 for pyenvdir in "${pyenvdirs[@]}" ; do
     if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then


### PR DESCRIPTION
Installing pyenv's Python versions under `brew --prefix pyenv` will make the user have to re-install all Python versions everytime pyenv is updated by brew. This is because `brew --prefix pyenv` by links to a Homebrew Cellar directory containing pyenv's version name.

See my installation as an example:
```
$ brew --prefix pyenv
/usr/local/opt/pyenv
$ ls -l $(brew --prefix pyenv) 
lrwxr-xr-x  1 me  admin  22 May 22 18:26 /usr/local/opt/pyenv -> ../Cellar/pyenv/1.0.10
```

Note that this change will stop `pyenv` from finding any current Python installations in the `brew --prefix pyenv` directory. Is this acceptable?