### PR TITLE
Add support for custom timestamp format in history

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -19,16 +19,13 @@ function omz_history {
 }
 
 # Timestamp format
-if [ ! -z "$HIST_STAMPS" ]; then
-  case $HIST_STAMPS in
-    "mm/dd/yyyy") alias history='omz_history -f' ;;
-    "dd.mm.yyyy") alias history='omz_history -E' ;;
-    "yyyy-mm-dd") alias history='omz_history -i' ;;
-    *) alias history='omz_history -t "$HIST_STAMPS"' ;;
-  esac
-else
-  alias history='omz_history'
-fi
+case $HIST_STAMPS in
+  "mm/dd/yyyy") alias history='omz_history -f' ;;
+  "dd.mm.yyyy") alias history='omz_history -E' ;;
+  "yyyy-mm-dd") alias history='omz_history -i' ;;
+  "") alias history='omz_history' ;;
+  *) alias history="omz_history -t '$HIST_STAMPS'" ;;
+esac
 
 ## History file configuration
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -19,12 +19,16 @@ function omz_history {
 }
 
 # Timestamp format
-case $HIST_STAMPS in
-  "mm/dd/yyyy") alias history='omz_history -f' ;;
-  "dd.mm.yyyy") alias history='omz_history -E' ;;
-  "yyyy-mm-dd") alias history='omz_history -i' ;;
-  *) alias history='omz_history' ;;
-esac
+if [ ! -z "$HIST_STAMPS" ]; then
+  case $HIST_STAMPS in
+    "mm/dd/yyyy") alias history='omz_history -f' ;;
+    "dd.mm.yyyy") alias history='omz_history -E' ;;
+    "yyyy-mm-dd") alias history='omz_history -i' ;;
+    *) alias history='omz_history -t "$HIST_STAMPS"' ;;
+  esac
+else
+  alias history='omz_history'
+fi
 
 ## History file configuration
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -48,7 +48,10 @@ ZSH_THEME="robbyrussell"
 
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
 # HIST_STAMPS="mm/dd/yyyy"
 
 # Would you like to use another custom folder than $ZSH/custom?


### PR DESCRIPTION
As per discussion in https://github.com/robbyrussell/oh-my-zsh/pull/6589, this PR adds the ability to define a custom format for timestamps shown by the `history` command.
1. If `HIST_STAMPS` is unset or empty the default behavior is maintained and no timestamps are shown. 
2. The custom formats `mm/dd/yyy`, `dd.mm.yyyy`, and `yyyy-mm-dd` are kept as well.
3. Otherwise `HIST_STAMPS` is used as a format string passed to the `fc` command via the `-t` option. The format string — as per [`fc`'s manual](http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html) — "is formatted with the strftime function with the zsh extensions described for the `%D{string}` prompt format in [Prompt Expansion](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Prompt-Expansion)." . More info on the accepted escape sequences are available via [`man strftime`](https://linux.die.net/man/3/strftime).

The PR also updates the `zshrc.zsh-template`  template with instructions.

See issue https://github.com/robbyrussell/oh-my-zsh/issues/6109, for further background.