### PR TITLE
Allow skipping execution of compinit/compaudit

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -67,16 +67,20 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-  # If completion insecurities exist, warn the user
-  if ! compaudit &>/dev/null; then
-    handle_completion_insecurities
+# Skip compinit/compaudit entirely if the user wishes to run it manually
+# by defining $ZSH_DISABLE_COMPINIT
+if (( ! ${+ZSH_DISABLE_COMPINIT} )); then
+  if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+    # If completion insecurities exist, warn the user
+    if ! compaudit &>/dev/null; then
+      handle_completion_insecurities
+    fi
+    # Load only from secure directories
+    compinit -i -d "${ZSH_COMPDUMP}"
+  else
+    # If the user wants it, load from all found directories
+    compinit -u -d "${ZSH_COMPDUMP}"
   fi
-  # Load only from secure directories
-  compinit -i -d "${ZSH_COMPDUMP}"
-else
-  # If the user wants it, load from all found directories
-  compinit -u -d "${ZSH_COMPDUMP}"
 fi
 
 # Load all of the plugins that were defined in ~/.zshrc


### PR DESCRIPTION
Loading autocompletions and auditing the directories for insecurities is
a relatively time-consuming process in the lifecycle of a shell process
startup. If a user would like to skip this process (either one-off or on
a regular basis), they may do so after this change by defining
`ZSH_DISABLE_COMPINIT`.

The change permits the variable to be defined in any way and merely
checks that it exists, not what its value is, using a Zsh idiom
involving treating the variable as a substitution within an arithmetic
expression.

After changing this, it will be necessary to add information about this
change here: https://github.com/robbyrussell/oh-my-zsh/wiki/Design.

Fixes #7336.