### PR TITLE
Added readme for catimg plugin

### DIFF
--- a/plugins/catimg/README.md
+++ b/plugins/catimg/README.md
@@ -1,0 +1,35 @@
+# catimg
+
+Plugin for displaying images on the terminal using the the `catimg.sh` script provided by [posva](https://github.com/posva/catimg)
+
+## Requirements
+
+- `convert` (ImageMagick)
+
+## Enabling the plugin
+
+1. Open your `.zshrc` file and add `catimg` in the plugins section:
+
+   ```zsh
+   plugins=(
+       # all your enabled plugins
+       catimg
+   )
+   ```
+
+2. Reload the source file or restart your Terminal session:
+
+   ```console
+   $ source ~/.zshrc
+   $
+   ```
+
+## Functions
+
+| Function | Description                              |
+| -------- | ---------------------------------------- |
+| `catimg` | Displays the given image on the terminal |
+
+## Usage examples
+
+[![asciicast](https://asciinema.org/a/204702.png)](https://asciinema.org/a/204702)


### PR DESCRIPTION
I have created a readme for the `catimg` plugin, which contains how to enable the plugin and an asciinema usage example.