### PR TITLE
Fix gpg-agent plugin checks

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,16 +1,17 @@
 # Enable gpg-agent if it is not running-
 # --use-standard-socket will work from version 2 upwards
-# If already running then new agent won't be started.
 
-gpg-agent --daemon --use-standard-socket >/dev/null 2>&1
+AGENT_SOCK=`gpgconf --list-dirs | grep agent-socket | cut -d : -f 2`
+
+if [ ! -S ${AGENT_SOCK} ]; then
+  gpg-agent --daemon --use-standard-socket >/dev/null 2>&1
+fi
 export GPG_TTY=$(tty)
 
-# Set SSH to use gpg-agent if it is configured to do so
-GNUPGCONFIG="${GNUPGHOME:-"$HOME/.gnupg"}/gpg-agent.conf"
-if [ -r "$GNUPGCONFIG" ] && grep -q enable-ssh-support "$GNUPGCONFIG"; then
-  if [ "${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
-    export SSH_AUTH_SOCK="$(gpgconf --list-dirs agent-ssh-socket)"
-    unset SSH_AGENT_PID
-  fi
+# Set SSH to use gpg-agent if it's enabled
+GPG_SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
+if [ -S ${GPG_SSH_AUTH_SOCK} ]; then
+  export SSH_AUTH_SOCK=$GPG_SSH_AUTH_SOCK
+  unset SSH_AGENT_PID
 fi
 

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,14 +1,16 @@
-# Enable gpg-agent if it is not running
-GPG_AGENT_SOCKET="${XDG_RUNTIME_DIR}/gnupg/S.gpg-agent.ssh"
-if [ ! -S $GPG_AGENT_SOCKET ]; then
-  gpg-agent --daemon >/dev/null 2>&1
-  export GPG_TTY=$(tty)
-fi
+# Enable gpg-agent if it is not running-
+# --use-standard-socket will work from version 2 upwards
+# If already running then new agent won't be started.
+
+gpg-agent --daemon --use-standard-socket >/dev/null 2>&1
+export GPG_TTY=$(tty)
 
 # Set SSH to use gpg-agent if it is configured to do so
 GNUPGCONFIG="${GNUPGHOME:-"$HOME/.gnupg"}/gpg-agent.conf"
 if [ -r "$GNUPGCONFIG" ] && grep -q enable-ssh-support "$GNUPGCONFIG"; then
-  unset SSH_AGENT_PID
-  export SSH_AUTH_SOCK=$GPG_AGENT_SOCKET
+  if [ "${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
+    export SSH_AUTH_SOCK="$(gpgconf --list-dirs agent-ssh-socket)"
+    unset SSH_AGENT_PID
+  fi
 fi
 

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -9,9 +9,8 @@ fi
 export GPG_TTY=$(tty)
 
 # Set SSH to use gpg-agent if it's enabled
-GPG_SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
-if [ -S ${GPG_SSH_AUTH_SOCK} ]; then
-  export SSH_AUTH_SOCK=$GPG_SSH_AUTH_SOCK
+if [ -S "${AGENT_SOCK}.ssh" ]; then
+  export SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
   unset SSH_AGENT_PID
 fi
 


### PR DESCRIPTION
I discovered a few problems with the gpg-agent plugin changes on some machines. 

1. ${XDG_RUNTIME_DIR}  isn't always set
2. Older versions of gpg-agent do not use the "default location", therefore multiple agents are opened.

Therefore my solution is to use the gpgconf file to get the default location of the socket. We use this as the test to see if we need to start the agent.

Adding -use-standard-socket to starting the daemon means that older versions of gpg-agent behave in the same was as newer versions. 

I applied the same idea for the ssh agent. We can check if we have an ssh socket, if so then we set the SSH_AUTH_SOCKET - The reason for this is that newer versions of gpg-agent default to enabling ssh-agent therefore checking for the config variable wasn't reliable.

Hope this all makes sense.

Cheers
Chris