### PR TITLE
Adds custom themes directory support to `lstheme`

### DIFF
--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -19,6 +19,5 @@ function theme
 
 function lstheme
 {
-    cd $ZSH/themes
-    ls *zsh-theme | sed 's,\.zsh-theme$,,'
+    (ls $ZSH/themes/ && ls $ZSH_CUSTOM/themes/) | sed 's,\.zsh-theme$,,'
 }


### PR DESCRIPTION
`lstheme` command used to list only the themes listed in `$ZSH/themes/` directory. This commit adds themes in `$ZSH_CUSTOM/themes/` also to the theme listings.