### PR TITLE
Added plugged_in func for linux in battery plugin

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -70,6 +70,10 @@ elif [[ "$OSTYPE" = linux*  ]] ; then
     ! [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]]
   }
 
+  function plugged_in() {
+    ! [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]]
+  }
+
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
       echo "$(acpi 2>/dev/null | cut -f2 -d ',' | tr -cd '[:digit:]')"


### PR DESCRIPTION
Cloned battery_is_charging() func with the same name as the osx version in order to maintain compatibility across the systems in themes that make use of the plugin.