### PR TITLE
Add kubernetes context manager

### DIFF
--- a/plugins/kube/README.md
+++ b/plugins/kube/README.md
@@ -1,0 +1,14 @@
+# Kubectl context manager
+Kubectl, the kubernetes client, needs context to work correctly. By default, it uses the file on `~/.kube/config`, which has an horrible design. With this plugin, the better approach is to not have a `~/.kube/config` file and `n` `~/.kube/something-config`. If you do so, you'll be able to manage multiple contexts easily.
+
+This plugin is based on the [aws](https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins#aws) one. The functions that provides are `ksp` and `kgp`. The first one let's you choose between the contexts and the second one shows which one is being used.
+
+See the `~/.kube` directory:
+
+```bash
+tree ~/.kube
+
+/home/whatever/.kube
+├── firstContext-config
+└── secondContext-config
+```

--- a/plugins/kube/kube.plugin.zsh
+++ b/plugins/kube/kube.plugin.zsh
@@ -1,0 +1,23 @@
+export KUBE_HOME=~/.kube
+
+function kgp {
+  echo $KUBECONFIG
+}
+
+function ksp {
+  local rprompt=${RPROMPT/<aws:$(kgp)>/}
+
+  export KUBE_PROFILE=$1
+  export KUBECONFIG=$KUBE_HOME/$1-config
+
+  export RPROMPT="<kube:$KUBE_PROFILE>$rprompt"
+}
+
+function kube_profiles {
+  reply=($(ls $KUBE_HOME/*-config |
+	       awk -F'/' '{print $5}' |
+	       sed "s/-config$/ /g" |
+	       tr -d '\n'))
+}
+
+compctl -K kube_profiles ksp

--- a/plugins/kube/kube.plugin.zsh
+++ b/plugins/kube/kube.plugin.zsh
@@ -5,7 +5,7 @@ function kgp {
 }
 
 function ksp {
-  local rprompt=${RPROMPT/<aws:$(kgp)>/}
+  local rprompt=${RPROMPT/<k8s:$(kgp)>/}
 
   export KUBE_PROFILE=$1
   export KUBECONFIG=$KUBE_HOME/$1-config


### PR DESCRIPTION
I couldn't find a convention to edit the wiki file, and I understand that this plugin should be added there. I may do it if you point me on the right direction.

What do you think, this plugin should be different than the [kubectl](https://github.com/drym3r/oh-my-zsh/tree/master/plugins/kubectl) one? I have no problem on add the one I made to that one.

PD: Thanks for all your work!