### PR TITLE
Create README.md for go plugin

### DIFF
--- a/plugins/go/README.md
+++ b/plugins/go/README.md
@@ -1,0 +1,8 @@
+# Go plugin
+This is a duplicate plugin of the [Golang plugin](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/golang), and now symlinks there.
+
+To use it, add `go` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... go)
+```

--- a/plugins/go/README.md
+++ b/plugins/go/README.md
@@ -1,8 +1,1 @@
-# Go plugin
-This is a duplicate plugin of the [Golang plugin](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/golang), and now symlinks there.
-
-To use it, add `go` to the plugins array in your zshrc file:
-
-```zsh
-plugins=(... go)
-```
+The go plugin is deprecated. Use the [golang plugin](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/golang) instead.


### PR DESCRIPTION
This adds a new README.md for the go plugin, which explains to the user that the go plugin is a duplicate of the golang plugin and now symlinks there. 

For #7175