### PR TITLE
Added trizen to the archlinux plugin

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -2,6 +2,31 @@
 
 ## Features
 
+#### TRIZEN
+
+| Alias   | Command                            | Description                                                         |
+|---------|------------------------------------|---------------------------------------------------------------------|
+| trconf  | trizen -C                          | Fix all configuration files with vimdiff                            |
+| trin    | trizen -S                          | Install packages from the repositories                              |
+| trins   | trizen -U                          | Install a package from a local file                                 |
+| trinsd  | trizen -S --asdeps                 | Install packages as dependencies of another package                 |
+| trloc   | trizen -Qi                         | Display information about a package in the local database           |
+| trlocs  | trizen -Qs                         | Search for packages in the local database                           |
+| trlst   | trizen -Qe                         | List installed packages including from AUR (tagged as "local")      |
+| trmir   | trizen -Syy                        | Force refresh of all package lists after updating mirrorlist        |
+| trorph  | trizen -Qtd                        | Remove orphans using yaourt                                         |
+| trre    | trizen -R                          | Remove packages, keeping its settings and dependencies              |
+| trrem   | trizen -Rns                        | Remove packages, including its settings and unneeded dependencies   |
+| trrep   | trizen -Si                         | Display information about a package in the repositories             |
+| trreps  | trizen -Ss                         | Search for packages in the repositories                             |
+| trupd   | trizen -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
+| trupd   | trizen -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
+| trupd   | trizen -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
+| trupd   | trizen -Sy                         | Update and refresh the local package database                       |
+| trupd   | trizen -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
+| trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
+| upgrade | trizen -Syu                        | Sync with repositories before upgrading packages                    |
+
 #### YAOURT
 
 | Alias   | Command                            | Description                                                         |
@@ -27,7 +52,7 @@
 | yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
 | upgrade | yaourt -Syu                        | Sync with repositories before upgrading packages                    |
 
-### PACAUR
+#### PACAUR
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|
@@ -95,3 +120,4 @@
 - ornicar - thibault.duplessis@gmail.com
 - Juraj Fiala - doctorjellyface@riseup.net
 - Majora320 (Moses Miller) - Majora320@gmail.com
+- Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -1,3 +1,32 @@
+if (( $+commands[trizen] )); then
+  alias trconf='trizen -C'
+  alias trupg='trizen -Syua'
+  alias trsu='trizen -Syua --noconfirm'
+  alias trin='trizen -S'
+  alias trins='trizen -U'
+  alias trre='trizen -R'
+  alias trrem='trizen -Rns'
+  alias trrep='trizen -Si'
+  alias trreps='trizen -Ss'
+  alias trloc='trizen -Qi'
+  alias trlocs='trizen -Qs'
+  alias trlst='trizen -Qe'
+  alias trorph='trizen -Qtd'
+  alias trinsd='trizen -S --asdeps'
+  alias trmir='trizen -Syy'
+
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias trupd='trizen -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias trupd='trizen -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias trupd='trizen -Sy && sudo aur'
+  else
+    alias trupd='trizen -Sy'
+  fi
+fi
+
 if (( $+commands[yaourt] )); then
   alias yaconf='yaourt -C'
   alias yaupg='yaourt -Syua'
@@ -54,7 +83,11 @@ if (( $+commands[pacaur] )); then
   fi
 fi
 
-if (( $+commands[pacaur] )); then
+if (( $+commands[trizen] )); then
+  upgrade() {
+    trizen -Syu
+  }
+elif (( $+commands[pacaur] )); then
   upgrade() {
     pacaur -Syu
   }


### PR DESCRIPTION
This PR add commands for calling the trizen aur helper/pacman front-end for Arch to the `archlinux` plugin

trizen is the recommended solution for using the Arch User Repository.
both yaourt and pacaur have some issues.

If you have trizen installed on your system, the aliases for it will be added, and the "upgrade" command will be run with trizen. If you don't have it installed, no behaviour will be changed. 

Signed-off by: Arthur Brainville (Ybalrid) <ybalrid@ybalrid.info>