### PR TITLE
Simplify hub check and hardcode aliasing

### DIFF
--- a/plugins/github/_hub
+++ b/plugins/github/_hub
@@ -89,6 +89,7 @@ __hub_setup_zsh_fns () {
       browse:'browse the project on GitHub'
       compare:'open GitHub compare view'
       ci-status:'lookup commit in GitHub Status API'
+      sync:'update local branches from upstream'
     )
     _describe -t hub-commands 'hub command' hub_commands && ret=0
 
@@ -115,6 +116,7 @@ create
 browse
 compare
 ci-status
+sync
 EOF
     __git_list_all_commands_without_hub
   }

--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,8 +1,6 @@
 # Set up hub wrapper for git, if it is available; http://github.com/github/hub
-if [ "$commands[(I)hub]" ]; then
-  if hub --version &>/dev/null; then
-    eval $(hub alias -s zsh)
-  fi
+if (( $+commands[hub] )); then
+  alias git=hub
 fi
 
 # Functions #################################################################


### PR DESCRIPTION
The current version makes 2 calls to `hub`, which can be quite slow. Since `hub alias -s` just outputs `alias git=hub` we can substitute it altogether.