### PR TITLE
Add support for ForkLift 3

### DIFF
--- a/plugins/forklift/forklift.plugin.zsh
+++ b/plugins/forklift/forklift.plugin.zsh
@@ -1,6 +1,6 @@
 # Open folder in ForkLift.app or ForkLift2.app from console
 # Author: Adam Strzelecki nanoant.com, modified by Bodo Tasche bitboxer.de
-#         Updated to support ForkLift2 by Johan Kaving
+#         Updated to support ForkLift 2 and ForkLift 3 by Johan Kaving
 #
 # Usage:
 #   fl [<folder>]
@@ -24,46 +24,84 @@ function fl {
   fi
   osascript 2>&1 1>/dev/null <<END
 
-    try
-      tell application "Finder"
-        set appName to name of application file id "com.binarynights.ForkLift2"
-      end tell
-    on error err_msg number err_num
-      tell application "Finder"
-        set appName to name of application file id "com.binarynights.ForkLift"
-      end tell
-    end try
+  try
+    tell application "Finder"
+        set forkLift3 to name of application file id "com.binarynights.ForkLift-3"
+    end tell
+  on error err_msg number err_num
+    set forkLift3 to null
+  end try
+  try
+    tell application "Finder"
+        set forkLift2 to name of application file id "com.binarynights.ForkLift2"
+    end tell
+  on error err_msg number err_num
+    set forkLift2 to null
+  end try
+  try
+    tell application "Finder"
+        set forkLift to name of application file id "com.binarynights.ForkLift"
+    end tell
+  on error err_msg number err_num
+    set forkLift to null
+  end try
 
-    if application appName is running
-      tell application appName
+  if forkLift3 is not null and application forkLift3 is running then
+    tell application forkLift3
         activate
-      end tell
-    else
-      tell application appName
+        set forkLiftVersion to version
+    end tell
+  else if forkLift2 is not null and application forkLift2 is running then
+    tell application forkLift2
         activate
-      end tell
-      repeat until application appName is running
-        delay 1
-      end repeat
-      tell application appName
+        set forkLiftVersion to version
+    end tell
+  else if forkLift is not null and application forkLift is running then
+    tell application forkLift
         activate
-      end tell
+        set forkLiftVersion to version
+    end tell
+  else
+    if forkLift3 is not null then
+        set appName to forkLift3
+    else if forkLift2 is not null then
+        set appName to forkLift2
+    else if forkLift is not null then
+        set appName to forkLift
     end if
+    
+    tell application appName
+        activate
+        set forkLiftVersion to version
+    end tell
+    repeat until application appName is running
+        delay 1
+    end repeat
+    tell application appName
+        activate
+    end tell
+  end if
 
-    tell application "System Events"
-      tell application process "ForkLift"
+  tell application "System Events"
+    tell application process "ForkLift"
         try
-          set topWindow to window 1
+            set topWindow to window 1
         on error
-          keystroke "n" using command down
-          set topWindow to window 1
+            keystroke "n" using command down
+            set topWindow to window 1
         end try
         keystroke "g" using {command down, shift down}
-        tell sheet 1 of topWindow
-          set value of text field 1 to "$PWD"
-          keystroke return
-        end tell
-      end tell
+        if forkLiftVersion starts with "3" then
+            tell pop over of list of group of splitter group of splitter group of topWindow
+                set value of text field 1 to "$PWD"
+            end tell
+        else
+            tell sheet 1 of topWindow
+                set value of text field 1 to "$PWD"
+            end tell
+        end if
+        keystroke return
     end tell
+  end tell
 END
 }


### PR DESCRIPTION
This adds support for ForkLift 3, which uses a different
application id and also uses a popover instead of a sheet for
entering the directory to go to.

This also improves the handling of different versions of ForkLift,
by first choosing any currently running instance, and if none is
running starting the newest available version.

Fixes #6565.