### PR TITLE
Adds Homebrew and completion support to asdf plugin

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,33 +1,17 @@
-_homebrew-installed() {
-    type brew &> /dev/null
-}
+# Find where asdf should be installed
+ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
 
-FOUND_ASDF=0
-DEFAULT_ASDF_DIR="$HOME/.asdf"
-
-if [ -d $DEFAULT_ASDF_DIR/bin ] ; then
-    FOUND_ASDF=1
-    ASDF_DIR="$DEFAULT_ASDF_DIR"
-    ASDF_COMPLETIONS_DIR="$DEFAULT_ASDF_DIR/completions"
+# If not found, check for Homebrew package
+if [[ ! -d $ASDF_DIR ]] && (( $+commands[brew] )); then
+   ASDF_DIR="$(brew --prefix asdf)"
 fi
 
-if [ $FOUND_ASDF -eq 0 ] && _homebrew-installed ; then
-    ASDF_DIR="$(brew --prefix)/opt/asdf"
-    if [ $? -eq 0 -a -d $ASDF_DIR/bin ] ; then
-        FOUND_ASDF=1
-        ASDF_COMPLETIONS_DIR="$ASDF_DIR/etc/bash_completion.d/asdf.bash"
+# Load command
+if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
+    . "$ASDF_DIR/asdf.sh"
+
+    # Load completions
+    if [[ -f "$ASDF_DIR/completions/asdf.bash" ]]; then
+        . "$ASDF_DIR/completions/asdf.bash"
     fi
 fi
-
-if [ $FOUND_ASDF -gt 0 ] ; then
-    export PATH=${ASDF_DIR}/bin:$PATH
-    . $ASDF_DIR/asdf.sh
-    if [ -f $ASDF_COMPLETIONS_DIR/completions/asdf.bash ]; then
-      . $ASDF_COMPLETIONS_DIR/completions/asdf.bash
-    fi
-fi
-
-unset FOUND_ASDF
-unset ASDF_DIR
-unset ASDF_COMPLETIONS_DIR
-

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,12 +1,33 @@
-# Find where asdf should be installed.
-ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
+_homebrew-installed() {
+    type brew &> /dev/null
+}
 
-# Load asdf, if found.
-if [ -f $ASDF_DIR/asdf.sh ]; then
+FOUND_ASDF=0
+DEFAULT_ASDF_DIR="$HOME/.asdf"
+
+if [ -d $DEFAULT_ASDF_DIR/bin ] ; then
+    FOUND_ASDF=1
+    ASDF_DIR="$DEFAULT_ASDF_DIR"
+    ASDF_COMPLETIONS_DIR="$DEFAULT_ASDF_DIR/completions"
+fi
+
+if [ $FOUND_ASDF -eq 0 ] && _homebrew-installed ; then
+    ASDF_DIR="$(brew --prefix)/opt/asdf"
+    if [ $? -eq 0 -a -d $ASDF_DIR/bin ] ; then
+        FOUND_ASDF=1
+        ASDF_COMPLETIONS_DIR="$ASDF_DIR/etc/bash_completion.d/asdf.bash"
+    fi
+fi
+
+if [ $FOUND_ASDF -gt 0 ] ; then
+    export PATH=${ASDF_DIR}/bin:$PATH
     . $ASDF_DIR/asdf.sh
+    if [ -f $ASDF_COMPLETIONS_DIR/completions/asdf.bash ]; then
+      . $ASDF_COMPLETIONS_DIR/completions/asdf.bash
+    fi
 fi
 
-# Load asdf completions, if found.
-if [ -f $ASDF_DIR/completions/asdf.bash ]; then
-    . $ASDF_DIR/completions/asdf.bash
-fi
+unset FOUND_ASDF
+unset ASDF_DIR
+unset ASDF_COMPLETIONS_DIR
+


### PR DESCRIPTION
* Modifies the search logic for asdf to include Homebrew when it is
installed.  The implementation is adapted from the pyenv plugin.

* Includes command completions for both regular and Homebrew installs.
This enhancement was inspired by PR #6046.