### PR TITLE
Reword the update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -42,7 +42,7 @@ if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
       if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then
         _upgrade_zsh
       else
-        echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
+        echo "[Oh My Zsh] Would you like to update? [Y/n]: \c"
         read line
         if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
           _upgrade_zsh


### PR DESCRIPTION
`[Oh My Zsh] Would you like to check for updates? [Y/n]: ` does not make sense, since answering yes will download/apply the new updates instead of checking for them.

Fixes #6643 