### PR TITLE
Remove the white space

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -1,4 +1,4 @@
-alias be="bundle exec "
+alias be="bundle exec"
 alias bl="bundle list"
 alias bp="bundle package"
 alias bo="bundle open"


### PR DESCRIPTION
The white space is causing an error and bundler cannot find any commands!

```sh
bundler: command not found: _rails_command
Install missing gem executables with `bundle install`
```