### PR TITLE
Update vscode.plugin.zsh

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -25,7 +25,7 @@ plugins=(... vscode)
 
 | Alias                   | Command                                                          | Description                       |
 | ----------------------- | ---------------------------------------------------------------- | --------------------------------- |
-| vsce `dir`              | code --extensions-dir `dir`                                      | Set the root path for extensions. |
+| vsced `dir`             | code --extensions-dir `dir`                                      | Set the root path for extensions. |
 | vscie `id or vsix-path` | code --install-extension `extension-id> or <extension-vsix-path` | Installs an extension.            |
 | vscue `id or vsix-path` | code --uninstall-extension `id or vsix-path`                     | Uninstalls an extension.          |
 
@@ -35,4 +35,4 @@ plugins=(... vscode)
 | ------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | vscv         | code --verbose            | Print verbose output (implies --wait).                                                                                |
 | vscl `level` | code --log `level`        | Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. |
-| vsced        | code --disable-extensions | Disable all installed extensions.                                                                                     |
+| vscde        | code --disable-extensions | Disable all installed extensions.                                                                                     |

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -10,10 +10,10 @@ alias vscr='code --reuse-window'
 alias vscw='code --wait'
 alias vscu='code --user-data-dir'
 
-alias vsce='code --extensions-dir'
+alias vsced='code --extensions-dir'
 alias vscie='code --install-extension'
 alias vscue='code --uninstall-extension'
 
 alias vscv='code --verbose'
 alias vscl='code --log'
-alias vsced='code --disable-extensions'
+alias vscde='code --disable-extensions'


### PR DESCRIPTION
cc: @MarsiBarsi 

Changed 2 aliases from
```
alias vsce='code --extensions-dir'
alias vsced='code --disable-extensions'
```
to
```
alias vsced='code --extensions-dir'
alias vscde='code --disable-extensions'
```
Because `vsce` is the command line to publish extensions.