### PR TITLE
Only use virtualenvwrapper_lazy when WORKON_HOME is set

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,7 +1,7 @@
 virtualenvwrapper='virtualenvwrapper.sh'
 virtualenvwrapper_lazy='virtualenvwrapper_lazy.sh'
 
-if (( $+commands[$virtualenvwrapper_lazy] )); then
+if (( $+commands[$virtualenvwrapper_lazy] )) && [ "$WORKON_HOME" != "" ]; then
   function {
     setopt local_options
     unsetopt equals


### PR DESCRIPTION
Fix [#6882](https://github.com/robbyrussell/oh-my-zsh/issues/6882)

As I described in the issue. `workon_cwd` relies on `$WORKON_HOME` so we cannot use `virtualenvwrapper_lazy` unless the `$WORKON_HOME` is already manually set.