### PR TITLE
make git config oh-my-zsh.hide-status work with the agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -87,7 +87,7 @@ prompt_context() {
 # Git: branch/detached head, dirty status
 prompt_git() {
   (( $+commands[git] )) || return
-  if [[ "$(git config --get oh-my-zsh.hide-status)" == "1" ]]; then
+  if [[ "$(git config --get oh-my-zsh.hide-status 2>/dev/null)" = 1 ]]; then
     return
   fi
   local PL_BRANCH_CHAR

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -87,6 +87,9 @@ prompt_context() {
 # Git: branch/detached head, dirty status
 prompt_git() {
   (( $+commands[git] )) || return
+  if [[ "$(git config --get oh-my-zsh.hide-status)" == "1" ]]; then
+    return
+  fi
   local PL_BRANCH_CHAR
   () {
     local LC_ALL="" LC_CTYPE="en_US.UTF-8"


### PR DESCRIPTION
Hide the git prompt when the oh-my-zsh.hide-status git config option is set.