### PR TITLE
Remove po alias

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -28,7 +28,3 @@ alias lsa='ls -lah'
 alias l='ls -lah'
 alias ll='ls -lh'
 alias la='ls -lAh'
-
-# Push and pop directories on directory stack
-alias pu='pushd'
-alias po='popd'


### PR DESCRIPTION
Fixes #6761

>I am the lead maintainer for po, a tool that provides a great command line experience for Particle users.
>
>Many po users are oh-my-zsh users. Those who are oh-my-zsh users annoyed when they are unable to use po because of the popd conflict. Several users are not savvy enough with the command line to disable the po alias to resolve the conflict, and it pains me to hear from a user that oh-my-zsh is interfering with their Particle workflow.
>
>All I ask is that you no longer make po be an alias for popd. It conflicts with po, and popd is a pretty uncommon command. I don't see why it is necessary to make a two letter alias for a four letter command.
>
>Thanks