### PR TITLE
Fix wrong $GNUPGHOME usage in gpg-agent plugin

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -6,7 +6,7 @@ if [ ! -S $GPG_AGENT_SOCKET ]; then
 fi
 
 # Set SSH to use gpg-agent if it is configured to do so
-GNUPGCONFIG=${GNUPGHOME:-"$HOME/.gnupg/gpg-agent.conf"}
+GNUPGCONFIG="${GNUPGHOME:-"$HOME/.gnupg"}/gpg-agent.conf"
 if [ -r "$GNUPGCONFIG" ] && grep -q enable-ssh-support "$GNUPGCONFIG"; then
   unset SSH_AGENT_PID
   export SSH_AUTH_SOCK=$GPG_AGENT_SOCKET


### PR DESCRIPTION
$GNUPGHOME variable was used incorrectly and caused a grep error when
set. See #6140 for more details.