### PR TITLE
Create super useful gac and gacp aliases

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -248,3 +248,25 @@ alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip-- [skip ci]"'
+
+gac() {
+  if [ $# -ge 2 ]; then
+    git add "${@: 1:-1}" && git commit -m "${@: -1}"
+  elif [ $# -eq 1 ]; then
+    git add -A && git commit -m "$1"
+  else
+    git add -A && git commit
+  fi
+}
+
+
+gacp() {
+  if [ $# -ge 2 ]; then
+    git add "${@: 1:-1}" && git commit -m "${@: -1}"
+  elif [ $# -eq 1 ]; then
+    git add -A && git commit -m "$1"
+  else
+    git add -A && git commit
+  fi
+  git push
+}


### PR DESCRIPTION
`gac` will add all files and will open your editor to commit everything
`gac 'Initial commit'` will add all files and commit with the message 'Initial commit'
`gac  plugins/git/git.plugin.zsh 'Create super useful gac and gacp aliases'` will add the plugin file with the commit message. You can list as many files/folders that you'd like to commit

gacp has the same functionality but will also push your commit