### PR TITLE
Fixes jump plugin printf path output

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -32,7 +32,7 @@ marks() {
 		local markname="$fg[cyan]${link:t}$reset_color"
 		local markpath="$fg[blue]$(readlink $link)$reset_color"
 		printf "%s\t" $markname
-		printf "~> %s \t\n" $markpath
+		printf -- "-> %s \t\n" $markpath
 	done
 }
 

--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -32,7 +32,7 @@ marks() {
 		local markname="$fg[cyan]${link:t}$reset_color"
 		local markpath="$fg[blue]$(readlink $link)$reset_color"
 		printf "%s\t" $markname
-		printf "-> %s \t\n" $markpath
+		printf "~> %s \t\n" $markpath
 	done
 }
 


### PR DESCRIPTION
Using the `jump` plugin, using the `marks` command will yield this output:
```
$ marks
desktop marks:printf:5: bad option: ->
dotfiles        marks:printf:5: bad option: ->
home    marks:printf:5: bad option: ->
```

the `marks` function uses `printf` with `->` and I believe `-` is used by `printf` for left-justification.  changing this to `-- "->"` seems to render the appropriate output.

```
desktop -> /Users/uname/Desktop
dotfiles        -> /Users/uname/.dotfiles
home    -> /Users/uname
```