### PR TITLE
Uninstall restores now the original shell

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -86,6 +86,8 @@ main() {
     # If this platform provides a "chsh" command (not Cygwin), do it, man!
     if hash chsh >/dev/null 2>&1; then
       printf "${BLUE}Time to change your default shell to zsh!${NORMAL}\n"
+      # Store current shell
+      grep $USER /etc/passwd | awk -F ":" '{print $7}' >> ~/.shell.pre-oh-my-zsh
       chsh -s $(grep /zsh$ /etc/shells | tail -1)
     # Else, suggest the user do so manually.
     else

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -9,6 +9,7 @@ if [ -d ~/.oh-my-zsh ]; then
   rm -rf ~/.oh-my-zsh
 fi
 
+# if we had zsh previously 
 echo "Looking for original zsh config..."
 if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]; then
   echo "Found ~/.zshrc.pre-oh-my-zsh -- Restoring to ~/.zshrc";
@@ -20,15 +21,20 @@ if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]; then
   fi
 
   mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
-
   echo "Your original zsh config was restored. Please restart your session."
-else
-  if hash chsh >/dev/null 2>&1; then
-    echo "Switching back to bash"
-    chsh -s /bin/bash
-  else
-    echo "You can edit /etc/passwd to switch your default shell back to bash"
-  fi
 fi
 
+echo "Restoring default shell..."
+if [ -f ~/.shell.pre-oh-my-zsh ] ; then
+  if hash chsh >/dev/null 2>&1; then
+    echo "Found ~/.shell.pre-oh-my-zsh -- Restoring your default shell to" $(cat ~/.shell.pre-oh-my-zsh)
+    chsh -s $(cat ~/.shell.pre-oh-my-zsh)
+    rm ~/.shell.pre-oh-my-zsh
+  else
+    echo "Switching back to bash"
+    chsh -s /bin/bash
+  fi
+else
+  echo "You can edit /etc/passwd to switch your default shell back to bash"
+fi
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
Hi there, 
after having uninstalled oh-my-zsh I've noticed that the environment was not restored correctly. 
The aim of this PR is to:
1 - Store the current shell into ~/.shell.pre-oh-my-zsh, when running install.sh
2 - Restore the default shell (previous to oh-my-zsh), when running the uninstall script.