### PR TITLE
git: add alias for git diff untracked files

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -93,6 +93,7 @@ alias gdct='git describe --tags `git rev-list --tags --max-count=1`'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
 alias gdw='git diff --word-diff'
+alias gdu='git diff /dev/null'
 
 gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff


### PR DESCRIPTION
Add alias `gdu='git diff /dev/null'`

```
$ gdu common/utils.py
```
```
diff --git a/common/utils.py b/common/utils.py
new file mode 100644
index 0000000..d26a7c8
--- /dev/null
+++ b/common/utils.py
@@ -0,0 +1,5 @@
+# -*- coding: UTF-8 -*-
+import logging
+
+LOGGER = logging.getLogger('myapp')
```