### PR TITLE
Fix MacOS compatibility of the gpg-agent plugin

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,5 +1,5 @@
 # Enable gpg-agent if it is not running
-GPG_AGENT_SOCKET="${XDG_RUNTIME_DIR}/gnupg/S.gpg-agent.ssh"
+GPG_AGENT_SOCKET="$(gpgconf --list-dirs agent-ssh-socket)"
 if [ ! -S $GPG_AGENT_SOCKET ]; then
   gpg-agent --daemon >/dev/null 2>&1
   export GPG_TTY=$(tty)


### PR DESCRIPTION
MacOS holds the GPG agent socket in a different directory than
Linux-based systems. Asking gpgconf for the correct path is the
most straightforward approach to fix this problem.

See #6106 for further details and discussion.