### PR TITLE
Correctly handle verbose/version flags for rustc

### DIFF
--- a/plugins/rust/_rust
+++ b/plugins/rust/_rust
@@ -88,14 +88,14 @@ _rustc_opts_vals=(
     --pretty='[Pretty-print the input instead of compiling]::TYPE:_values "TYPES" "$_rustc_pretty_types[@]"'
     --unpretty='[Present the input source, unstable (and less-pretty)]::TYPE:_values "TYPES" "$_rustc_unpretty_types[@]"'
     --color='[Configure coloring of output]:CONF:_values "COLORS" "$_rustc_color_types[@]"'
-    {-v,--version}'[Print version info and exit]::VERBOSE:(verbose)'
 )
 
 _rustc_opts_switches=(
     -g'[Equivalent to --debuginfo=2]'
     -O'[Equivalent to --opt-level=2]'
     --test'[Build a test harness]'
-    --verbose'[Use verbose output]'
+    {-v,--verbose}'[Use verbose output]'
+    {-V,--version}'[Print version info and exit]'
     {-h,--help}'[Display this message]'
     --no-analysis'[Parse and expand the output, but run no analysis or produce output]'
     --no-trans'[Run all passes except translation; no output]'


### PR DESCRIPTION
There was some confusion between the `--version` flag (`-V`) and the `--verbose` flag (`-v`).

See the below help output for rustc (v1.25):

```
Usage: rustc [OPTIONS] INPUT

Options:
    -h, --help          Display this message
        --cfg SPEC      Configure the compilation environment
    -L [KIND=]PATH      Add a directory to the library search path. The
                        optional KIND can be one of dependency, crate, native,
                        framework or all (the default).
    -l [KIND=]NAME      Link the generated crate(s) to the specified native
                        library NAME. The optional KIND can be one of static,
                        dylib, or framework. If omitted, dylib is assumed.
        --crate-type [bin|lib|rlib|dylib|cdylib|staticlib|proc-macro]
                        Comma separated list of types of crates for the
                        compiler to emit
        --crate-name NAME
                        Specify the name of the crate being built
        --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
                        Comma separated list of types of output for the
                        compiler to emit
        --print [crate-name|file-names|sysroot|cfg|target-list|target-cpus|target-features|relocation-models|code-models|tls-models|target-spec-json|native-static-libs]
                        Comma separated list of compiler information to print
                        on stdout
    -g                  Equivalent to -C debuginfo=2
    -O                  Equivalent to -C opt-level=2
    -o FILENAME         Write output to <filename>
        --out-dir DIR   Write output to compiler-chosen filename in <dir>
        --explain OPT   Provide a detailed explanation of an error message
        --test          Build a test harness
        --target TARGET Target triple for which the code is compiled
    -W, --warn OPT      Set lint warnings
    -A, --allow OPT     Set lint allowed
    -D, --deny OPT      Set lint denied
    -F, --forbid OPT    Set lint forbidden
        --cap-lints LEVEL
                        Set the most restrictive lint level. More restrictive
                        lints are capped at this level
    -C, --codegen OPT[=VALUE]
                        Set a codegen option
    -V, --version       Print version info and exit
    -v, --verbose       Use verbose output

Additional help:
    -C help             Print codegen options
    -W help             Print 'lint' options and default settings
    --help -v           Print the full set of options rustc accepts
```