### PR TITLE
.gitingore prevents adding itself, so breaks the function.

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -36,7 +36,7 @@ new_gh() { # [DIRECTORY]
   print '.*'"\n"'*~' >> .gitignore
   git add [^.]* \
     || return
-  git add .gitignore \
+  git add -f .gitignore \
     || return
   git commit -m 'Initial commit.' \
     || return


### PR DESCRIPTION
Change `git add .gitignore` to `git add -f .gitignore`.