### PR TITLE
More compatible flag for ln

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -19,7 +19,7 @@ mark() {
 		MARK="$1"
 	fi
 	if read -q \?"Mark $PWD as ${MARK}? (y/n) "; then
-		mkdir -p "$MARKPATH"; ln -sfh "$PWD" "$MARKPATH/$MARK"
+		mkdir -p "$MARKPATH"; ln -sfn "$PWD" "$MARKPATH/$MARK"
 	fi
 }
 


### PR DESCRIPTION
The flag '-h' isn't universal across implementation. According to FreeBSD man page for ln you can use 'n'.