### PR TITLE
Add alias for yarn remove

### DIFF
--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,7 +1,8 @@
 # Alias sorted alphabetically
 
-alias y="yarn "
+alias y="yarn"
 alias ya="yarn add"
+alias yr="yarn remove"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
 alias yo="yarn outdated"


### PR DESCRIPTION
Adds a simple alias that maps `yr` to `yarn remove`, also removes extra whitespace from `y` alias.