### PR TITLE
Adding whatthecommit to lol plugin

### DIFF
--- a/plugins/lol/lol.plugin.zsh
+++ b/plugins/lol/lol.plugin.zsh
@@ -45,6 +45,7 @@ alias bringz='git pull'
 alias chicken='git add'
 alias oanward='git commit -m'
 alias ooanward='git commit -am'
+alias yolo='git commit -m "$(curl -s whatthecommit.com/index.txt)"'
 alias letcat='git checkout'
 alias violenz='git rebase'
 


### PR DESCRIPTION
```
$ curl -s whatthecommit.com/index.txt
So my boss wanted this button ...

$ curl -s whatthecommit.com/index.txt
A long time ago, in a galaxy far far away...

$ curl -s whatthecommit.com/index.txt
Switched off unit test 15 because the build had to go out now and there was no time to fix it properly.
```