### PR TITLE
pyenv plugin refactor (8x faster)

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,9 +1,9 @@
 # This plugin loads pyenv into the current shell and provides prompt info via
 # the 'pyenv_prompt_info' function. Also loads pyenv-virtualenv if available.
 
-if which pyenv > /dev/null; then
+if (( $+commands[pyenv] )); then
     eval "$(pyenv init - zsh)"
-    if which pyenv-virtualenv-init > /dev/null; then
+    if (( $+commands[pyenv-virtualenv-init] )); then
         eval "$(pyenv virtualenv-init - zsh)"
     fi
     function pyenv_prompt_info() {

--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,50 +1,17 @@
-_homebrew-installed() {
-    type brew &> /dev/null
-}
+# This plugin loads pyenv into the current shell and provides prompt info via
+# the 'pyenv_prompt_info' function. Also loads pyenv-virtualenv if available.
 
-_pyenv-from-homebrew-installed() {
-    brew --prefix pyenv &> /dev/null
-}
-
-FOUND_PYENV=0
-pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
-
-for pyenvdir in "${pyenvdirs[@]}" ; do
-    if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then
-        FOUND_PYENV=1
-        export PYENV_ROOT=$pyenvdir
-        export PATH=${pyenvdir}/bin:$PATH
-        eval "$(pyenv init - zsh)"
-
-        if pyenv commands | command grep -q virtualenv-init; then
-            eval "$(pyenv virtualenv-init - zsh)"
-        fi
-
-        function pyenv_prompt_info() {
-            echo "$(pyenv version-name)"
-        }
+if which pyenv > /dev/null; then
+    eval "$(pyenv init - zsh)"
+    if which pyenv-virtualenv-init > /dev/null; then
+        eval "$(pyenv virtualenv-init - zsh)"
     fi
-done
-unset pyenvdir
-
-if [ $FOUND_PYENV -eq 0 ] ; then
-    pyenvdir=$(brew --prefix pyenv 2> /dev/null)
-    if [ $? -eq 0 -a -d $pyenvdir/bin ] ; then
-        FOUND_PYENV=1
-        export PYENV_ROOT=$pyenvdir
-        export PATH=${pyenvdir}/bin:$PATH
-        eval "$(pyenv init - zsh)"
-
-        if pyenv commands | command grep -q virtualenv-init; then
-            eval "$(pyenv virtualenv-init - zsh)"
-        fi
-
-        function pyenv_prompt_info() {
-            echo "$(pyenv version-name)"
-        }
-    fi
-fi
-
-if [ $FOUND_PYENV -eq 0 ] ; then
-    function pyenv_prompt_info() { echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')" }
+    function pyenv_prompt_info() {
+        echo "$(pyenv version-name)"
+    }
+else
+    # fallback to system python
+    function pyenv_prompt_info() {
+        echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
+    }
 fi


### PR DESCRIPTION
The current version of the pyenv plugin searches for pyenv using a predefined list of paths. If found, the plugin adds the pyenv bin directory to the user's `PATH` variable, and finally runs pyenv to load it into the environment. This is backwards. No matter which pyenv installation method you use, the `pyenv` utility will already be in your path.

I've refactored the plugin to simply load pyenv directly. It will also load pyenv-virtualenv if it's available, as in the original version. If pyenv is not in the user's path, it gracefully falls back to displaying the system-installed python version in the prompt.

#### Speed Increase

After refactoring, I noticed this made the plugin much faster. Let's profile it (with python of course):

profiler command: `$ python -m timeit "__import__('subprocess').call(['zsh', '/Users/cyphus/.oh-my-zsh/plugins/pyenv/pyenv.plugin.zsh'])"`

<dl>
  <dt>Original:</dt>
  <dd>10 loops, best of 3: <b>822 msec</b> per loop</dd>

  <dt>Refactored:</dt>
  <dd>10 loops, best of 3: <b>103 msec</b> per loop.</dd>
</dl>

This PR makes the pyenv plugin load 8x faster, while fixing underlying issues. Winner winner 🍗 dinner.

#### Issues closed by this PR

* Close #6142 
* Close #5884 
* Close #6139 
* Close #6017 
* Close #4674 (Note: Possibly. This looks to be an issue of stemming from initializing two separate pyenv installations into the same shell. The first one is initialized based on the user's `PATH`, and the second is initialized based on the plugin's search order. This PR would change the pyenv plugin to also initialize based on the user's `PATH`, it would initialize the same pyenv. I can't say for sure without recreating the user's issue.)
