### PR TITLE
Change `agud` alias from `dist-upgrade` to `full-upgrade`

### DIFF
--- a/plugins/ubuntu/readme.md
+++ b/plugins/ubuntu/readme.md
@@ -16,6 +16,6 @@ afs = Apt-File Search --regexp - this has the regexp switch on without being rep
 
 Then there are the 2 other 4 letter aliases for combined commands, that are straight forward and easy to remember.  
 aguu = sudo Apt-Get Update && sudo apt-get Upgrade      - better then adg or not?  
-agud = sudo Apt-Get Update && sudo apt-get Dist-upgrade
+agud = sudo Apt-Get Update && sudo apt-get full-upgrade
 
 For a full list aliases and the functions just watch the plugins code https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/ubuntu/ubuntu.plugin.zsh, look at the comments if you want to switch from the debian plugin. Ubuntu, Mint and & co users will like the new aar function to install packages from ppas with a single command.

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -2,6 +2,7 @@
 # https://github.com/AlexBio
 # https://github.com/dbb
 # https://github.com/Mappleconfusers
+# https://github.com/trinaldi
 # Nicolas Jonas nextgenthemes.com
 # https://github.com/loctauxphilippe
 #
@@ -36,7 +37,7 @@ alias agi='sudo apt-get install'  # ai
 alias agp='sudo apt-get purge'    # ap
 alias agr='sudo apt-get remove'   # ar
 alias agu='sudo apt-get update'   # ad
-alias agud='sudo apt-get update && sudo apt-get dist-upgrade' #adu
+alias agud='sudo apt-get update && sudo apt-get full-upgrade' #adu
 alias agug='sudo apt-get upgrade' # ag
 alias aguu='sudo apt-get update && sudo apt-get upgrade'      #adg
 alias agar='sudo apt-get autoremove'
@@ -50,7 +51,7 @@ compdef _agi agi='sudo apt-get install'
 compdef _agp agp='sudo apt-get purge'
 compdef _agr agr='sudo apt-get remove'
 compdef _agu agu='sudo apt-get update'
-compdef _agud agud='sudo apt-get update && sudo apt-get dist-upgrade'
+compdef _agud agud='sudo apt-get update && sudo apt-get full-upgrade'
 compdef _agug agug='sudo apt-get upgrade'
 compdef _aguu aguu='sudo apt-get update && sudo apt-get upgrade'
 compdef _agar agar='sudo apt-get autoremove'


### PR DESCRIPTION
While both commands have the same functionality, `full-upgrade` is now the standard.