### PR TITLE
pyenv: add back the logic to search for the pyenv command if not found

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,7 +1,29 @@
 # This plugin loads pyenv into the current shell and provides prompt info via
 # the 'pyenv_prompt_info' function. Also loads pyenv-virtualenv if available.
 
-if (( $+commands[pyenv] )); then
+FOUND_PYENV=$+commands[pyenv]
+
+if [[ $FOUND_PYENV -ne 1 ]]; then
+    pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
+    for dir in $pyenvdirs; do
+        if [[ -d $dir/bin ]]; then
+            export PATH="$PATH:$dir/bin"
+            FOUND_PYENV=1
+            break
+        fi
+    done
+fi
+
+if [[ $FOUND_PYENV -ne 1 ]]; then
+    if (( $+commands[brew] )) && dir=$(brew --prefix pyenv 2>/dev/null); then
+        if [[ -d $dir/bin ]]; then
+            export PATH="$PATH:$dir/bin"
+            FOUND_PYENV=1
+        fi
+    fi
+fi
+
+if [[ $FOUND_PYENV -eq 1 ]]; then
     eval "$(pyenv init - zsh)"
     if (( $+commands[pyenv-virtualenv-init] )); then
         eval "$(pyenv virtualenv-init - zsh)"
@@ -15,3 +37,5 @@ else
         echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
     }
 fi
+
+unset FOUND_PYENV dir


### PR DESCRIPTION
This reverts back to looking for pyenv in predefined directories if the `pyenv` command is not found, but discards the setting of `PYENV_ROOT` which should [default to `$HOME/.pyenv` as per their documentation](https://github.com/pyenv/pyenv#environment-variables).

Such search will only be done if the pyenv command is not found, and we will only look for the homebrew prefix if all else fails. This way the load will take progressively longer as is needed, not taking so long for everybody as it did before.

This should satisfy users who complained that, after #6165, they can no longer use pyenv due to it not being found in their `$PATH` (see https://github.com/robbyrussell/oh-my-zsh/pull/6165#issuecomment-385840876, https://github.com/robbyrussell/oh-my-zsh/commit/8efcf2776b2e7e00c073b149f76c04715aa695d3).

Fixes #6810.

cc @cyphus @Kriechi @quietcoolwu @humitos @ysolis @brandonb927 @yuvalek