### PR TITLE
Git plugin: add aliases for '--(no-)skip-worktree' & showing hidden files

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -156,7 +156,7 @@ alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
 
 alias ghh='git help'
-alias ghidden='git ls-files -v . | grep ^S'
+alias ghidden='git ls-files -v . | grep ^S | awk '\''{ print $2 }'\'''
 alias ghide='git update-index --skip-worktree'
 
 alias gignore='git update-index --assume-unchanged'
@@ -234,6 +234,7 @@ alias gts='git tag -s'
 alias gtv='git tag | sort -V'
 
 alias gunhide='git update-index --no-skip-worktree'
+alias gunhidea='cd $(git rev-parse --show-toplevel || echo ".") && ghidden | xargs gunhide'
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 alias gup='git pull --rebase'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -234,7 +234,7 @@ alias gts='git tag -s'
 alias gtv='git tag | sort -V'
 
 alias gunhide='git update-index --no-skip-worktree'
-alias gunhidea='cd $(git rev-parse --show-toplevel || echo ".") && ghidden | xargs gunhide'
+alias gunhidea='cd $(git rev-parse --show-toplevel || echo ".") && ghidden | while read -r i; do gunhide "$i"; done'
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 alias gup='git pull --rebase'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -156,6 +156,8 @@ alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
 
 alias ghh='git help'
+alias ghidden='git ls-files -v . | grep ^S'
+alias ghide='git update-index --skip-worktree'
 
 alias gignore='git update-index --assume-unchanged'
 alias gignored='git ls-files -v | grep "^[[:lower:]]"'
@@ -231,6 +233,7 @@ alias gsu='git submodule update'
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'
 
+alias gunhide='git update-index --no-skip-worktree'
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 alias gup='git pull --rebase'


### PR DESCRIPTION
This adds some aliases for "hiding" files from git (in such a way that they won't be overwritten when you pull remote changes - subtly different to `assume-unchanged`):

* `ghide path/to/file` will hide the file from `git status`, `git add`, etc.
* `gunhide path/to/file` restores the file visibility.
* `gunhidea` restores the file visibility for all hidden files.
* `ghidden` lists all files hidden in this manner.

@ncanceill