### PR TITLE
Fix gpg-agent plugin for environments not using XDG_RUNTIME_DIR

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,5 +1,7 @@
+#Define GPG_AGENT_SOCKET
+GPG_AGENT_SOCKET=`gpgconf --list-dirs agent-ssh-socket`
+
 # Enable gpg-agent if it is not running
-GPG_AGENT_SOCKET="${XDG_RUNTIME_DIR}/gnupg/S.gpg-agent.ssh"
 if [ ! -S $GPG_AGENT_SOCKET ]; then
   gpg-agent --daemon >/dev/null 2>&1
   export GPG_TTY=$(tty)


### PR DESCRIPTION
In #6140 there were quit big changes in gpg-agent plugin and environments not using XDG_RUNTIME_DIR (like ZSH on OS X) stopped to work.

Here is short fix which adds backward compatibility for socket in users home dir.