### PR TITLE
Origin agnostic

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,7 +61,14 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 $(git remote get-url origin) $ZSH || {
+  
+  branch="$(env git symbolic-ref --short HEAD)"
+  if [[ "$?" != "0" ]] || [[ "$branch" == "" ]]; then
+    printf "Error: failed to get current git branch\n"
+    exit 1
+  fi
+  
+  env git clone --depth=1 $(git remote get-url origin) -b "$branch" $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,11 +61,14 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  env git clone --depth=1 $(git remote get-url origin) $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }
-
+  (cd $ZSH && env git submodule init && env git submodule update) || {
+    printf "Error: failed to init and update submodules\n"
+    exit 1
+  }
 
   printf "${BLUE}Looking for an existing zsh config...${NORMAL}\n"
   if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -68,7 +68,7 @@ main() {
     exit 1
   fi
   
-  env git clone --depth=1 $(git remote get-url origin) -b "$branch" $ZSH || {
+  env git clone --depth=1 $(git config --get remote.origin.url) -b "$branch" $ZSH || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }


### PR DESCRIPTION
This PR makes the `tools/install.sh` script work for forks. Instead of using a hardcoded url for the origin it uses `git remote get-url` to figure out the remote url. It also checks which branch we're on and installs the same branch instead of master.

Also added support for submodules since they can be nice to have when installing custom themes in a fork.