### PR TITLE
add -backend-config flag to terraform init command

### DIFF
--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -62,6 +62,7 @@ __init() {
         '-address=[(url) URL of the remote storage server. Required for HTTP backend, optional for Atlas and Consul.]' \
         '-access-token=[(token) Authentication token for state storage server. Required for Atlas backend, optional for Consul.]' \
         '-backend=[(atlas) Specifies the type of remote backend. Must be one of Atlas, Consul, or HTTP. Defaults to atlas.]' \
+        '-backend-config=[(path) Specifies the path to remote backend config file.]' \
         '-name=[(name) Name of the state file in the state storage server. Required for Atlas backend.]' \
         '-path=[(path) Path of the remote state in Consul. Required for the Consul backend.]'
 }


### PR DESCRIPTION
-backend-config flag was introduced in terraform 0.9.1 version