### PR TITLE
Remove afind which adds noticable time to startup

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -26,13 +26,6 @@ env_default LESS '-R'
 alias _='sudo'
 alias please='sudo'
 
-## more intelligent acking for ubuntu users
-if which ack-grep &> /dev/null; then
-  alias afind='ack-grep -il'
-else
-  alias afind='ack -il'
-fi
-
 # only define LC_CTYPE if undefined
 if [[ -z "$LC_CTYPE" && -z "$LC_ALL" ]]; then
 	export LC_CTYPE=${LANG%%:*} # pick the first entry from LANG


### PR DESCRIPTION
I'm on a little hunt to optimize my personal zsh setup and I noticed that this afind alias adds a decent amount of time to startup.

First run: 0.23 seconds
Second run: 0.10 seconds