### PR TITLE
Add yarn alias

### DIFF
--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -2,6 +2,7 @@
 
 alias y="yarn "
 alias ya="yarn add"
+alias yad="yarn add --dev"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
 alias yo="yarn outdated"


### PR DESCRIPTION
The command `yarn add --dev` is used frequently. Add this alias will make it convenient.