### PR TITLE
Clarify how to enable timestamps in history (#6109)

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -50,6 +50,8 @@ ZSH_THEME="robbyrussell"
 # stamp shown in the history command output.
 # The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
 # HIST_STAMPS="mm/dd/yyyy"
+# with this setting you need this alias (by default history is aliased to 'fc -l 1')
+# alias history="fc -il 1"
 
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder


### PR DESCRIPTION
(see also https://github.com/robbyrussell/oh-my-zsh/issues/6109 for further info)

The comment in the `.zshrc` is not very clear about the fact that you also need to change the alias of `history` to display timestamps.