### PR TITLE
Fixed `fwl` function in `firewalld` plugin when `sources` used

### DIFF
--- a/plugins/firewalld/firewalld.plugin.zsh
+++ b/plugins/firewalld/firewalld.plugin.zsh
@@ -6,7 +6,7 @@ alias fwrp="sudo firewall-cmd --runtime-to-permanent"
 function fwl () {
   # converts output to zsh array ()
   # @f flag split on new line
-  zones=("${(@f)$(sudo firewall-cmd --get-active-zones | grep -v interfaces)}")
+  zones=("${(@f)$(sudo firewall-cmd --get-active-zones | grep -v 'interfaces\|sources')}")
 
   for i in $zones; do
     sudo firewall-cmd --zone $i --list-all


### PR DESCRIPTION
`firewall-cmd --get-active-zones` returns something like this:

```
dmz
  sources: ipset:dmz-hosts
public
  interfaces: eth0
```

if zone binding is based on source ips, so strings with `sources: ...` should be excluded along with `interfaces: ...` to get zones list.