### PR TITLE
Change tmux new-session -s alias

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -4,7 +4,7 @@
 
 alias ta='tmux attach -t'
 alias tad='tmux attach -d -t'
-alias ts='tmux new-session -s'
+alias tn='tmux new-session -s'
 alias tl='tmux list-sessions'
 alias tksv='tmux kill-server'
 alias tkss='tmux kill-session -t'


### PR DESCRIPTION
Change tmux new session alias from `ts` to `tn`.
Since the equivalent shortcut is `:new` it makes more sense to use `tn` instead of `ts`.