### PR TITLE
[plugins/archlinux] add alias for yay

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -2,6 +2,26 @@
 
 ## Features
 
+#### YAY
+
+| Alias   | Command                            | Description                                                         |
+|---------|------------------------------------|---------------------------------------------------------------------|
+| yaconf  | yay -Pg                            | Print current configuration                                         |
+| yain    | yay -S                             | Install packages from the repositories                              |
+| yains   | yay -U                             | Install a package from a local file                                 |
+| yainsd  | yay -S --asdeps                    | Install packages as dependencies of another package                 |
+| yaloc   | yay -Qi                            | Display information about a package in the local database           |
+| yalocs  | yay -Qs                            | Search for packages in the local database                           |
+| yalst   | yay -Qe                            | List installed packages including from AUR (tagged as "local")      |
+| yamir   | yay -Syy                           | Force refresh of all package lists after updating mirrorlist        |
+| yaorph  | yay -Qtd                           | Remove orphans using yaourt                                         |
+| yare    | yay -R                             | Remove packages, keeping its settings and dependencies              |
+| yarem   | yay -Rns                           | Remove packages, including its settings and unneeded dependencies   |
+| yarep   | yay -Si                            | Display information about a package in the repositories             |
+| yareps  | yay -Ss                            | Search for packages in the repositories                             |
+| yaupg   | yay -Syu                           | Sync with repositories before upgrading packages                    |
+| yasu    | yay -Syu --no-confirm              | Same as `yaupg`, but without confirmation                           |
+
 #### TRIZEN
 
 | Alias   | Command                            | Description                                                         |

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -56,6 +56,35 @@ if (( $+commands[yaourt] )); then
   fi
 fi
 
+if (( $+commands[yay] )); then
+  alias yaconf='yay -Pg'
+  alias yaupg='yay -Syu'
+  alias yasu='yay -Syu --noconfirm'
+  alias yain='yay -S'
+  alias yains='yay -U'
+  alias yare='yay -R'
+  alias yarem='yay -Rns'
+  alias yarep='yay -Si'
+  alias yareps='yay -Ss'
+  alias yaloc='yay -Qi'
+  alias yalocs='yay -Qs'
+  alias yalst='yay -Qe'
+  alias yaorph='yay -Qtd'
+  alias yainsd='yay -S --asdeps'
+  alias yamir='yay -Syy'
+
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias yaupd='yay -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias yaupd='yay -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias yaupd='yay -Sy && sudo aur'
+  else
+    alias yaupd='yay -Sy'
+  fi
+fi
+
 if (( $+commands[pacaur] )); then
   alias paupg='pacaur -Syu'
   alias pasu='pacaur -Syu --noconfirm'
@@ -91,9 +120,9 @@ elif (( $+commands[pacaur] )); then
   function upgrade() {
     pacaur -Syu
   }
-elif (( $+commands[yaourt] )); then
+elif (( $+commands[yay] )); then
   function upgrade() {
-    yaourt -Syu
+    yay -Syu
   }
 else
   function upgrade() {

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -120,6 +120,11 @@ elif (( $+commands[pacaur] )); then
   function upgrade() {
     pacaur -Syu
   }
+  }
+elif (( $+commands[yaourt] )); then
+  function upgrade() {
+    yay -Syu
+  }
 elif (( $+commands[yay] )); then
   function upgrade() {
     yay -Syu

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -122,7 +122,7 @@ elif (( $+commands[pacaur] )); then
   }
 elif (( $+commands[yaourt] )); then
   function upgrade() {
-    yay -Syu
+    yaourt -Syu
   }
 elif (( $+commands[yay] )); then
   function upgrade() {

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -120,7 +120,6 @@ elif (( $+commands[pacaur] )); then
   function upgrade() {
     pacaur -Syu
   }
-  }
 elif (( $+commands[yaourt] )); then
   function upgrade() {
     yay -Syu


### PR DESCRIPTION
[Yay](https://github.com/Jguer/yay) another Yogurt - An AUR Helper written in Go

Considering the  [Arch wiki: AUR helpers](https://wiki.archlinux.org/index.php/AUR_helpers), I think `yay` is more robust and powerful than `yaourt`.

I alias `yay` with the same commands as `yaourt`, I think most people will not use them together.