### PR TITLE
Parse branch-name for fresh repo

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -41,7 +41,7 @@ ahead, behind = 0, 0
 status = [(line[0], line[1], line[2:]) for line in stdout.decode('utf-8').splitlines()]
 for st in status:
     if st[0] == '#' and st[1] == '#':
-        if re.search('Initial commit on', st[2]):
+        if re.search('Initial commit on', st[2]) or re.search('No commits yet on', st[2]):
             branch = st[2].split(' ')[-1]
         elif re.search('no branch', st[2]):  # detached status
             branch = get_tagname_or_hash()


### PR DESCRIPTION
Inside a fresh git repo, i.e. immediately after a `git init`, usually no
commit template exists yet. In this case, git renders a different
status message than "Initial commit on". We should consider this message
when attempting to parse out the branch name.

Fixes #6301