### PR TITLE
fzf: Fix shell directory for archlinux package

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -24,6 +24,13 @@ fi
 
 if [[ -n "${fzf_base}" ]]; then
 
+  # Fix fzf shell directory for Archlinux package
+  if [[ ! -d "${fzf_base}/shell" ]] && [[ "$(uname -n)" == 'archlinux' ]]; then
+    fzf_shell="${fzf_base}"
+  else
+    fzf_shell="${fzf_base}/shell"
+  fi
+
   # Setup fzf
   # ---------
   if [[ ! "$PATH" == *$fzf_base/bin* ]]; then
@@ -33,13 +40,13 @@ if [[ -n "${fzf_base}" ]]; then
   # Auto-completion
   # ---------------
   if [[ ! "$DISABLE_FZF_AUTO_COMPLETION" == "true" ]]; then
-    [[ $- == *i* ]] && source "$fzf_base/shell/completion.zsh" 2> /dev/null
+    [[ $- == *i* ]] && source "${fzf_shell}/completion.zsh" 2> /dev/null
   fi
   
   # Key bindings
   # ------------
   if [[ ! "$DISABLE_FZF_KEY_BINDINGS" == "true" ]]; then
-    source "$fzf_base/shell/key-bindings.zsh"
+    source "${fzf_shell}/key-bindings.zsh"
   fi
 
 else

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -54,4 +54,4 @@ else
         "Please add \`export FZF_BASE=/path/to/fzf/install/dir\` to your .zshrc" >&2
 fi
 
-unset fzf_base
+unset fzf_base fzf_shell dir fzfdirs

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -25,7 +25,7 @@ fi
 if [[ -n "${fzf_base}" ]]; then
 
   # Fix fzf shell directory for Archlinux package
-  if [[ ! -d "${fzf_base}/shell" ]] && [[ "$(uname -n)" == 'archlinux' ]]; then
+  if [[ ! -d "${fzf_base}/shell" ]] && [[ -f /etc/arch-release ]]; then
     fzf_shell="${fzf_base}"
   else
     fzf_shell="${fzf_base}/shell"

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -33,7 +33,7 @@ if [[ -n "${fzf_base}" ]]; then
 
   # Setup fzf
   # ---------
-  if [[ ! "$PATH" == *$fzf_base/bin* ]]; then
+  if ! (( ${+commands[fzf]} )) && [[ ! "$PATH" == *$fzf_base/bin* ]]; then
     export PATH="$PATH:$fzf_base/bin"
   fi
   


### PR DESCRIPTION
A small change to fix #7110, I keep it minimal to stay as close possible to the [upstream install script](https://github.com/junegunn/fzf/blob/8540902a35361dba217cc3ad86ff2215ae51918e/install#L266-L278).

I also made a change to not clutter PATH if `fzf` is already available.

I tested these changes on the following `fzf` installations:
* MacOS + brew
* Archlinux + Pacman
* Fedora + RPM
* Linux + Git