### PR TITLE
Create Fasd cache file in user home directory

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -1,5 +1,5 @@
 if [ $commands[fasd] ]; then # check if fasd is installed
-  fasd_cache="${ZSH_CACHE_DIR}/fasd-init-cache"
+  fasd_cache="~/.fasd-init-cache"
   if [ "$(command -v fasd)" -nt "$fasd_cache" -o ! -s "$fasd_cache" ]; then
     fasd --init auto >| "$fasd_cache"
   fi


### PR DESCRIPTION
If oh-my-zsh is installed globally, `$ZSH_CACHE_DIR`  may point to a directory which is not writable by the user or which is shared amog all the users. For example, in Arch Linux, it is pointing to `/usr/share/oh-my-zsh`.

This fix will create Fasd cache file as hidden in his home directory.