### PR TITLE
Added readme file for sudo plugin

### DIFF
--- a/plugins/sudo/README.md
+++ b/plugins/sudo/README.md
@@ -1,0 +1,57 @@
+# sudo
+
+Easily prefix your current or previous commands with `sudo` by pressing <kbd>esc</kbd> twice
+
+## Enabling the plugin
+
+1.  Open your `.zshrc` file and add `sudo` in the plugins section:
+
+    ```zsh
+    plugins=(
+        # all your enabled plugins
+        sudo
+    )
+    ```
+
+2.  Reload the source file or restart your Terminal session:
+
+    ```console
+    $ source ~/.zshrc
+    $
+    ```
+
+## Usage examples
+
+### Current typed commands
+
+Say you have typed a long command and forgot to add `sudo` in front:
+
+```console
+$ apt-get install build-essential
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+
+```console
+$ sudo apt-get install build-essential
+```
+
+### Previous executed commands
+
+Say you want to delete a system file and denied:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$ sudo rm some-system-file.txt
+Password:
+$
+```


### PR DESCRIPTION
I have created a [readme file](https://github.com/grikomsn/oh-my-zsh/blob/master/plugins/sudo/README.md) for the `sudo` plugin, with steps to add the plugin to the `.zshrc` file, and some usage examples. I was planning to add a `asciinema` embed example but I can't replicate some "permission denied" examples, so here's just the readme.

Feedbacks appreciated, and [happy Hacktoberfest](https://hacktoberfest.digitalocean.com/)! 🎉