### PR TITLE
Insert alias to checkout changed files

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -77,6 +77,7 @@ alias gcm='git checkout master'
 alias gcd='git checkout develop'
 alias gcmsg='git commit -m'
 alias gco='git checkout'
+alias gcall='git checkout --'
 alias gcount='git shortlog -sn'
 compdef _git gcount
 alias gcp='git cherry-pick'


### PR DESCRIPTION
`git checkout -- .` undo changes for all files that is not added or commited. I added an alias `gcall` (git checkout (all)) (files).

Example:
```
> gcall .
> gcall path/to/file
```