### PR TITLE
Make prompt end in '$' and newline for clarity

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -225,4 +225,4 @@ build_prompt() {
   prompt_end
 }
 
-PROMPT='%{%f%b%k%}$(build_prompt) '
+PROMPT='%{%f%b%k%}$(build_prompt) '$'\n$ '


### PR DESCRIPTION
When nested deep in long directories or branches, the prompt is at the end of the terminal, so it's better on a newline by default and always in the same place.