### PR TITLE
 Allow user to hide "Random theme ... loaded"

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -105,7 +105,9 @@ if [[ "$ZSH_THEME" == "random" ]]; then
   ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}
   source "$RANDOM_THEME"
-  echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  if [ "$ZSH_THEME_RANDOM_MESSAGE" != "false" ]; then
+    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  fi
 else
   if [ ! "$ZSH_THEME" = ""  ]; then
     if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -41,6 +41,9 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to display red dots whilst waiting for completion.
 # COMPLETION_WAITING_DOTS="true"
 
+# Uncomment the following line to hide the random theme load message.
+# ZSH_THEME_RANDOM_MESSAGE="false"
+
 # Uncomment the following line if you want to disable marking untracked files
 # under VCS as dirty. This makes repository status check for large repositories
 # much, much faster.


### PR DESCRIPTION
I'm not so interested in the message that tells me that a random theme was loaded, since I know that the theme is randomly chosen from my picks, so I wanted to be able to hide that message. I added an option that can be set in `.zshrc` to hide the message by uncommenting a line.

As can be seen in `templates/zshrc.zsh-template` at lines 44-45, if `ZSH_THEME_RANDOM_MESSAGE` is set to `false` by uncommenting the line, then the message will be disabled.