### PR TITLE
Added aliases to readme of docker-compose plugin

### DIFF
--- a/plugins/docker-compose/README.md
+++ b/plugins/docker-compose/README.md
@@ -2,3 +2,22 @@
 
 A copy of the completion script from the [docker-compose](https://github.com/docker/compose/blob/master/contrib/completion/zsh/_docker-compose) git repo.
 
+## Aliases
+
+| Alias    | Command                                   | Description                                                 |
+|-------   |-------------------------------------------|-------------------------------------------------------------|
+| dco      | `docker-compose`                          | Docker compose
+| dcb      | `docker-compose build`                    | Build containers
+| dce      | `docker-compose exec`                     | Execute command inside a container
+| dcps     | `docker-compose ps`                       | Lists containers
+| dcrestart| `docker-compose restart`                  | Restat container
+| dcrm     | `docker-compose rm`                       | Remove container
+| dcr      | `docker-compose run`                      | Runs a command in container
+| dcstop   | `docker-compose stop`                     | Stop a container
+| dcup     | `docker-compose up`                       | Builds, (re)creates, starts, and attaches to containers for a service.
+| dcupd    | `docker-compose up -d`                    | Same as dcup, but starts as daemon
+| dcdn     | `docker-compose down`                     | Stops and removes containers
+| dcl      | `docker-compose logs`                     | Show logs of container
+| dclf     | `docker-compose logs -f`                  | Show logs and follow output
+| dcpull   | `docker-compose pull`                     | Pull image of a service
+| dcstart  | `docker-compose start`                    | Start a container

--- a/plugins/docker-compose/README.md
+++ b/plugins/docker-compose/README.md
@@ -1,23 +1,29 @@
-# Docker-compose plugin for oh my zsh
+# Docker-compose
 
-A copy of the completion script from the [docker-compose](https://github.com/docker/compose/blob/master/contrib/completion/zsh/_docker-compose) git repo.
+This plugin provides completion for [docker-compose](https://docs.docker.com/compose/) as well as some
+aliases for frequent docker-compose commands.
+
+To use it, add docker-compose to the plugins array of your zshrc file:
+```
+plugins=(... docker-compose)
+```
 
 ## Aliases
 
-| Alias    | Command                                   | Description                                                 |
-|-------   |-------------------------------------------|-------------------------------------------------------------|
-| dco      | `docker-compose`                          | Docker compose
-| dcb      | `docker-compose build`                    | Build containers
-| dce      | `docker-compose exec`                     | Execute command inside a container
-| dcps     | `docker-compose ps`                       | Lists containers
-| dcrestart| `docker-compose restart`                  | Restat container
-| dcrm     | `docker-compose rm`                       | Remove container
-| dcr      | `docker-compose run`                      | Runs a command in container
-| dcstop   | `docker-compose stop`                     | Stop a container
-| dcup     | `docker-compose up`                       | Builds, (re)creates, starts, and attaches to containers for a service.
-| dcupd    | `docker-compose up -d`                    | Same as dcup, but starts as daemon
-| dcdn     | `docker-compose down`                     | Stops and removes containers
-| dcl      | `docker-compose logs`                     | Show logs of container
-| dclf     | `docker-compose logs -f`                  | Show logs and follow output
-| dcpull   | `docker-compose pull`                     | Pull image of a service
-| dcstart  | `docker-compose start`                    | Start a container
+| Alias     | Command                  | Description                                                      |
+|-----------|--------------------------|------------------------------------------------------------------|
+| dco       | `docker-compose`         | Docker-compose main command                                      |
+| dcb       | `docker-compose build`   | Build containers                                                 |
+| dce       | `docker-compose exec`    | Execute command inside a container                               |
+| dcps      | `docker-compose ps`      | List containers                                                  |
+| dcrestart | `docker-compose restart` | Restart container                                                |
+| dcrm      | `docker-compose rm`      | Remove container                                                 |
+| dcr       | `docker-compose run`     | Run a command in container                                       |
+| dcstop    | `docker-compose stop`    | Stop a container                                                 |
+| dcup      | `docker-compose up`      | Build, (re)create, start, and attach to containers for a service |
+| dcupd     | `docker-compose up -d`   | Same as `dcup`, but starts as daemon                             |
+| dcdn      | `docker-compose down`    | Stop and remove containers                                       |
+| dcl       | `docker-compose logs`    | Show logs of container                                           |
+| dclf      | `docker-compose logs -f` | Show logs and follow output                                      |
+| dcpull    | `docker-compose pull`    | Pull image of a service                                          |
+| dcstart   | `docker-compose start`   | Start a container                                                |


### PR DESCRIPTION
Current readme file of docker-compose plugin doesn't have aliases included. It is added.
Contributes to #7175 