### PR TITLE
Colorize plugin

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -3,11 +3,12 @@
 # If no highlighting method supported for given extension then it tries 
 # guess it by looking for file content.
 
-alias colorize='colorize_via_pygmentize'
+#easier alias to use plugin
+alias ccat='colorize_via_pygmentize'
 
 colorize_via_pygmentize() {
     if [ ! -x "$(which pygmentize)" ]; then
-        echo "package \'pygmentize\' is not installed!"
+        echo "package \'Pygments\' is not installed!"
         return -1
     fi
 


### PR DESCRIPTION
updated the created alias to be more user friendly/intuitive

updated exception message to reflect the proper python package.

pygmentize (0.2.1) does not install into current python3 version.
 "Could not find a version that satisfies the requirement pygmentize (from versions: )
No matching distribution found for pygmentize"

Pygments (2.2.0) does install