### PR TITLE
Fix default location of the virtualenvwrapper script

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -6,6 +6,13 @@ if (( $+commands[$virtualenvwrapper] )); then
     unsetopt equals
     source ${${virtualenvwrapper}:c}
   }
+elif [[ -f "/usr/local/bin/virtualenvwrapper.sh" ]]; then
+  function {
+    setopt local_options
+    unsetopt equals
+    virtualenvwrapper="/usr/local/bin/virtualenvwrapper.sh"
+    source "/usr/local/bin/virtualenvwrapper.sh"
+  }
 elif [[ -f "/etc/bash_completion.d/virtualenvwrapper" ]]; then
   function {
     setopt local_options


### PR DESCRIPTION
The `virtualenvwrapper` script has been relocated to
`/usr/local/bin/virtualenvwrapper.sh`. Update the
plugin to look in the new location first. See:

http://virtualenvwrapper.readthedocs.io/en/latest/#introduction

to confirm the change in location for this script.

This addresses issue #3047 where the solution was to source this file
from your zshrc.