### PR TITLE
Fix behavior when reusing a mark

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -19,7 +19,7 @@ mark() {
 		MARK="$1"
 	fi
 	if read -q \?"Mark $PWD as ${MARK}? (y/n) "; then
-		mkdir -p "$MARKPATH"; ln -s "$PWD" "$MARKPATH/$MARK"
+		mkdir -p "$MARKPATH"; ln -sfh "$PWD" "$MARKPATH/$MARK"
 	fi
 }
 


### PR DESCRIPTION
Force the mark to point to the new dir, replacing the old one.

Fixes the unexpected behavior reported on #7195.