### PR TITLE
Fix the env variable to set when it does not exist

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -95,8 +95,8 @@ function default() {
 #    0 if the env variable exists, 3 if it was set
 #
 function env_default() {
-    env | grep -q "^$1=" && return 0
-    export "$1=$2"       && return 3
+    [[ -z "$1" && ${env | grep -q "^$1="} ]] && return 0
+    export "$1=$2"                           && return 3
 }
 
 


### PR DESCRIPTION
When the env_default function is used on a variable that does not yet exist, it creates an error message when executing the command: "source ~ / .zshrc"

_Example :_
With this feature #5231, I **never** define PAGER or LESS

<img width="509" alt="oh-my-zsh" src="https://user-images.githubusercontent.com/12966574/35174244-f4504372-fd6e-11e7-962e-bd01ed77dbf0.png">

_Solution :_
Add a check on the variable before executing the command
