### PR TITLE
Update AWS completion

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -42,11 +42,11 @@ function aws_profiles {
 
 compctl -K aws_profiles asp
 
-if _homebrew-installed && _awscli-homebrew-installed ; then
+if which aws_zsh_completer.sh &>/dev/null; then
+  _aws_zsh_completer_path=$(which aws_zsh_completer.sh 2>/dev/null)
+elif _homebrew-installed && _awscli-homebrew-installed; then
   _aws_zsh_completer_path=$_brew_prefix/libexec/bin/aws_zsh_completer.sh
-else
-  _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi
 
-[ -x $_aws_zsh_completer_path ] && source $_aws_zsh_completer_path
+[ -n "$_aws_zsh_completer_path" ] && [ -x $_aws_zsh_completer_path ] && source $_aws_zsh_completer_path
 unset _aws_zsh_completer_path


### PR DESCRIPTION
Using `which` to determine the path `aws_zsh_completer.sh` is vastly faster than using brew to determine the base path first. Often the completer is already in your PATH, so it makes more sense to check which first.

Also added additional check for in case the file isn't found.

I can't give you comparison benchmarks, as which is a shell builtin, and time doesn't show the times:
```
$ time brew --prefix awscli
/usr/local/Cellar/awscli/1.15.0
brew --prefix awscli  0.33s user 0.15s system 96% cpu 0.499 total

$ time which aws_zsh_completer.sh
/usr/local/bin/aws_zsh_completer.sh

$ type -f which
which is a shell builtin
```