### PR TITLE
fix bug-6404

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -4,9 +4,15 @@ function zle-keymap-select() {
   zle -R
 }
 
+# Ensures that MODE_INDITCATOR is displayed on terminal start up.
+function zle-line-init() {
+  zle reset-prompt
+}
+
 # Ensure that the prompt is redrawn when the terminal size changes.
 TRAPWINCH() {
   zle &&  zle -R
+  zle reset-prompt
 }
 
 zle -N zle-keymap-select


### PR DESCRIPTION
This pr fixes two things:
* [bug-6404](https://github.com/robbyrussell/oh-my-zsh/issues/6404): Indicator is shown after window resize. In case the window is maximized, the indicator is shown but an error message is displayed: `widgets can only be called when ZLE is active`. Haven't found out yet how to get rid of it, but it works.
* Makes sure `MODE_INDICATOR` is drawn when the terminal is started. This is not the case with the actual plugin.
