### PR TITLE
[subl] Fix sublime plugin for cygwin. Typo in path variable was introduced by cea941c

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -42,8 +42,8 @@ elif  [[ "$OSTYPE" = darwin* ]]; then
         fi
     done
 elif [[ "$OSTYPE" = 'cygwin' ]]; then
-    local sublime_cygwin_paths
-    sublime_cygwin_paths=(
+    local _sublime_cygwin_paths
+    _sublime_cygwin_paths=(
         "$(cygpath $ProgramW6432/Sublime\ Text\ 2)/sublime_text.exe"
         "$(cygpath $ProgramW6432/Sublime\ Text\ 3)/sublime_text.exe"
     )


### PR DESCRIPTION
Fixes broken sublime plugin for cygwin environment. Typo in variable name was introduced in cea941ce42b5d550489367608dd1ac4401151c97.