### PR TITLE
add hanami to the list of wrapped gems

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -14,6 +14,7 @@ bundled_commands=(
   cucumber
   foodcritic
   guard
+  hanami
   irb
   jekyll
   kitchen


### PR DESCRIPTION
This PR adds `hanami` to the list of gems wrapped by the `bundler` plugin. [Hanami](http://hanamirb.org/) is a Ruby web framework.