### PR TITLE
Enhanced Laravel 5 Plugin

### DIFF
--- a/plugins/laravel5/laravel5.plugin.zsh
+++ b/plugins/laravel5/laravel5.plugin.zsh
@@ -1,6 +1,6 @@
 # Laravel5 basic command completion
 _laravel5_get_command_list () {
-	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^ +[a-z]+/ { print $1 }'
+	php artisan --raw --no-ansi list | sed "s/[[:space:]].*//g"
 }
 
 _laravel5 () {


### PR DESCRIPTION
This simple enhancement adds the colon if tab is pressed.

Previously, you could type `php artisan m` and hit tab. This resulted in `php artisan make`. To get to the end of the command, it was required to type ":mo" to get to `php artisan make:model`

The change in this PR automatically adds the colon and typing `php artisan ma` results in `php artisan make:`.  While looking like a very small change, it results in much faster autocompletition because you have to type 2 keys less (shift+:).