### PR TITLE
Set RBENV_ROOT to "$HOME/.rbenv" if not already set

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -7,6 +7,9 @@ rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv"
 if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null); then
     rbenvdirs=($rbenv_homebrew_path "${rbenvdirs[@]}")
     unset rbenv_homebrew_path
+    if [[ $RBENV_ROOT = '' ]]; then 
+      RBENV_ROOT="$HOME/.rbenv"
+    fi
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
This is the default behavior of rbenv and what users are expecting
most of the time.

It allows users to have their own set of rubies and gems. It also
prevents losing all rubies when rbenv is updated using Homebrew which
is not true when RBENV_ROOT is set to /usr/local/opt/rbenv.