### PR TITLE
make aws plugin load profile names from ~/.aws/credentials

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -37,7 +37,7 @@ function asp {
 }
 
 function aws_profiles {
-  reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
+  reply=($(grep -e '^\[' $AWS_HOME/credentials | sed -e 's/^\[\(.*\)\]$/\1/'))
 }
 compctl -K aws_profiles asp
 


### PR DESCRIPTION
NOTE: It is more feasible to load profile names from .aws/credentials
rather than loading it from .aws/config. the 'credentials' file is a lot
more frequently used when using third party tools to retrieve and store
temporary STS credentials. Therefore, profile names in .aws/credentials
are more likely to be backed with actual 'hot' credentials.

Signed-off-by: Daniel Stamer <daniel.stamer@cloudreach.com>