### PR TITLE
Fixing pyenv plugin slowness

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -7,7 +7,7 @@ _pyenv-from-homebrew-installed() {
 }
 
 FOUND_PYENV=0
-pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
+pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
 
 for pyenvdir in "${pyenvdirs[@]}" ; do
     if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then


### PR DESCRIPTION
Adding "/usr/local/opt/pyenv" to list of search directories.  Brew uses that folder and without it `brew --prefix pyenv` is used, which is much
slower.