### PR TITLE
Fixed the gpg-agent plugin for new gpg versions

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,41 +1,14 @@
-local GPG_ENV=$HOME/.gnupg/gpg-agent.env
-
-function start_agent_nossh {
-    eval $(/usr/bin/env gpg-agent --quiet --daemon --write-env-file ${GPG_ENV} 2> /dev/null)
-    chmod 600 ${GPG_ENV}
-    export GPG_AGENT_INFO
-}
-
-function start_agent_withssh {
-    eval $(/usr/bin/env gpg-agent --quiet --daemon --enable-ssh-support --write-env-file ${GPG_ENV} 2> /dev/null)
-    chmod 600 ${GPG_ENV}
-    export GPG_AGENT_INFO
-    export SSH_AUTH_SOCK
-    export SSH_AGENT_PID
-}
-
-# check if another agent is running
-if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
-    # source settings of old agent, if applicable
-    if [ -f "${GPG_ENV}" ]; then
-        . ${GPG_ENV} > /dev/null
-        export GPG_AGENT_INFO
-        export SSH_AUTH_SOCK
-        export SSH_AGENT_PID
-    fi
-
-    # check again if another agent is running using the newly sourced settings
-    if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
-        # check for existing ssh-agent
-        if ssh-add -l > /dev/null 2> /dev/null; then
-            # ssh-agent running, start gpg-agent without ssh support
-            start_agent_nossh;
-        else
-            # otherwise start gpg-agent with ssh support
-            start_agent_withssh;
-        fi
-    fi
+# Enable gpg-agent if it is not running
+GPG_AGENT_SOCKET="${XDG_RUNTIME_DIR}/gnupg/S.gpg-agent.ssh"
+if [ ! -S $GPG_AGENT_SOCKET ]; then
+  gpg-agent --daemon >/dev/null 2>&1
+  export GPG_TTY=$(tty)
 fi
 
-GPG_TTY=$(tty)
-export GPG_TTY
+# Set SSH to use gpg-agent if it is configured to do so
+GNUPGCONFIG=${GNUPGHOME:-"$HOME/.gnupg/gpg-agent.conf"}
+if [ -r "$GNUPGCONFIG" ] && grep -q enable-ssh-support "$GNUPGCONFIG"; then
+  unset SSH_AGENT_PID
+  export SSH_AUTH_SOCK=$GPG_AGENT_SOCKET
+fi
+


### PR DESCRIPTION
The gpg-agent plugin did not work for gpg versions above or equal to
2.1 because of the `--write-env-file` option deprecation. This new version
works fine and also enables the ssh-agent support only if it is enabled in the
gpg-agent config file.