### PR TITLE
Update to mix plugin to support Phoenix v1.3.0+ tasks

### DIFF
--- a/plugins/mix/_mix
+++ b/plugins/mix/_mix
@@ -36,6 +36,8 @@ _1st_arguments=(
     'loadconfig:Loads and persists the given configuration'
     'local:List local tasks'
     'local.hex:Install hex locally'
+    'local.phoenix:Updates Phoenix locally'
+    'local.phx:Updates the Phoenix project generator locally'
     'local.rebar:Install rebar locally'
     'new:Create a new Elixir project'
     'phoenix.digest:Digests and compress static files'
@@ -44,9 +46,24 @@ _1st_arguments=(
     'phoenix.gen.json:Generates a controller and model for a JSON based resource'
     'phoenix.gen.model:Generates an Ecto model'
     'phoenix.gen.secret:Generates a secret'
-    'phoenix.new:Create a new Phoenix application'
+    'phoenix.new:Creates a new Phoenix v1.2.1 application'
     'phoenix.routes:Prints all routes'
     'phoenix.server:Starts applications and their servers'
+    'phx.digest:Digests and compresses static files'
+    'phx.digest.clean:Removes old versions of static assets.'
+    'phx.gen.channel:Generates a Phoenix channel'
+    'phx.gen.context:Generates a context with functions around an Ecto schema'
+    'phx.gen.embedded:Generates an embedded Ecto schema file'
+    'phx.gen.html:Generates controller, views, and context for an HTML resource'
+    'phx.gen.json:Generates controller, views, and context for a JSON resource'
+    'phx.gen.presence:Generates a Presence tracker'
+    'phx.gen.schema:Generates an Ecto schema and migration file'
+    'phx.gen.secret:Generates a secret'
+    'phx.new:Creates a new Phoenix v1.3.0 application'
+    'phx.new.ecto:Creates a new Ecto project within an umbrella project'
+    'phx.new.web:Creates a new Phoenix web project within an umbrella project'
+    'phx.routes:Prints all routes'
+    'phx.server:Starts applications and their servers'
     'run:Run the given file or expression'
     "test:Run a project's tests"
     '--help:Describe available tasks'
@@ -58,7 +75,7 @@ __task_list ()
     local expl
     declare -a tasks
 
-    tasks=(app.start archive archive.build archive.install archive.uninstall clean cmd compile compile.protocols deps deps.clean deps.compile deps.get deps.unlock deps.update do escript.build help hex hex.config hex.docs hex.info hex.key hex.outdated hex.owner hex.publish hex.search hex.user loadconfig local local.hex local.rebar new phoenix.digest phoenix.gen.channel phoenix.gen.html phoenix.gen.json phoenix.gen.model phoenix.gen.secret phoenix.new phoenix.routes phoenix.server run test)
+    tasks=(app.start archive archive.build archive.install archive.uninstall clean cmd compile compile.protocols deps deps.clean deps.compile deps.get deps.unlock deps.update do escript.build help hex hex.config hex.docs hex.info hex.key hex.outdated hex.owner hex.publish hex.search hex.user loadconfig local local.hex local.rebar new phoenix.digest phoenix.gen.channel phoenix.gen.html phoenix.gen.json phoenix.gen.model phoenix.gen.secret phoenix.new phoenix.routes phoenix.server phx.digest phx.digest.clean phx.gen.channel phx.gen.context phx.gen.embedded phx.gen.html phx.gen.json phx.gen.presence phx.gen.schema phx.gen.secret phx.new phx.new.ecto phx.new.web phx.routes phx.server run test)
 
     _wanted tasks expl 'help' compadd $tasks
 }


### PR DESCRIPTION
The mix tasks have changed for the Phoenix framework as of version 1.3.0. I added the new relevant tasks while leaving the existing <1.3.0 version tasks. 