### PR TITLE
Add twoLine theme

### DIFF
--- a/themes/twoLine.zsh-theme
+++ b/themes/twoLine.zsh-theme
@@ -1,0 +1,30 @@
+# A multiline prompt with time, path limited to 30 chars, return status, git branch, git dirty status, git remote status, git prompt status
+
+local return_status="%{$fg[red]%}%(?..⏎)%{$reset_color%}"
+
+local host_color="green"
+if [ -n "$SSH_CLIENT" ]; then
+  local host_color="red"
+fi
+
+PROMPT='
+%{$fg_bold[grey]%}┌─[%T]%{$reset_color%} %{$fg_bold[blue]%}%30<...<%~%<<%{$reset_color%} $(git_prompt_info) $(git_remote_status) $(git_prompt_status)
+%{$fg_bold[grey]%}└─➤%{$reset_color%}%{$fg_bold[white]%} '
+
+
+RPROMPT='${return_status}%{$reset_color%}'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[green]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg_bold[yellow]%} ☞%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_GIT_PROMPT_BEHIND_REMOTE="%{$fg_bold[magenta]%}↓%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE="%{$fg_bold[magenta]%}↑%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE="%{$fg_bold[magenta]%}↕%{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_ADDED="%{$fg_bold[green]%} +"
+ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg[yellow]%} ±"
+ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%} ✗"
+ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[blue]%} ➦"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[magenta]%} ✂"
+ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[white]%} ✱"


### PR DESCRIPTION
<img width="223" alt="screen shot 2017-11-23 at 13 47 51" src="https://user-images.githubusercontent.com/5623982/33175849-ec2b0a3e-d054-11e7-9daa-36fd3181d1a8.png">

Add's a theme which sets the prompt over two lines as shown in the attached image. It also has several symbols used to indicate git status.