### PR TITLE
git-prompt: fix error when multiple tags exist

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -22,7 +22,7 @@ def get_tagname_or_hash():
         tagname = 'tags/' + output[m.start()+len('tag: '): m.end()-1]
 
     if tagname:
-        return tagname
+        return tagname.replace(' ', '')
     elif hash_:
         return hash_
     return None


### PR DESCRIPTION
When a commit has multiple tags associated to it, the git-prompt will
throw the following error:

git_super_status:[:4: integer expression expected: v0.21.x\ntags/v0.21.5,
git_super_status:[:7: integer expression expected: origin/v0.21.x,
git_super_status:[:11: integer expression expected: origin/v0.21.x,
git_super_status:[:14: integer expression expected: v0.21.x
git_super_status:[:23: integer expression expected: v0.21.x

This is due to the prompt expecting the tag field to be a single word
with no spaces in between but if there are multiple tags the python
script returns a string with ', ' space separated list of tags.
This throws off the parser. The solution is to ensure that the python
script returns a space-less string ensuring the git-prompt parser to
properly parse the data.

Signed-off-by: Thanh Ha <zxiiro@linux.com>