### PR TITLE
Disable menu-select completion on buggy zsh versions

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -11,7 +11,11 @@ setopt always_to_end
 
 # should this be in keybindings?
 bindkey -M menuselect '^o' accept-and-infer-next-history
-zstyle ':completion:*:*:*:*:*' menu select
+
+# These versions delete the prompt on CTRL+C while on menu selection
+if ! [[ $ZSH_VERSION == 5.1.1 || $ZSH_VERSION == 5.2 ]]; then
+  zstyle ':completion:*' menu select
+fi
 
 # case insensitive (all), partial-word and substring completion
 if [[ "$CASE_SENSITIVE" = true ]]; then


### PR DESCRIPTION
Also abbreviate zstyle syntax.

From https://github.com/robbyrussell/oh-my-zsh/issues/6818#issuecomment-389110400:
> I've narrowed it down to versions between https://github.com/zsh-users/zsh/commit/32f5d3d8c16b4f3a11fa39c0ee378d72336ba853 (which introduces the bug) and https://github.com/zsh-users/zsh/commit/1d8b5285226afba4f1ef9030cf862c14b975c284 (which fixes it). 
> That means that versions 5.1.1 and 5.2 have this bug (first reported [here](http://www.zsh.org/mla/workers/2015/msg03349.html)).

Fixes #6818.

cc @orlp