### PR TITLE
I've added a small selection of cloudfoundry aliases and functions...

### DIFF
--- a/plugins/cloudfoundry/cloudfoundry.plugin.zsh
+++ b/plugins/cloudfoundry/cloudfoundry.plugin.zsh
@@ -1,0 +1,30 @@
+# Some Useful CloudFoundry Aliases & Functions
+alias cfl="cf login"
+alias cft="cf target"
+alias cfa="cf apps"
+alias cfs="cf services"
+alias cfm="cf marketplace"
+alias cfp="cf push"
+alias cfcs="cf create-service"
+alias cfbs="cf bind-service"
+alias cfus="cf unbind-service"
+alias cfds="cf delete-service"
+alias cfup="cf cups"
+alias cfp="cf push"
+alias cflg="cf logs"
+alias cfr="cf routes"
+alias cfe="cf env"
+alias cfsh="cf ssh"
+alias cfsc="cf scale"
+alias cfev="cf events"
+function cfh.() { export CF_HOME=$(pwd)/.cf }
+function cfh~() { export CF_HOME=~/.cf }
+function cfhu() { unset CF_HOME }
+function cfpm() { cf push -f $1 }
+function cflr() { cf logs $1 --recent }
+function cfsrt() { cf start $1 }
+function cfstp() { cf stop $1 }
+function cfstg() { cf restage $1 }
+function cfdel() { cf delete $1 }
+function cfsrtall() cf apps | awk '/stopped/ { system("cf start " $1)}'
+function cfstpall() cf apps | awk '/started/ { system("cf stop " $1)}'


### PR DESCRIPTION
…as a ZSH plugin for use with the open source cloudfoundry `cf` cli tool. I've been testing them out on my machine and they seem OK, but it would be nice to have them available to other users to see what they think pr what they would like to add.

I searched the oh_my_zsh repo and issues log looking for other cloudfoundry related requests but all I found was this issue which is highlighting a clash but nothing along the same lines as this plugin:  (https://github.com/robbyrussell/oh-my-zsh/pull/3879)