### PR TITLE
add nvmng plugin

### DIFF
--- a/plugins/nvmng/README.md
+++ b/plugins/nvmng/README.md
@@ -1,0 +1,10 @@
+# Description
+
+This plugin loads the nvm-ng hard fork of nvm, with the --fast-reuse patch
+applied. This improves loading times for your shell significantly.
+
+# Installation
+
+This plugin requires to install [nvm-ng](https://github.com/wzrdtales/nvm-ng).
+Please follow the instructions on their README page.
+

--- a/plugins/nvmng/_nvm
+++ b/plugins/nvmng/_nvm
@@ -1,0 +1,26 @@
+#compdef nvm
+#autoload
+
+[[ -f "$NVM_DIR/nvm.sh" ]] || return 0
+
+local -a _1st_arguments
+_1st_arguments=(
+  'help:show help'
+  'install:download and install a version'
+  'uninstall:uninstall a version'
+  'use:modify PATH to use version'
+  'run:run version with given arguments'
+  'ls:list installed versions or versions matching a given description'
+  'ls-remote:list remote versions available for install'
+  'deactivate:undo effects of NVM on current shell'
+  'alias:show or set aliases'
+  'unalias:deletes an alias'
+  'copy-packages:install global NPM packages to current version'
+)
+
+_arguments -C '*:: :->subcmds' && return 0
+
+if (( CURRENT == 1 )); then
+  _describe -t commands "nvm subcommand" _1st_arguments
+  return
+fi

--- a/plugins/nvmng/nvmng.plugin.zsh
+++ b/plugins/nvmng/nvmng.plugin.zsh
@@ -1,0 +1,5 @@
+# Set NVM_DIR if it isn't already defined
+[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
+
+# Load nvm if it exists
+[[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh" --fast-reuse


### PR DESCRIPTION
This adds the [nvmng](https://github.com/wzrdtales/nvm-ng). plugin, which loads nvm with the flag --fast-reuse, which is exposed
by nvm-ng. This is a hard fork of nvm which contains patches that accelerate load time
for nvm, to get back to a more smooth behavior of your shell.

nvm-ng can be found here

https://github.com/wzrdtales/nvm-ng

Signed-off-by: Tobias Gurtzick <magic@wizardtales.com>