### PR TITLE
Check for Microsoft's WSL in open_command

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -25,7 +25,9 @@ function open_command() {
   case "$OSTYPE" in
     darwin*)  open_cmd='open' ;;
     cygwin*)  open_cmd='cygstart' ;;
-    linux*)   open_cmd='xdg-open' ;;
+    linux*)   [[ $(uname -a) =~ "Microsoft" ]] && \
+                open_cmd='cmd.exe /c start' || \
+                open_cmd='xdg-open' ;;
     msys*)    open_cmd='start ""' ;;
     *)        echo "Platform $OSTYPE not supported"
               return 1


### PR DESCRIPTION
This will work only on files and directories in a DrvFs mount, i.e. that can be translated to a Windows drive path. For example: `/mnt/c/Users/user`.

Files and folders inside the LXSS directory can't be handled in Windows, they must be ONLY used by the WSL subsystem. That's why you won't be able to open your $HOME directory, for instance.

See https://blogs.msdn.microsoft.com/commandline/2016/11/17/do-not-change-linux-files-using-windows-apps-and-tools/