### PR TITLE
Make steeef theme much faster by not iterating through all history

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -62,7 +62,7 @@ zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
 
 
 function steeef_preexec {
-    case "$(whence -c $(fc -l $HISTCMD $HISTCMD))" in
+    case "$2" in
         *git*)
             PR_GIT_UPDATE=1
             ;;

--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -62,7 +62,7 @@ zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
 
 
 function steeef_preexec {
-    case "$(history $HISTCMD)" in
+    case "$(whence $(fc -l $HISTCMD $HISTCMD))" in
         *git*)
             PR_GIT_UPDATE=1
             ;;

--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -62,7 +62,7 @@ zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
 
 
 function steeef_preexec {
-    case "$(whence $(fc -l $HISTCMD $HISTCMD))" in
+    case "$(whence -c $(fc -l $HISTCMD $HISTCMD))" in
         *git*)
             PR_GIT_UPDATE=1
             ;;


### PR DESCRIPTION
Currently, in each preexec hook, the steeef theme runs `history $HISTCMD` which has the effect of iterating through your entire history and runs `git ls-files` **every time** you run any command. For people with lots of history, this takes a really long time and makes the terminal feel much more sluggish. If I read the intention of this correctly, it seems like the steeef theme only intended to read the last command.

This change fixes that (and uses `fc` directly instead of `history` which is an alias for `fc -l`). It also uses `whence` to expand any aliases so that if you type `gst`, for example, it'll expands to, say, `git status` and the `PR_GIT_UPDATE` environment variable will be properly set.

One notable issue is that this may feel like it breaks a piece of `steeef`'s functionality to some. Per intention, `steeef` was only supposed to update the prompt for untracked files if a `git` or `svn` command was issued. However, because of the broken functionality, if you ever had a `git` command in your history, it would check every time and always update the prompt. So, while it might be much faster and technically accurate according to what seems to be the original intention, some users may be confused about the new behavior.

@steeef thoughts?