### PR TITLE
[dotenv] Add a message informing users about parsing errors

### DIFF
--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -2,7 +2,11 @@
 
 source_env() {
   if [[ -f .env ]]; then
-    source .env
+	if errs=$(bash -n .env 2>&1); 
+		then source .env; 
+	else 
+		printf '%s\n' "Found some errors while parsing your .env file: " "$errs"; 
+	fi
   fi
 }
 


### PR DESCRIPTION
I couldn't tell why I got this error `.env: line 129: syntax error near unexpected token ('` after adding a bunch of plugins.
I didn't knew what most of the plugins do, nor what the `dotenv` plugin is doing behind the scene!
After figuring out the problem, I though it would be much better displaying an error message only in case there are some parsing errors. Now I would get this:

```
Found some errors while parsing your .env file:
.env: line 129: syntax error near unexpected token `('
```