### PR TITLE
[systemd] Added commands for system control

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -44,6 +44,7 @@ alias app='apt-cache policy'
 if [[ $use_sudo -eq 1 ]]; then
 # commands using sudo #######
     alias aac='sudo $apt_pref autoclean'
+    alias aar='sudo apt-get --purge autoremove' #this command is only with apt-get
     alias abd='sudo $apt_pref build-dep'
     alias ac='sudo $apt_pref clean'
     alias ad='sudo $apt_pref update'
@@ -75,6 +76,7 @@ if [[ $use_sudo -eq 1 ]]; then
 # commands using su #########
 else
     alias aac='su -ls \'$apt_pref autoclean\' root'
+    alias aar='su -lc "apt-get --purge autoremove" root' #this command is only with apt-get
     abd() {
         cmd="su -lc '$apt_pref build-dep $@' root"
         print "$cmd"

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -1,6 +1,8 @@
 user_commands=(
   list-units is-active status show help list-unit-files
-  is-enabled list-jobs show-environment cat list-timers)
+  is-enabled list-jobs show-environment cat list-timers
+  is-system-running default rescue halt poweroff reboot
+  emergency kexec exit suspend hibernate hybrid-sleep)
 
 sudo_commands=(
   start stop reload restart try-restart isolate kill
@@ -14,3 +16,4 @@ for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
 alias sc-enable-now="sc-enable --now"
 alias sc-disable-now="sc-disable --now"
 alias sc-mask-now="sc-mask --now"
+


### PR DESCRIPTION
It would be very nice to have these systemctl command shortcuts, since they are now the desired way to manipulate the running state of the system. 

These commands are user verified by systemd itself, so we don't need to
`sudo` them.

@aelesbao, any comments on this?