### PR TITLE
Replace the current shell with the new ZSH instance

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -108,7 +108,7 @@ main() {
   echo 'p.p.s. Get stickers and t-shirts at https://shop.planetargon.com.'
   echo ''
   printf "${NORMAL}"
-  env zsh -l
+  exec env zsh -l
 }
 
 main


### PR DESCRIPTION
This Replaces the currently running ZSH process with the new one using `exec` instead of creating a new Process.
This way, when the user `exit`s out of the the new shell it will not pop them back into the shell from which oh-my-zsh was installed from.