### PR TITLE
Update archlinux.plugin.zsh

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -83,7 +83,7 @@ alias pacmir='sudo pacman -Syy'
 alias paclsorphans='sudo pacman -Qdt'
 alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
 alias pacfileupg='sudo pacman -Fy'
-alias pacfiles='pacman tFs'
+alias pacfiles='pacman -Fs'
 
 
 if (( $+commands[abs] && $+commands[aur] )); then


### PR DESCRIPTION
-alias pacfiles='pacman tFs'
+alias pacfiles='pacman -Fs'

pacman tFs makes no sense. I assume who ever wrote this meant `-Fs`