### PR TITLE
Make sure the line begins with a (forward) slash ('/')

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -84,7 +84,7 @@ main() {
     # If this platform provides a "chsh" command (not Cygwin), do it, man!
     if hash chsh >/dev/null 2>&1; then
       printf "${BLUE}Time to change your default shell to zsh!${NORMAL}\n"
-      chsh -s $(grep /zsh$ /etc/shells | tail -1)
+      chsh -s $(grep '^/.*/zsh$' /etc/shells | tail -1)
     # Else, suggest the user do so manually.
     else
       printf "I can't change your shell automatically because this system does not have chsh.\n"


### PR DESCRIPTION
Make sure the line begins with a (forward) slash ('/') - otherwise we risk a situation where a full path to `zsh` is commented in, i.e.:

    #/usr/local/bin/zsh