### PR TITLE
[plugins/vundle] Use HTTPS to clone repository.

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -6,7 +6,7 @@ function vundle-init () {
 
   if [ ! -d ~/.vim/bundle/Vundle.vim/.git ] && [ ! -f ~/.vim/bundle/Vundle.vim/.git ]
   then
-    git clone git://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+    git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
     echo "\n\tRead about vim configuration for vundle at https://github.com/VundleVim/Vundle.vim\n"
   fi
 }


### PR DESCRIPTION
The git protocol is likely to be blocked in some networks while HTTPS usually
works.