### PR TITLE
Added autocompletion for kubernetes-helm

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -1,0 +1,3 @@
+if [ $commands[helm] ]; then
+  source <(helm completion zsh)
+fi


### PR DESCRIPTION
This plugin provides zsh autocompletion for kubernetes-helm.