### PR TITLE
Respect RBENV_ROOT and PYENV_ROOT if set (quick merge for rbenv and pyenv plugins)

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -9,6 +9,10 @@ _pyenv-from-homebrew-installed() {
 FOUND_PYENV=0
 pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
 
+if [[ -n "$PYENV_ROOT" ]]; then
+  pyenvdirs=($PYENV_ROOT "${pyenvdirs[@]}")
+fi
+
 for pyenvdir in "${pyenvdirs[@]}" ; do
     if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then
         FOUND_PYENV=1

--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -12,6 +12,10 @@ if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null)
     fi
 fi
 
+if [[ -n "$RBENV_ROOT" ]]; then
+  rbenvdirs=($RBENV_ROOT "${rbenvdirs[@]}")
+fi
+
 for rbenvdir in "${rbenvdirs[@]}" ; do
   if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then
     FOUND_RBENV=1


### PR DESCRIPTION
If `RBENV_ROOT` or `PYENV_ROOT` have been set, assume this is intentional by the user and put that path at the front of `rbenvdirs` or `pyenvdirs`. :smile_cat: 

The current (hostile) behaviour ignores these  officially documented env vars.