### PR TITLE
add aliases for interacting with k8s namespaces & configmaps

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -43,6 +43,12 @@ alias kei='k edit ingress'
 alias kdi='k describe ingress'
 alias kdeli='k delete ingress'
 
+# Namespace management
+alias kgns='k get namespaces'
+alias kens='k edit namespace'
+alias kdns='k describe namespace'
+alias kdelns='k delete namespace'
+
 # Secret management
 alias kgsec='k get secret'
 alias kdsec='k describe secret'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -49,6 +49,12 @@ alias kens='k edit namespace'
 alias kdns='k describe namespace'
 alias kdelns='k delete namespace'
 
+# ConfigMap management
+alias kgcm='k get configmaps'
+alias kecm='k edit configmap'
+alias kdcm='k describe configmap'
+alias kdelcm='k delete configmap'
+
 # Secret management
 alias kgsec='k get secret'
 alias kdsec='k describe secret'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -44,16 +44,16 @@ alias kdi='k describe ingress'
 alias kdeli='k delete ingress'
 
 # Namespace management
-alias kgns='k get namespaces'
-alias kens='k edit namespace'
-alias kdns='k describe namespace'
-alias kdelns='k delete namespace'
+alias kgns='kubectl get namespaces'
+alias kens='kubectl edit namespace'
+alias kdns='kubectl describe namespace'
+alias kdelns='kubectl delete namespace'
 
 # ConfigMap management
-alias kgcm='k get configmaps'
-alias kecm='k edit configmap'
-alias kdcm='k describe configmap'
-alias kdelcm='k delete configmap'
+alias kgcm='kubectl get configmaps'
+alias kecm='kubectl edit configmap'
+alias kdcm='kubectl describe configmap'
+alias kdelcm='kubectl delete configmap'
 
 # Secret management
 alias kgsec='k get secret'


### PR DESCRIPTION
Tiny addition to the `kubectl` plugin for interacting with `namespaces` & `configmaps`.