### PR TITLE
Fix yarn alias that conflicts with yeoman cli

### DIFF
--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -4,7 +4,7 @@ alias y="yarn "
 alias ya="yarn add"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
-alias yo="yarn outdated"
+alias yout="yarn outdated" # yo would conflict with yeoman which is quite popular in yarn community
 alias yui="yarn upgrade-interactive"
 
 _yarn ()

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -4,7 +4,7 @@ alias y="yarn "
 alias ya="yarn add"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
-alias yout="yarn outdated" # yo would conflict with yeoman which is quite popular in yarn community
+alias yout="yarn outdated"
 alias yui="yarn upgrade-interactive"
 
 _yarn ()


### PR DESCRIPTION
Yeoman cli alias is 'yo' so 'yarn outdated' can't be aliased to 'yo'.
See: http://yeoman.io/

Fixes #6435
Fixes #6502
Closes #6778
Closes #6635