### PR TITLE
Fix rvm-prompt usage in fino* themes

### DIFF
--- a/themes/fino-time.zsh-theme
+++ b/themes/fino-time.zsh-theme
@@ -25,12 +25,16 @@ function box_name {
 }
 
 
-local rvm_ruby='‹$(rvm-prompt i v g)›%{$reset_color%}'
+rvm_ruby=''
+if type rvm-prompt &>/dev/null; then
+    rvm_ruby='using%{$FG[243]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
+fi
+
 local current_dir='${PWD/#$HOME/~}'
 local git_info='$(git_prompt_info)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%} ${rvm_ruby} %D - %*
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}${rvm_ruby} %D - %*
 ╰─$(virtualenv_info)$(prompt_char) "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -22,10 +22,10 @@ function box_name {
 
 local ruby_env=''
 if which rvm-prompt &> /dev/null; then
-  ruby_env=' ‹$(rvm-prompt i v g)›%{$reset_color%}'
+  ruby_env='using%{$FG[243]%} ‹$(rvm-prompt i v g)›%{$reset_color%}'
 else
   if which rbenv &> /dev/null; then
-    ruby_env=' ‹$(rbenv version-name)›%{$reset_color%}'
+    ruby_env='using%{$FG[243]%} ‹$(rbenv version-name)›%{$reset_color%}'
   fi
 fi
 
@@ -34,7 +34,7 @@ local git_info='$(git_prompt_info)'
 local prompt_char='$(prompt_char)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%}${ruby_env}
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}${ruby_env}
 ╰─${prompt_char}%{$reset_color%} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"


### PR DESCRIPTION
- Check if `rmv-prompt` is installed before trying to use it 