### PR TITLE
Feat: Adding untacked file changes before upgrade

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -20,8 +20,18 @@ else
   NORMAL=""
 fi
 
-printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Zsh"
+STASH_NAME="STASH BEFORE UPDATING"
+
 cd "$ZSH"
+
+if [ -n "$(git status --untracked-files=no --porcelain)" ]; then
+  # Working directory clean excluding untracked files
+  printf "${YELLOW}%s${NORMAL}\n" "Found untracked files, automatically stash for you."
+  git stash save "${STASH_NAME}" >/dev/null
+fi
+
+printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Zsh"
+
 if git pull --rebase --stat origin master
 then
   printf '%s' "$GREEN"
@@ -31,9 +41,16 @@ then
   printf '%s\n' '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
   printf '%s\n' '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
   printf '%s\n' '                        /____/                       '
+
+  if [ -n "$(git stash list | grep "${STASH_NAME}")" ]; then
+    printf "${YELLOW}%s${NORMAL}\n" "Automatically pop untracked files for you."
+    git stash pop >/dev/null
+  fi
+  
   printf "${BLUE}%s\n" "Hooray! Oh My Zsh has been updated and/or is at the current version."
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "To keep up on the latest news and updates, follow us on twitter: https://twitter.com/ohmyzsh"
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "Get your Oh My Zsh swag at:  https://shop.planetargon.com/"
 else
   printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
 fi
+


### PR DESCRIPTION
I modified some files in `.oh-my-zsh`.
Every times when I do a `upgrade_oh_my_zsh`, it throws an error, because my git repo is not clean.
So I have to go to the directory and do `git bash && git pull && git stash pop` manually.

I add this code to do it automatically, if you have untracked files, then stash for you.

This is the testing result:
![uploadfile](https://user-images.githubusercontent.com/2182004/43622059-fbea99c4-970c-11e8-9150-d9a58ff188b8.png)