### PR TITLE
Fixed curl-output used for auto-completion

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
 function gi() { curl -fL https://www.gitignore.io/api/${(j:,:)@} }
 
 _gitignoreio_get_command_list() {
-  curl -fL https://www.gitignore.io/api/list | tr "," "\n"
+  curl -sfL https://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignoreio () {


### PR DESCRIPTION
Removed the status-output with the `-s` argument.