### PR TITLE
Enable passing multiple directories to take

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -11,8 +11,8 @@ function upgrade_oh_my_zsh() {
 }
 
 function take() {
-  mkdir -p $1
-  cd $1
+  mkdir -p $@
+  cd ${@:$#}
 }
 
 function open_command() {

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -11,8 +11,7 @@ function upgrade_oh_my_zsh() {
 }
 
 function take() {
-  mkdir -p $@
-  cd ${@:$#}
+  mkdir -p $@ && cd ${@:$#}
 }
 
 function open_command() {


### PR DESCRIPTION
This change enables the `take` function to support multiple directories (mirroring `mkdir`). Before this change, `take A B C` would create a directory `A` and `cd` into it, while silently ignoring `B` and `C`. Now it will make all three directories and `cd` into `C`.

It also allows passing arguments to `mkdir`. Before this change:

    $ take --mode=777 xyz
    mkdir: missing operand
    Try 'mkdir --help' for more information.
    take:cd:2: no such file or directory: --mode=777

but this change allows the above to work correctly.

This should not break any current usage of `take`, since before only a single argument was supported. If someone had been doing `take A B C` before, it will now have a different result, but since that was almost certainly not doing what they intended, it seems like a safe change.