### PR TITLE
[shrink-path plugin] unset chpwd_functions before running `cd`

### DIFF
--- a/plugins/shrink-path/shrink-path.plugin.zsh
+++ b/plugins/shrink-path/shrink-path.plugin.zsh
@@ -94,6 +94,11 @@ shrink_path () {
         (( tilde )) && dir=${dir/$HOME/\~}
         tree=(${(s:/:)dir})
         (
+                # unset chpwd_functions since we'll be calling `cd` and don't
+                # want any side-effects (eg., if the user was using auto-ls)
+                chpwd_functions=()
+                # unset chpwd since even if chpwd_functions is (), zsh will
+                # attempt to execute chpwd
                 unfunction chpwd 2> /dev/null
                 if [[ $tree[1] == \~* ]] {
                         cd ${~tree[1]}


### PR DESCRIPTION
This avoids side-effects if the user has set any `chpwd_functions` which cause output, such as is the case if the user is using `auto-ls`.

I was using `auto-ls` plugin alongside shrink-path in `agnoster` them. I had, in my `.zshrc` file:

```
ZSH_THEME="agnoster"
plugins=(git autojump lol colored-man-pages copyzshell shrink-path)
AUTO_LS_COMMANDS=(ls)
AUTO_LS_NEWLINE=false
```

Without this fix, my prompt was filled with the contents of my home directory. It took up the whole terminal, hahaha.

