### PR TITLE
Add plugin README template

### DIFF
--- a/plugins/plugin.README.template.md
+++ b/plugins/plugin.README.template.md
@@ -1,0 +1,35 @@
+# README TEMPLATE
+The following is a template to be used when submitting plugins.
+Please fill out any relevant sections below and include with your plugin files:
+
+# Title
+
+* Description
+* What it does, benifits etc
+
+## Requirements
+
+* List all software and task's before this plugin can be used
+* 
+
+## Configuration
+
+* List $VARIRABLES or other config that can be set
+
+## Usage
+
+* brief description of usage
+
+## Aliases
+
+| Alias| Command   | Description   |
+|------|-----------|---------------|
+| l    | ls -la    | list all files|
+
+## Functions
+
+* do_stuff - do some stuff when condition is met
+
+## Maintiner/s /Authors
+
+[@D-sha](https://github.com/d-sha) / email@domain.com


### PR DESCRIPTION
Add a default plugin readme template

I thought it may be helpful to have a template for plugin README's
then plugins can be required to have a readme before being merged.

Does anyone else think is a good idea?
Comments on format or content?