### PR TITLE
History file is truncated to 10000 lines on zsh exit

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -28,8 +28,8 @@ esac
 
 ## History file configuration
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
-HISTSIZE=50000
-SAVEHIST=10000
+[ -z "$HISTSIZE" ] && HISTSIZE=50000
+[ -z "$SAVEHIST" ] && SAVEHIST=10000
 
 ## History command configuration
 setopt extended_history       # record timestamp of command in HISTFILE


### PR DESCRIPTION
Fix: Do not override values of ```HISTSIZE``` and ```SAVEHIST``` in ```lib/history.zsh``` if configured previously
This causes history file to be truncated to 10000 lines on exit