### PR TITLE
Add yarn build, yarn start and yarn test aliases

### DIFF
--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -2,9 +2,12 @@
 
 alias y="yarn "
 alias ya="yarn add"
+alias yb="yarn build"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
 alias yo="yarn outdated"
+alias ys="yarn start"
+alias yt="yarn test"
 alias yui="yarn upgrade-interactive"
 
 _yarn ()


### PR DESCRIPTION
Typically used for https://github.com/facebookincubator/create-react-app

```json
  "scripts": {
    "start": "react-scripts start",
    "build": "react-scripts build",
    "test": "react-scripts test --env=jsdom",
```