### PR TITLE
Fix the terraform function name

### DIFF
--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -17,5 +17,5 @@ your .zsh-theme file and in a choosen place insert:
 
 ```
 $FG[045]\
-$(terraform_prompt_info)\
+$(tf_prompt_info)\
 ```

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -1,4 +1,4 @@
-function terraform_prompt_info() {
+function tf_prompt_info() {
     # check if in terraform dir
     if [ -d .terraform ]; then
       workspace=$(terraform workspace show 2> /dev/null) || return


### PR DESCRIPTION
Current function name do worse. I always use `terr<TAB>` and before those prompt it was add space in the end. Now because we have multiple functions and binaries started with terraform there are no space.