### PR TITLE
Add alias glr for git log --reverse.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -174,6 +174,7 @@ alias gke='\gitk --all $(git log -g --pretty=%h)'
 compdef _git gke='gitk'
 
 alias gl='git pull'
+alias glr='git log --reverse'
 alias glg='git log --stat'
 alias glgp='git log --stat -p'
 alias glgg='git log --graph'


### PR DESCRIPTION
I wanted to add another one the `gl` for `git log`, but that's already taken for `git pull`, so I added the one I use often when I want to go to the starting commits of some repository which is `git log --reverse` for which `glr` is a nice alias, which isn't taken already.