### PR TITLE
Add AWS_PROFILE env var to prompt for agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -217,15 +217,12 @@ prompt_status() {
 # - displays yellow on red if profile name contains 'production' or
 #   ends in '-prod'
 # - displays black on green otherwise
-prompt_aws_profile() {
-  local aws_profile="$AWS_PROFILE"
-  if [[ -n $aws_profile ]]; then
-    if [[ $aws_profile == *"-prod" || $aws_profile == *"production"* ]]; then
-      prompt_segment red yellow  "AWS: $aws_profile"
-    else
-      prompt_segment green black "AWS: $aws_profile" 
-    fi
-  fi
+prompt_aws() {
+  [[ -z "$AWS_PROFILE" ]] && return
+  case "$AWS_PROFILE" in
+    *-prod|*production*) prompt_segment red yellow  "AWS: $AWS_PROFILE" ;;
+    *) prompt_segment green black "AWS: $AWS_PROFILE" ;;
+  esac
 }
 
 ## Main prompt
@@ -233,7 +230,7 @@ build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
-  prompt_aws_profile
+  prompt_aws
   prompt_context
   prompt_dir
   prompt_git

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -221,9 +221,9 @@ prompt_aws_profile() {
   local aws_profile="$AWS_PROFILE"
   if [[ -n $aws_profile ]]; then
     if [[ $aws_profile == *"-prod" || $aws_profile == *"production"* ]]; then
-      prompt_segment red yellow  "$aws_profile"
+      prompt_segment red yellow  "AWS: $aws_profile"
     else
-      prompt_segment green black "$aws_profile" 
+      prompt_segment green black "AWS: $aws_profile" 
     fi
   fi
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -212,11 +212,29 @@ prompt_status() {
   [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
 }
 
+#AWS Profile:
+# - display current AWS_PROFILE name
+# - displays yellow on red if profile name contains 'production' or
+#   ends in '-prod'
+# - displays black on green otherwise
+prompt_aws_profile() {
+  local aws_profile="$AWS_PROFILE"
+  if [[ -n $aws_profile ]]; then
+    if [[ $aws_profile == *"-prod" || $aws_profile == *"production"* ]]; then
+      prompt_segment red yellow  "$aws_profile"
+    else
+      prompt_segment green black "$aws_profile" 
+    fi
+  fi
+}
+
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
+  prompt_aws_profile
   prompt_context
   prompt_dir
   prompt_git

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -228,7 +228,6 @@ prompt_aws_profile() {
   fi
 }
 
-
 ## Main prompt
 build_prompt() {
   RETVAL=$?


### PR DESCRIPTION
Adds the AWS_PROFILE environment variable to the command prompt for the agnoster theme. 

Setting the AWS_PROFILE to anything containing `production` or ending in `-prod` will set the colour to yellow on red, otherwise it will be black on green 

![image](https://user-images.githubusercontent.com/22946190/36126898-cf61bc8c-10ae-11e8-92a8-d2aea619b958.png)

