### PR TITLE
Fix Spotify share url copying

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -533,7 +533,7 @@ function spotify() {
       url=${url#$remove}
       url="http://open.spotify.com/track/$url"
       cecho "Share URL: $url";
-      cecho -n "$url" | pbcopy
+      echo -n "$url" | pbcopy
       break;;
 
       -h|--help| *)


### PR DESCRIPTION
Piping cecho output to pbcopy caused the plugin to copy "[1m[32m-n(B[m" to the clipboard, not the url.

Changing to use 'echo' fixes that.