### PR TITLE
Support new naming convention in Bundler

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -79,7 +79,7 @@ _bundler-installed() {
 _within-bundled-project() {
   local check_dir="$PWD"
   while [ "$check_dir" != "/" ]; do
-    [ -f "$check_dir/Gemfile" ] && return
+    [ -f "$check_dir/Gemfile" -o -f "$check_dir/gems.rb" ] && return
     check_dir="$(dirname $check_dir)"
   done
   false


### PR DESCRIPTION
As [Bundler](https://bundler.io) now allows using `gems.rb` and `gems.locked` filenames instead of `Gemfile` and `Gemfile.lock`, the bundler plugin should try searching not only for `Gemfile` but also for `gems.rb` when it is checking if we are inside a bundled project.

Currently the bundler plugin doesn't prepend bundled commands with `bundle exec` if the project uses `gems.rb` instead of a `Gemfile`.