### PR TITLE
delete update.lock first incase it already exist

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -29,7 +29,7 @@ fi
 # Cancel upgrade if git is unavailable on the system
 whence git >/dev/null || return 0
 
-# delete update.lock if it alreday exist
+# Delete update.lock if it alreday exists
 rmdir $ZSH/log/update.lock 2>/dev/null
 
 if mkdir "$ZSH/log/update.lock" 2>/dev/null; then

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -29,6 +29,9 @@ fi
 # Cancel upgrade if git is unavailable on the system
 whence git >/dev/null || return 0
 
+# delete update.lock if it alreday exist
+rmdir $ZSH/log/update.lock 2>/dev/null
+
 if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
   if [ -f ${ZSH_CACHE_DIR}/.zsh-update ]; then
     . ${ZSH_CACHE_DIR}/.zsh-update


### PR DESCRIPTION
Fix check_for_upgrade does not work on shell init

delete update.lock first incase it already exist

[issue 7036](https://github.com/robbyrussell/oh-my-zsh/issues/7036)