### PR TITLE
gpg-agent Don't set SSH_AUTH_SOCK if ssh-agent plugin is enabled

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,7 +1,5 @@
 # Enable gpg-agent if it is not running-
 # --use-standard-socket will work from version 2 upwards
-typeset _gpg_ssh_socket
-
 AGENT_SOCK=`gpgconf --list-dirs | grep agent-socket | cut -d : -f 2`
 
 if [ ! -S ${AGENT_SOCK} ]; then
@@ -9,12 +7,10 @@ if [ ! -S ${AGENT_SOCK} ]; then
 fi
 export GPG_TTY=$(tty)
 
-# Set SSH to use gpg-agent if it's enabled, and we've set config 
-zstyle -b :omz:plugins:gpg-agent ssh-socket _gpg_ssh_socket
-
-if [[ $_gpg_ssh_socket == "yes" && -S "${AGENT_SOCK}.ssh" ]]; then
+# Set SSH to use gpg-agent if it's enabled, and we're not using the ssh-agent plugin
+echo "$plugins" | fgrep -q "ssh-agent"
+if [[ $? -eq 1 && -S "${AGENT_SOCK}.ssh" ]]; then
   export SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
   unset SSH_AGENT_PID
 fi
 
-unset _gpg_ssh_socket

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,16 +1,14 @@
 # Enable gpg-agent if it is not running-
 # --use-standard-socket will work from version 2 upwards
-AGENT_SOCK=`gpgconf --list-dirs | grep agent-socket | cut -d : -f 2`
+AGENT_SOCK=$(gpgconf --list-dirs | grep agent-socket | cut -d : -f 2)
 
-if [ ! -S ${AGENT_SOCK} ]; then
-  gpg-agent --daemon --use-standard-socket >/dev/null 2>&1
+if [[ ! -S "$AGENT_SOCK" }]; then
+  gpg-agent --daemon --use-standard-socket &>/dev/null
 fi
-export GPG_TTY=$(tty)
+export GPG_TTY=$TTY
 
 # Set SSH to use gpg-agent if it's enabled, and we're not using the ssh-agent plugin
-echo "$plugins" | fgrep -q "ssh-agent"
-if [[ $? -eq 1 && -S "${AGENT_SOCK}.ssh" ]]; then
-  export SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
+if [[ ${+plugins[(r)ssh-agent} -ne 0 && -S "$AGENT_SOCK.ssh" ]]; then
+  export SSH_AUTH_SOCK="$AGENT_SOCK.ssh"
   unset SSH_AGENT_PID
 fi
-

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,5 +1,6 @@
 # Enable gpg-agent if it is not running-
 # --use-standard-socket will work from version 2 upwards
+typeset _gpg_ssh_socket
 
 AGENT_SOCK=`gpgconf --list-dirs | grep agent-socket | cut -d : -f 2`
 
@@ -8,9 +9,12 @@ if [ ! -S ${AGENT_SOCK} ]; then
 fi
 export GPG_TTY=$(tty)
 
-# Set SSH to use gpg-agent if it's enabled
-if [ -S "${AGENT_SOCK}.ssh" ]; then
+# Set SSH to use gpg-agent if it's enabled, and we've set config 
+zstyle -b :omz:plugins:gpg-agent ssh-socket _gpg_ssh_socket
+
+if [[ $_gpg_ssh_socket == "yes" && -S "${AGENT_SOCK}.ssh" ]]; then
   export SSH_AUTH_SOCK="${AGENT_SOCK}.ssh"
   unset SSH_AGENT_PID
 fi
 
+unset _gpg_ssh_socket


### PR DESCRIPTION
fixes #6772 that was introduced in #6469 

Don't setup  SSH_AUTH_SOCK if the ssh-agent plugin is enabled.