### PR TITLE
Allow arguments to `d` to be passed to dirs

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -21,7 +21,14 @@ alias 9='cd -9'
 
 alias md='mkdir -p'
 alias rd=rmdir
-alias d='dirs -v | head -10'
+function d () {
+  if [[ -n $1 ]]; then
+    dirs "$@"
+  else
+    dirs -v | head -10
+  fi
+}
+compdef _dirs d
 
 # List directory contents
 alias lsa='ls -lah'


### PR DESCRIPTION
Replace the alias with a function. Call `dirs` if arguments are given to `d`.

I think this should be purely feature-enabling, if there's a better way to do this let me know.