### PR TITLE
change AWS_DEFAULT_PROFILE to AWS_PROFILE

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -1,0 +1,17 @@
+# aws
+
+This plugin provides completion to set the AWS_PROFILE environment variable, as well as a
+function to get the current value of it.
+
+To use it add `aws` to th e plugins array in your zshrc file.
+
+```zsh
+plugins=(... aws)
+```
+
+## Plugin commands
+
+* `asp <profile>`: Sets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
+It also adds it to your RPROMPT.
+* `agp`: Gets the current value of `AWS_PROFILE`
+* `aws_profiles`: Lists the available profiles in the file referenced in `AWS_CONFIG_FILE` (default: ~/.aws/config). Used to provide completion.

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -24,7 +24,7 @@ _awscli-homebrew-installed() {
 export AWS_HOME=~/.aws
 
 function agp {
-  echo $AWS_DEFAULT_PROFILE
+  echo $AWS_PROFILE
 }
 
 function asp {
@@ -33,7 +33,7 @@ function asp {
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
 
-  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>$rprompt"
+  export RPROMPT="<aws:$AWS_PROFILE>$rprompt"
 }
 
 function aws_profiles {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -21,8 +21,6 @@ _awscli-homebrew-installed() {
   [ -r $_brew_prefix/libexec/bin/aws_zsh_completer.sh ] &> /dev/null
 }
 
-export AWS_HOME=~/.aws
-
 function agp {
   echo $AWS_PROFILE
 }
@@ -37,7 +35,12 @@ function asp {
 }
 
 function aws_profiles {
-  reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
+  local aws_config_file=$AWS_CONFIG_FILE
+  if [ -z "${AWS_CONFIG_FILE+1}" ]; then
+    aws_config_file=~/.aws/config
+  fi
+
+  reply=($(grep profile "$aws_config_file"|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
 }
 compctl -K aws_profiles asp
 


### PR DESCRIPTION
The environment variable name used to be AWS_DEFAULT_PROFILE but the
CLI documentation now only mentions AWS_PROFILE.

https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html

It seems like the CLI was the only tool using AWS_DEFAULT_PROFILE, and
all the AWS SDKs used AWS_PROFILE, so they standardized on it.

https://onetechnical.wordpress.com/2016/10/07/the-curious-case-of-aws_default_profile/

Note: still left AWS_DEFAULT_PROFILE on the method to set the profile to
maintain backwards compatibility.