### PR TITLE
Added ranger-cd plugin

### DIFF
--- a/plugins/ranger-cd/README.md
+++ b/plugins/ranger-cd/README.md
@@ -1,0 +1,9 @@
+## ranger-cd
+
+Compatible with ranger 1.4.2 through 1.7.\*
+
+After ranger quits, automatically change the current directory of zsh to the
+last visited directory in ranger.
+
+Code comes from a [ranger plugin](https://github.com/ranger/ranger/blob/master/examples/bash_automatic_cd.sh)
+for bash, but I find it more convenient to have it as an [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/) plugin.

--- a/plugins/ranger-cd/ranger-cd.plugin.zsh
+++ b/plugins/ranger-cd/ranger-cd.plugin.zsh
@@ -1,0 +1,13 @@
+# functions
+function ranger-cd {
+  tempfile="$(mktemp -t tmp.XXXXXX)"
+  /usr/bin/ranger --choosedir="$tempfile" "${@:-$(pwd)}"
+  test -f "$tempfile" &&
+    if [ "$(cat -- "$tempfile")" != "$(echo -n `pwd`)" ]; then
+        cd -- "$(cat "$tempfile")"
+    fi
+  rm -f -- "$tempfile"
+}
+
+# aliases
+alias ranger=ranger-cd


### PR DESCRIPTION
@robbyrussell I have a suggestion.

#### ranger-cd
I propose a tiny zsh plugin for the `ranger` file browser: When ranger quits, the terminal's working directory is the same from which ranger was started before in the first place. This plugin changes the terminal's working directory to the last selected directory in ranger, after quitting ranger.  
