### PR TITLE
[plugin] npx

### DIFF
--- a/plugins/npx/README.md
+++ b/plugins/npx/README.md
@@ -1,0 +1,17 @@
+# NPX Plugin
+> npx(1) -- execute npm package binaries. ([more info](https://github.com/zkat/npx))
+
+This plugin automatically registers npx command-not-found handler if `npx` exists in your `$PATH`.
+
+## Setup
+
+- Add plugin to `~/.zshrc`
+
+```bash
+plugins=(.... npx)
+```
+
+- Globally install npx binary (you need node.js installed too!)
+```bash
+sudo npm install -g npx
+```

--- a/plugins/npx/npx.plugin.zsh
+++ b/plugins/npx/npx.plugin.zsh
@@ -1,0 +1,7 @@
+# NPX Plugin
+# https://www.npmjs.com/package/npx
+# Maintainer: Pooya Parsa <pooya@pi0.ir>
+
+(( $+commands[npx] )) && {
+ source <(npx --shell-auto-fallback zsh)
+}


### PR DESCRIPTION
This plugin automatically registers npx command-not-found handler if `npx` exists in `$PATH`. npx is actively maintained by npm5 developer. [more info](https://github.com/zkat/npx)