### PR TITLE
mvn-or-mvnw: Changing check from -f to -x

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -20,9 +20,9 @@ BACKGROUND_CYAN=$(tput setab 6)
 BACKGROUND_WHITE=$(tput setab 7)
 RESET_FORMATTING=$(tput sgr0)
 
-# if found a ./mvnw file execute it otherwise execute orignal mvn
+# if found an executable ./mvnw file execute it otherwise execute orignal mvn
 mvn-or-mvnw() {
-	if [ -f ./mvnw ] ; then
+	if [ -x ./mvnw ] ; then
 		echo "executing mvnw instead of mvn"		
 		./mvnw "$@";
 	else


### PR DESCRIPTION
The problem that can occur is ocassionally mvnw will not be executable. This can happen if mvnw is included from an archetype, as unix permissions aren't preserved within the jar they're stored in. Only using mvnw if it exists AND is executable