### PR TITLE
kdialog title option with double dash

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -42,7 +42,7 @@ bgnotify () { ## args: (title, subtitle)
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!
     notify-send "$1" "$2"
   elif hash kdialog 2>/dev/null; then #ubuntu kde!
-    kdialog  -title "$1" --passivepopup  "$2" 5
+    kdialog  --title "$1" --passivepopup  "$2" 5
   elif hash notifu 2>/dev/null; then #cygwyn support!
     notifu /m "$2" /p "$1"
   fi

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -42,7 +42,7 @@ bgnotify () { ## args: (title, subtitle)
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!
     notify-send "$1" "$2"
   elif hash kdialog 2>/dev/null; then #ubuntu kde!
-    kdialog  --title "$1" --passivepopup  "$2" 5
+    kdialog --title "$1" --passivepopup  "$2" 5
   elif hash notifu 2>/dev/null; then #cygwyn support!
     notifu /m "$2" /p "$1"
   fi


### PR DESCRIPTION
The options for kdialog in KDE use double dashes.