### PR TITLE
dash: update dash bundle identifier

### DIFF
--- a/plugins/dash/dash.plugin.zsh
+++ b/plugins/dash/dash.plugin.zsh
@@ -11,7 +11,7 @@ _dash() {
     # Use defaults to get the array of docsets from preferences
     # Have to smash it into one big line so that each docset is an element of
     # our DOCSETS array
-    DOCSETS=("${(@f)$(defaults read com.kapeli.dash docsets | tr -d '\n' | grep -oE '\{.*?\}')}")
+    DOCSETS=("${(@f)$(defaults read com.kapeli.dashdoc docsets | tr -d '\n' | grep -oE '\{.*?\}')}")
 
     # remove all newlines since defaults prints so pretty like
     # Now get each docset and output each on their own line


### PR DESCRIPTION
At some point the bundle identifier for Dash updated.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/7786383/45328822-c0030280-b51a-11e8-87c9-987d0306ca48.png">
