### PR TITLE
More Readable Colors for Prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -80,7 +80,7 @@ prompt_end() {
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)$USER@%m"
+    prompt_segment magenta default "%(!.%{%F{yellow}%}.)$USER@%m"
   fi
 }
 
@@ -187,7 +187,7 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue black '%~'
+  prompt_segment blue defatul '%~'
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
Hi, 

I think the prompt for Agnoster Theme is so dark. These colors work better with all the OS Branches (Linux, Mac OS and Windows 10 bash)