### PR TITLE
Update/add kubectl logging commands

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -20,7 +20,6 @@ alias kccc='k config current-context'
 
 # Pod management.
 alias kgp='k get pods'
-alias klp='k logs pods'
 alias kep='k edit pods'
 alias kdp='k describe pods'
 alias kdelp='k delete pods'
@@ -48,3 +47,7 @@ alias krsd='k rollout status deployment'
 alias kgrs='k get rs'
 alias krh='k rollout history'
 alias kru='k rollout undo'
+
+# Logs
+alias kl='k logs'
+alias klf='k logs -f'


### PR DESCRIPTION
This updates the `alias kl='k logs'` removing "pods" as it doesn't need to be specified
Usage `kl api-5ffb12` for logs of api-5ffb12
Added `alias klf='k logs -f'`, to tail/follow the logs
Usage `klf api-5ffb12`