### PR TITLE
Add autocomplete plugin for minikube

### DIFF
--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -1,0 +1,6 @@
+# Autocompletion for Minikube.
+#
+
+if [ $commands[minikube] ]; then
+  source <(minikube completion zsh)
+fi


### PR DESCRIPTION
[Minikube](https://github.com/kubernetes/minikube) can generate zsh completion code since [version v0.24.0](https://github.com/kubernetes/minikube/blob/master/CHANGELOG.md#version-0240---11292017).

This PR allows to enable this easily with oh-my-zsh.
  