### PR TITLE
Add Qwant engine - web_search plugin

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -16,6 +16,7 @@ function web_search() {
     baidu       "https://www.baidu.com/s?wd="
     ecosia      "https://www.ecosia.org/search?q="
     goodreads   "https://www.goodreads.com/search?q="
+    qwant       "https://www.qwant.com/?q="
   )
 
   # check whether the search engine is supported
@@ -49,6 +50,7 @@ alias github='web_search github'
 alias baidu='web_search baidu'
 alias ecosia='web_search ecosia'
 alias goodreads='web_search goodreads'
+alias qwant='web_search qwant'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
Add the Qwant search engine url to the "web_search" plugin.