### PR TITLE
Improve formatting of Terraform plugin output

### DIFF
--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -1,7 +1,10 @@
 function tf_prompt_info() {
+    RESET="%{${reset_color}%}"
+
     # check if in terraform dir
     if [ -d .terraform ]; then
       workspace=$(terraform workspace show 2> /dev/null) || return
-      echo "[${workspace}]"
+      TF_INFO="$RESET%{$fg_bold[blue]%}tf:(%{$fg_bold[magenta]%}$workspace%{$fg_bold[blue]%})$RESET "
+      echo "$TF_INFO"
     fi
 }


### PR DESCRIPTION
Improves the formatting of the Terraform plugin's `tf_prompt_info()`
function (see #6373 and #6418). It:
- adds a `tf:` prefix to indicate that what follows is the Terraform
  workspace
- adds colorization and formatting to make the appearance more similar
  to the `git-prompt` plugin
- adds a trailing space to separate the prompt from user input