### PR TITLE
optimize load of pyenv with homebrew

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -8,9 +8,6 @@ _pyenv-from-homebrew-installed() {
 
 FOUND_PYENV=0
 pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
-if _homebrew-installed && _pyenv-from-homebrew-installed ; then
-    pyenvdirs=($(brew --prefix pyenv) "${pyenvdirs[@]}")
-fi
 
 for pyenvdir in "${pyenvdirs[@]}" ; do
     if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then
@@ -29,6 +26,24 @@ for pyenvdir in "${pyenvdirs[@]}" ; do
     fi
 done
 unset pyenvdir
+
+if [ $FOUND_PYENV -eq 0 ] ; then
+    pyenvdir=$(brew --prefix pyenv 2> /dev/null)
+    if [ $? -eq 0 -a -d $pyenvdir/bin ] ; then
+        FOUND_PYENV=1
+        export PYENV_ROOT=$pyenvdir
+        export PATH=${pyenvdir}/bin:$PATH
+        eval "$(pyenv init - zsh)"
+
+        if pyenv commands | command grep -q virtualenv-init; then
+            eval "$(pyenv virtualenv-init - zsh)"
+        fi
+
+        function pyenv_prompt_info() {
+            echo "$(pyenv version-name)"
+        }
+    fi
+fi
 
 if [ $FOUND_PYENV -eq 0 ] ; then
     function pyenv_prompt_info() { echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')" }


### PR DESCRIPTION
This pull request attempts to optimize the load of pyenv with homebrew installed. As `homebrew --prefix pyenv` is a quite slow command(approx. 0.3s on my laptop). It would be better use the command less. Thus I added it to the last, and append the default homebrew pyenv installation path. As well as I eliminated the triple check into one check for the sake of speed.

I've tested for several cases. Looking forward to your response.