### PR TITLE
Add directory hierarchy navigation to dirhistory

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -2,6 +2,10 @@
 #   Navigate directory history using ALT-LEFT and ALT-RIGHT. ALT-LEFT moves back to directories 
 #   that the user has changed to in the past, and ALT-RIGHT undoes ALT-LEFT.
 # 
+#   Navigate directory hierarchy using ALT-UP and ALT-DOWN. (mac keybindings not yet implemented)
+#   ALT-UP moves to higher hierarchy (cd ..)
+#   ALT-DOWN moves into the first directory found in alphabetical order
+#
 
 dirhistory_past=($PWD)
 dirhistory_future=()
@@ -134,3 +138,49 @@ bindkey "\e\e[C" dirhistory_zle_dirhistory_future
 bindkey "\eO3C" dirhistory_zle_dirhistory_future
 
 
+# 
+# HIERARCHY Implemented in this section, in case someone wants to split it to another plugin if it clashes bindings
+# 
+
+# Move up in hierarchy
+function dirhistory_up() {
+  cd ..
+}
+
+# Move down in hierarchy
+function dirhistory_down() {
+  cd "`find . -mindepth 1 -maxdepth 1 -type d | sort -n | head -n 1`"
+}
+
+
+# Bind keys to hierarchy navigation
+function dirhistory_zle_dirhistory_up() {
+  zle kill-buffer   # Erase current line in buffer
+  dirhistory_up
+  zle accept-line
+}
+
+function dirhistory_zle_dirhistory_down() {
+  zle kill-buffer   # Erase current line in buffer
+  dirhistory_down
+  zle accept-line
+}
+
+zle -N dirhistory_zle_dirhistory_up
+# xterm in normal mode
+bindkey "\e[3A" dirhistory_zle_dirhistory_up
+bindkey "\e[1;3A" dirhistory_zle_dirhistory_up
+# Mac teminal (alt+up)
+    #bindkey "^[?" dirhistory_zle_dirhistory_up #dont know it
+# Putty:
+bindkey "\e\e[A" dirhistory_zle_dirhistory_up
+# GNU screen:
+bindkey "\eO3A" dirhistory_zle_dirhistory_up
+
+zle -N dirhistory_zle_dirhistory_down
+bindkey "\e[3B" dirhistory_zle_dirhistory_down
+bindkey "\e[1;3B" dirhistory_zle_dirhistory_down
+# Mac teminal (alt+down)
+    #bindkey "^[?" dirhistory_zle_dirhistory_down #dont know it
+bindkey "\e\e[B" dirhistory_zle_dirhistory_down
+bindkey "\eO3B" dirhistory_zle_dirhistory_down

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -144,12 +144,12 @@ bindkey "\eO3C" dirhistory_zle_dirhistory_future
 
 # Move up in hierarchy
 function dirhistory_up() {
-  cd ..
+  cd .. || return 1
 }
 
 # Move down in hierarchy
 function dirhistory_down() {
-  cd "`find . -mindepth 1 -maxdepth 1 -type d | sort -n | head -n 1`"
+  cd "$(find . -mindepth 1 -maxdepth 1 -type d | sort -n | head -n 1)" || return 1
 }
 
 


### PR DESCRIPTION
 Changes to be committed:
	modified:   dirhistory/dirhistory.plugin.zsh

New Feature:
  Navigate directory hierarchy using ALT-UP and ALT-DOWN. (mac keybindings not yet implemented)
  ALT-UP moves to higher hierarchy (cd ..)
  ALT-DOWN moves into the first directory found in alphabetical order