### PR TITLE
Update dircycle readme for readability and uniformity

### DIFF
--- a/plugins/dircycle/README.md
+++ b/plugins/dircycle/README.md
@@ -2,7 +2,7 @@
 
 Plugin for cycling through the directory stack
 
-This plugins enables directory navigation similar when using back and forward on browsers or common file explorers like Finder or Nautilus. `dircycle` uses a small zle trick that lets you cycle your directory stack left or right using <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd> / <kbd>Right</kbd> . This is useful when moving back and forth between directories in development environments, and can be thought of as kind of a nondestructive pushd/popd.
+This plugin enables directory navigation similar to using back and forward on browsers or common file explorers like Finder or Nautilus. It uses a small zle trick that lets you cycle through your directory stack left or right using <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd> / <kbd>Right</kbd> . This is useful when moving back and forth between directories in development environments, and can be thought of as kind of a nondestructive pushd/popd.
 
 ## Enabling the plugin
 
@@ -75,4 +75,4 @@ bindkey '^[[1;4D' insert-cycledleft
 bindkey '^[[1;4C' insert-cycledright
 ```
 
-You can get the bindkey sequence pressing <kbd>Ctrl</kbd> + <kbd>V</kbd>, then pressing the keyboard shortcut you want to use.
+You can get the bindkey sequence by pressing <kbd>Ctrl</kbd> + <kbd>V</kbd>, then pressing the keyboard shortcut you want to use.

--- a/plugins/dircycle/README.md
+++ b/plugins/dircycle/README.md
@@ -2,9 +2,7 @@
 
 Plugin for cycling through the directory stack
 
-This plugins enables directory navigation similar when using back and forward on browsers or common file explorers like Finder or Nautilus.
-
-This is a small zle trick that lets you cycle your directory stack left or right using Ctrl+Shift+Left/Right. This is useful when moving back and forth between directories in development environments, and can be thought of as kind of a nondestructive pushd/popd.
+This plugins enables directory navigation similar when using back and forward on browsers or common file explorers like Finder or Nautilus. `dircycle` uses a small zle trick that lets you cycle your directory stack left or right using <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd> / <kbd>Right</kbd> . This is useful when moving back and forth between directories in development environments, and can be thought of as kind of a nondestructive pushd/popd.
 
 ## Enabling the plugin
 
@@ -68,10 +66,11 @@ Here's an asciinema cast demonstrating the example above:
 | `insert-cycledleft`  | Change `$CWD` to the previous known stack, binded on <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd> |
 | `insert-cycledright` | Change `$CWD` to the next known stack, binded on <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Right</kbd>    |
 
-You can bind these functions to other key sequences, as long as you know the bindkey sequence:
+## Rebinding keys
 
-For example, these commands bind to Alt+Shift+Left/Right in xterm-256color:
-```
+You can bind these functions to other key sequences, as long as you know the bindkey sequence. For example, these commands bind to <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd> / <kbd>Right</kbd> in `xterm-256color`:
+
+```zsh
 bindkey '^[[1;4D' insert-cycledleft
 bindkey '^[[1;4C' insert-cycledright
 ```


### PR DESCRIPTION
I have updated the `dircycle` readme for readability and uniformity. For example, at PR #7213, the `dircycle` readme describes on how to rebind keys. This should be described on another section unrelated to the "Functions" section. This PR changes the following:

+ Changed keypresses to use the `<kbd>` tag
+ Added "rebinding keys" section
- Removed line break on description
- Removed line break on "rebinding keys"
