### PR TITLE
Add shortcut for opening current branch in Jira

### DIFF
--- a/plugins/jira/_jira
+++ b/plugins/jira/_jira
@@ -7,6 +7,7 @@ _1st_arguments=(
   'dashboard:open the dashboard'
   'reported:search for issues reported by a user'
   'assigned:search for issues assigned to a user'
+  'br:open the issue named after the git branch of the current directory'
   'dumpconfig:display effective jira configuration'
 )
 

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -51,8 +51,14 @@ function jira() {
     echo "JIRA_DEFAULT_ACTION=$JIRA_DEFAULT_ACTION"
   else
     # Anything that doesn't match a special action is considered an issue name
-    local issue_arg=$action
-    local issue="${jira_prefix}${issue_arg}"
+    # but `branch` is a special case that will parse the current git branch
+    if [[ "$action" == "br" ]]; then
+      local issue_arg=$(git rev-parse --abbrev-ref HEAD)
+      local issue="${jira_prefix}${issue_arg}"
+    else
+      local issue_arg=$action
+      local issue="${jira_prefix}${issue_arg}"
+    fi
     local url_fragment=''
     if [[ "$2" == "m" ]]; then
       url_fragment="#add-comment"


### PR DESCRIPTION
@tresni I'd like to add a `br` shortcut/command to the jira plugin that will allow you to open the Jira ticket named after the git branch of the current directory. This works well for projects that name branches after ticket numbers and saves the user from having to type out the whole ticket reference.  
I doubt it would clash with any existing workflows in use because it is such a short command and it doesn't fit the regex for Jira tickets.  
Let me know what you think - I was already using an alias setup to achieve this but thought it might be useful to others.