### PR TITLE
Add Kubernetes PS1 segment to agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -87,15 +87,14 @@ prompt_context() {
 prompt_kubernetes() {
 
   local cluster=$(kubectl config current-context)
-  local short_cluster=$(grep --colour=never -o '^[^.]*\.[^.]*'<<< "$cluster")
   local namespace=$(kubectl config get-contexts ${cluster} --no-headers | awk '{print $5}')
   if [[ -z "$namespace" ]] || [[ "$namespace" == 'default' ]]; then 
-    prompt_segment magenta black "☁️ ${short_cluster}☁️ "
+    prompt_segment magenta black "☁️ ${cluster}☁️ "
   else
-    if [[ "$namespace" =~ .*[Pp][Rr][Oo][Dd].* ]]; then 
-      prompt_segment red black "☁️ ${short_cluster}|${namespace}☁️ "
+    if [[ "$namespace" =~ [Pp][Rr][Oo][Dd].* ]]; then 
+      prompt_segment red black "☁️ ${cluster}|${namespace}☁️ "
     else 
-      prompt_segment magenta black "☁️ ${short_cluster}|${namespace}☁️ "
+      prompt_segment magenta black "☁️ ${cluster}|${namespace}☁️ "
     fi
   fi 
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -84,6 +84,12 @@ prompt_context() {
   fi
 }
 
+prompt_kubernetes() {
+
+  local cluster=$(kubectl config current-context | grep --colour=never -o '^[^.]*\.[^.]*')
+  prompt_segment magenta black "☁️ ${cluster}☁️ "
+}
+
 # Git: branch/detached head, dirty status
 prompt_git() {
   (( $+commands[git] )) || return
@@ -216,6 +222,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
+  prompt_kubernetes 
   prompt_virtualenv
   prompt_context
   prompt_dir


### PR DESCRIPTION
This PR adds a kubernetes cluster status to the agnoster theme PS1
The kubernetes segment is coloured magenta, unless the namespace matches the regex `[Pp][Rr][Oo][Dd].*` in which case it will be coloured red.