### PR TITLE
add -F and -X to default $LESS environment variable

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -20,7 +20,7 @@ setopt long_list_jobs
 
 ## pager
 env_default PAGER 'less'
-env_default LESS '-R'
+env_default LESS '-FRX'
 
 ## super user alias
 alias _='sudo'


### PR DESCRIPTION
The option '-F' causes 'less' to automatically quit if the contents fit 
the screen and the option '-X' causes 'less' to not clear the screen after 
quit. I think both options are generally useful for terminal applications.

They are in particular useful for Git as it runs all output through a
pager. Git will run 'less' with '-FRX' by default if the environment 
variable $LESS is not defined [1]. Since oh-my-zsh used to set $LESS to 
'-R', Git would not override this setting. Consequently, Git would 
display even a single line of output in a pager and the user would need
to explicitly quit that pager (see mailing list discussion [2]).

Therefore, lets change the oh-my-zsh default value for $LESS to '-FRX'.
This would be useful for oh-my-zsh Git users and likely for users of
other applications that use 'less' too.

[1] https://github.com/git/git/blob/36438dc19dd2a305dddebd44bf7a65f1a220075b/Documentation/config.txt#L819-L821
[2] https://public-inbox.org/git/2412A603-4382-4AF5-97D0-D16D5FAAFE28@eluvio.com/

---

#5363 #5877 are LESS related issues but they don't fix the problem described here.
/cc @peff @jasonracey