### PR TITLE
git plugin: print uniformly https and ssh repositories.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -18,7 +18,7 @@ function current_repository() {
   if ! $_omz_git_git_cmd rev-parse --is-inside-work-tree &> /dev/null; then
     return
   fi
-  echo $($_omz_git_git_cmd remote -v | cut -d':' -f 2)
+  echo $($_omz_git_git_cmd remote -v | awk 'BEGIN { FS = "github.com[\:\/]" } { print $NF }')
 }
 # Pretty log messages
 function _git_log_prettily(){


### PR DESCRIPTION
Before this change, this repository info:

```
$ git remote -v
origin  git@github.com:iglesias/oh-my-zsh.git (fetch)
origin  git@github.com:iglesias/oh-my-zsh.git (push)
upstream        https://github.com/robbyrussell/oh-my-zsh.git (fetch)
upstream        https://github.com/robbyrussell/oh-my-zsh.git (push)
```

would be shown as

```
$ current_repository 
iglesias/oh-my-zsh.git (fetch) iglesias/oh-my-zsh.git (push) //github.com/robbyrussell/oh-my-zsh.git (fetch) //github.com/robbyrussell/oh-my-zsh.git (push)
```

This change makes it look like

```
$ current_repository
iglesias/oh-my-zsh.git (fetch) iglesias/oh-my-zsh.git (push) robbyrussell/oh-my-zsh.git (fetch) robbyrussell/oh-my-zsh.git (push)
```