### PR TITLE
Add option to color any help command

### DIFF
--- a/plugins/colored-man-pages/README.md
+++ b/plugins/colored-man-pages/README.md
@@ -1,0 +1,15 @@
+# Colored man pages plugin
+
+This plugin adds colors to man pages.
+
+To use it, add `colored-man-pages` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... colored-man-pages)
+```
+
+You can also try to color other pages by prefixing the respective command with `colored`:
+
+```zsh
+colored git help clone
+```

--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -16,7 +16,7 @@ EOF
 	fi
 fi
 
-function man() {
+function colored() {
 	env \
 		LESS_TERMCAP_mb=$(printf "\e[1;31m") \
 		LESS_TERMCAP_md=$(printf "\e[1;31m") \
@@ -28,5 +28,9 @@ function man() {
 		PAGER="${commands[less]:-$PAGER}" \
 		_NROFF_U=1 \
 		PATH="$HOME/bin:$PATH" \
-			man "$@"
+			"$@"
+}
+
+function man() {
+	colored man "$@"
 }


### PR DESCRIPTION
This allows you to use `colored git log --help` for example, to get
colored output.