### PR TITLE
Renamed ggsup to gbsup

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -152,7 +152,7 @@ compdef _git ggpull=git-checkout
 alias ggpush='git push origin $(git_current_branch)'
 compdef _git ggpush=git-checkout
 
-alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
+alias gbsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
 
 alias ghh='git help'


### PR DESCRIPTION
Since GPSUP acronym stands for "Git Push Set UpStream", I guess alias name for "Git Branch Set UpStream" should be named GBSUP, not GGSUP.