### PR TITLE
Add support for --silent option in install.sh script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -108,7 +108,11 @@ main() {
   echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh.'
   echo ''
   printf "${NORMAL}"
-  env zsh -l
+  if [ "$1" == "--silent" ]; then
+    printf "Skipping launch of zsh shell. You can launch it yourself or restart your terminal."
+  else
+    env zsh -l
+  fi
 }
 
-main
+main "$@"


### PR DESCRIPTION
This is an implementation of #6537 using a flag in the existing script.
This allows to skip the execution of the zsh shell at the end of the installation process.