### PR TITLE
wp-cli: fix README typo for wptu command

### DIFF
--- a/plugins/wp-cli/README.md
+++ b/plugins/wp-cli/README.md
@@ -75,7 +75,7 @@ This plugin adds [tab completion](http://wp-cli.org/#complete) for `wp-cli` as w
 - wptp='wp theme path'
 - wpts='wp theme search'
 - wptst='wp theme status'
-- wptu='wp theme updatet'
+- wptu='wp theme update'
 
 ### User
 - wpuac='wp user add-cap'


### PR DESCRIPTION
Fixes typo in `wptu` command for wp-cli plugin's README file. Was previously `wp theme updatet` and now, it's `wp theme update`