### PR TITLE
Add support for Mac to dirhistory plugin

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -119,6 +119,8 @@ zle -N dirhistory_zle_dirhistory_back
 # xterm in normal mode
 bindkey "\e[3D" dirhistory_zle_dirhistory_back
 bindkey "\e[1;3D" dirhistory_zle_dirhistory_back
+# Mac teminal (alt+left/right)
+bindkey "^[b" dirhistory_zle_dirhistory_back
 # Putty:
 bindkey "\e\e[D" dirhistory_zle_dirhistory_back
 # GNU screen:
@@ -127,6 +129,7 @@ bindkey "\eO3D" dirhistory_zle_dirhistory_back
 zle -N dirhistory_zle_dirhistory_future
 bindkey "\e[3C" dirhistory_zle_dirhistory_future
 bindkey "\e[1;3C" dirhistory_zle_dirhistory_future
+bindkey "^[f" dirhistory_zle_dirhistory_future
 bindkey "\e\e[C" dirhistory_zle_dirhistory_future
 bindkey "\eO3C" dirhistory_zle_dirhistory_future
 


### PR DESCRIPTION
Add shortcuts for mac keyboards as an alternative to alt+left
abd alt+right: mac users can now use opt+left and opt+right.

On acceptance of this PR, I will update the wiki page accordingly.

Review of @jeffwilliams would be appreciated, thanks. 