### PR TITLE
Remove alias `yo` from yarn plugin

### DIFF
--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -4,7 +4,6 @@ alias y="yarn "
 alias ya="yarn add"
 alias ycc="yarn cache clean"
 alias yh="yarn help"
-alias yo="yarn outdated"
 alias yui="yarn upgrade-interactive"
 
 _yarn ()


### PR DESCRIPTION
`yo` is also a broadly used command line tool to install yeoman generators (http://yeoman.io/)