### PR TITLE
last-working-dir: disable chpwd_last_working_dir in subshells

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -4,8 +4,10 @@ typeset -g ZSH_LAST_WORKING_DIRECTORY
 # Updates the last directory once directory is changed
 chpwd_functions+=(chpwd_last_working_dir)
 chpwd_last_working_dir() {
-	local cache_file="$ZSH_CACHE_DIR/last-working-dir"
-	pwd >| "$cache_file"
+	if [ "$ZSH_SUBSHELL" = 0 ]; then
+		local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+		pwd >| "$cache_file"
+	fi
 }
 
 # Changes directory to the last working directory


### PR DESCRIPTION
This PR tries to make `last-working-dir` work more nicely with other shell plugins that change directory internally under subshells, e.g. [shrink-path](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/shrink-path/shrink-path.plugin.zsh#L96-L124).

`shrink-path` relies on the subshell exit to return the user to the correct working dir, but subshell exit does not trigger `chpwd_functions`. As a result, `last-working-dir` gets confused, recording the subshell's last working dir, and forgetting my actual working dir.

This PR works around the issue by disabling `chpwd_last_working_dir` in subshells.

#### Extra Details...

Here is a minimal reproduction of the current symptom:
```bash
> cd /usr
> cd /var
> pwd
/var
> cat "$ZSH_CACHE_DIR/last-working-dir"
/var
```
Up to here everything is normal--`last-working-dir` always records my current working dir. This is as expected.

```bash
> cd /usr
> (cd /var)
> pwd
/usr
> cat "$ZSH_CACHE_DIR/last-working-dir"
/var
```
Here `last-working-dir` has diverged, since it has followed the subshell, but my actual session has not. This is probably not the desired behavior.

Here's a final example, running my modifications
```bash
> cd /usr
> (cd /var)
> pwd
/usr
> cat "$ZSH_CACHE_DIR/last-working-dir"
/usr
```
`last-working-dir` stays in sync with my session, because the dir change under the subshell is ignored. This is my preferred behavior.