### PR TITLE
Quotes around EDITOR variable for proper argument passing

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -6,6 +6,6 @@ if [ $commands[fasd] ]; then # check if fasd is installed
   source "$fasd_cache"
   unset fasd_cache
 
-  alias v="f -e $EDITOR"
+  alias v="f -e \"$EDITOR\""
   alias o='a -e open_command'
 fi


### PR DESCRIPTION
If `EDITOR` variable contains arguments to an editor such as mine:
`export EDITOR=emacsclient -t -c --alternate-editor=''`
Then, the editor's arguments are passed on to `fasd`. To fix this, pass the EDITOR program in quotes.