### PR TITLE
Add Git alias for `git diff --staged`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -89,6 +89,7 @@ alias gd='git diff'
 alias gdca='git diff --cached'
 alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags `git rev-list --tags --max-count=1`'
+alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
 alias gdw='git diff --word-diff'
 


### PR DESCRIPTION
An alternative alias for `gdca = git diff --cached`:

> `gds` = `git diff --staged`

Equivalent option according to [git-diff man page](https://linux.die.net/man/1/git-diff).

Mentioned in #3167.