### PR TITLE
Change the "br" action to "branch" in the jira plugin to be more consistent with other actions

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -21,6 +21,7 @@ jira new        # opens a new issue
 jira dashboard  # opens your JIRA dashboard
 jira reported [username]  # queries for issues reported by a user
 jira assigned [username]  # queries for issues assigned to a user
+jira branch     # opens an existing issue matching the current branch name
 jira ABC-123    # opens an existing issue
 jira ABC-123 m  # opens an existing issue for adding a comment
 ```

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -60,7 +60,7 @@ function jira() {
   else
     # Anything that doesn't match a special action is considered an issue name
     # but `branch` is a special case that will parse the current git branch
-    if [[ "$action" == "br" ]]; then
+    if [[ "$action" == "branch" ]]; then
       local issue_arg=$(git rev-parse --abbrev-ref HEAD)
       local issue="${jira_prefix}${issue_arg}"
     else


### PR DESCRIPTION
# Context

The `br` action is the only action that is used as an abbreviation. 

# Suggestion Solution

This PR aims at:

1. Change the `br` action to `branch` to be aligned with other actions which don't use appreviations and also to be more consistent with the name of other actions.

2. Add the `branch` action in the list of possible actions in `README.md` which was not previously listed.



