### PR TITLE
Fix open_command for WSL environment

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -22,9 +22,10 @@ function open_command() {
   case "$OSTYPE" in
     darwin*)  open_cmd='open' ;;
     cygwin*)  open_cmd='cygstart' ;;
-    linux*)   [[ $(uname -a) =~ "Microsoft" ]] && \
-                open_cmd='cmd.exe /c start' || \
-                open_cmd='xdg-open' ;;
+    linux*)   ! [[ $(uname -a) =~ "Microsoft" ]] && open_cmd='xdg-open' || {
+                open_cmd='cmd.exe /c start ""'
+                [[ -e "$1" ]] && { 1="$(wslpath -w "${1:a}")" || return 1 }
+              } ;;
     msys*)    open_cmd='start ""' ;;
     *)        echo "Platform $OSTYPE not supported"
               return 1

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -16,9 +16,6 @@ function take() {
 }
 
 function open_command() {
-  emulate -L zsh
-  setopt shwordsplit
-
   local open_cmd
 
   # define the open command
@@ -36,9 +33,9 @@ function open_command() {
 
   # don't use nohup on OSX
   if [[ "$OSTYPE" == darwin* ]]; then
-    $open_cmd "$@" &>/dev/null
+    ${=open_cmd} "$@" &>/dev/null
   else
-    nohup $open_cmd "$@" &>/dev/null
+    nohup ${=open_cmd} "$@" &>/dev/null
   fi
 }
 


### PR DESCRIPTION
* Simplifies code

* Fix WSL code:

	- Add double quotes to command so that the next argument isn't interpreted as the title for the start command.
	
	- If the first argument is a valid path, convert it to Windows path notation. If `wslpath` fails—because it's a path from inside WSL, which cannot be converted to Windows path notation— fail with an error code.
	
	  This last circumstance will show an error like so:
	
	  > wslpath: path: Result not representable

## TODO

- [x] Test on Linux
- [x] Test for any number of passed arguments
- [x] Test on paths with spaces