### PR TITLE
Quote $ZSH where necessary in install script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,7 +61,7 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git "$ZSH" || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }
@@ -74,9 +74,9 @@ main() {
   fi
 
   printf "${BLUE}Using the Oh My Zsh template file and adding it to ~/.zshrc${NORMAL}\n"
-  cp $ZSH/templates/zshrc.zsh-template ~/.zshrc
+  cp "$ZSH"/templates/zshrc.zsh-template ~/.zshrc
   sed "/^export ZSH=/ c\\
-  export ZSH=$ZSH
+  export ZSH=\"$ZSH\"
   " ~/.zshrc > ~/.zshrc-omztemp
   mv -f ~/.zshrc-omztemp ~/.zshrc
 


### PR DESCRIPTION
The install script fails if the user's home directory contains a space or other white-space character. This fixes that error. See issue #4470 for some discussion around this. This patch doesn't solve any issues in other software, only in OMZ.

Fixes #4470