### PR TITLE
zsh fix for parse_git_dirty: declare local array FLAGS as such

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -11,7 +11,7 @@ function git_prompt_info() {
 # Checks if working tree is dirty
 function parse_git_dirty() {
   local STATUS=''
-  local FLAGS
+  local -a FLAGS
   FLAGS=('--porcelain')
   if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then


### PR DESCRIPTION
With zsh 5.4 a simple "local FLAGS" meant as an array must be explicitly declared so.
This fix avoids the dreaded "parse_git_dirty:3: FLAGS: attempt to assign array value to non-array".