### PR TITLE
disable terraform prompt info in home directory

### DIFF
--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -1,4 +1,6 @@
 function tf_prompt_info() {
+    # dont show 'default' workspace in home dir
+    [[ "$PWD" == ~ ]] && return
     # check if in terraform dir
     if [ -d .terraform ]; then
       workspace=$(terraform workspace show 2> /dev/null) || return


### PR DESCRIPTION
in the home directory there is a .terraform file for modules but it is most likely not an actual directory of terraform scripts. this disables checking for a workspace in the home directory which defaults to [default] if there is no workspace defined, which is unlikely in the home directory. It is possible others have a usecase where this would be desirable though, so maybe this patch should only be enabled with some disable_tf_prompt_in_home_dir type var.