### PR TITLE
gradle plugin should support kotlin gradle build files

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -88,7 +88,7 @@ function _gradle_arguments() {
 # and if so, regenerate the .gradle_tasks cache file
 ############################################################################
 _gradle_does_task_list_need_generating () {
-  [[ ! -f .gradletasknamecache ]] || [[ build.gradle -nt .gradletasknamecache ]]
+  [[ ! -f .gradletasknamecache ]] || [[ build.gradle -nt .gradletasknamecache || build.gradle.kts -nt .gradletasknamecache ]]
 }
 
 ##############
@@ -144,7 +144,7 @@ _gradle_parse_and_extract_tasks () {
 # Discover the gradle tasks by running "gradle tasks --all"
 ############################################################################
 _gradle_tasks () {
-  if [[ -f build.gradle ]]; then
+  if [[ -f build.gradle || -f build.gradle.kts ]]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
       _gradle_parse_and_extract_tasks "$(gradle tasks --all)" > .gradletasknamecache
@@ -154,7 +154,7 @@ _gradle_tasks () {
 }
 
 _gradlew_tasks () {
-  if [[ -f build.gradle ]]; then
+  if [[ -f build.gradle || -f build.gradle.kts ]]; then
     _gradle_arguments
     if _gradle_does_task_list_need_generating; then
       _gradle_parse_and_extract_tasks "$(./gradlew tasks --all)" > .gradletasknamecache


### PR DESCRIPTION
This change allows the gradle plugin to recognise build.gradle.kts files and
thus generate the autocomplete entries.

-=david=-

closes #6528