### PR TITLE
Fix zshrc alias when $EDITOR uses parameters

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -13,7 +13,7 @@ alias lS='ls -1FSsh'
 alias lart='ls -1Fcart'
 alias lrt='ls -1Fcrt'
 
-alias zshrc='$EDITOR ~/.zshrc' # Quick access to the ~/.zshrc file
+alias zshrc='${=EDITOR} ~/.zshrc' # Quick access to the ~/.zshrc file
 
 alias grep='grep --color'
 alias sgrep='grep -R -n -H -C 5 --exclude-dir={.git,.svn,CVS} '


### PR DESCRIPTION
According to #5003

if one exports EDITOR with parameters, say:
`export EDITOR='subl -w'`
 
running command:
`zshrc`
 
will result in:
`zsh: command not found: subl -w`

This can be fixed by updating common-aliases.plugin.zsh line 16 with:
`alias zshrc='${=EDITOR} ~/.zshrc' # Quick access to the ~/.zshrc file`

Fixes #5003