### PR TITLE
Add 'git branch hierarchy' alias on git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -50,6 +50,7 @@ alias gb='git branch'
 alias gba='git branch -a'
 alias gbd='git branch -d'
 alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*(master|develop|dev)\s*$)" | command xargs -n 1 git branch -d'
+alias gbh="git log --graph --simplify-by-decoration --pretty=format:'%d' --all"
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
 alias gbr='git branch --remote'


### PR DESCRIPTION
With this alias one can see the branches hierarchy of the repository
without all the commit messages.
Very useful when trying to discover which branch is the parent of
another and/or if a branch was merged.

```
*  (local-branch-for-tests)
*  (origin/newer-stuff, newer-stuff)
*  (tag: before-merging)
| *  (origin/more-stuff)
| | *  (origin/new-stuff, new-stuff)
| |/
| | *  (origin/another-branch)
| | | *  (origin/master, origin/HEAD)
| | |/
| | *
| | |\
| |/ /
| | *  (update-documentation)
| * |  (HEAD -> master)
| |/
| | *  (refs/stash)
| |/
|/|
* |  (pr-hints)
|/
| *  (tag: before-rebase)
|/
*  (old-local-branch)
| *  (branch5)
|/
| *  (branch4)
|/
| *  (branch3)
|/
| *  (origin/branch2, branch2)
|/
| *  (origin/branch1)
|/
*
```