### PR TITLE
remove unnecessary warning from virtualenvwrapper.plugin.zsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ custom/
 # temp files directories
 cache/
 log/
+
+.DS_Store

--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -39,11 +39,6 @@ if ! type workon &>/dev/null; then
   return
 fi
 
-if [[ "$WORKON_HOME" == "" ]]; then
-  print "[oh-my-zsh] \$WORKON_HOME is not defined so plugin virtualenvwrapper will not work" >&2
-  return
-fi
-
 if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
   # Automatically activate Git projects or other customized virtualenvwrapper projects based on the
   # directory name of the project. Virtual environment name can be overridden


### PR DESCRIPTION
I think this warning message is meaningless since 90a5bd06ca76aff04f76a5d43a432ed9340dd78d (from https://github.com/robbyrussell/oh-my-zsh/pull/6842), the reason being:

* if virtualenvwrapper.sh is being used, $WORKON_HOME will be
immediately (to the default value), no need for this warning
* if virtualenvwrapper_lazy.sh is being used, $WORKON_HOME will be set
(to the default value) later, automatically:

![image](https://user-images.githubusercontent.com/4319104/40639206-465a7974-6342-11e8-934c-dadc2786b8e6.png)

* if none of the initialization scripts are available, for example
if virtualenvwrapper was uninstalled, the installation command will be
printed during zsh start:

![image](https://user-images.githubusercontent.com/4319104/40639223-603c68ca-6342-11e8-8371-0c7391e15d4d.png)