### PR TITLE
Add readme for git-flow-avh

### DIFF
--- a/plugins/git-flow-avh/README.md
+++ b/plugins/git-flow-avh/README.md
@@ -3,10 +3,17 @@
 This plugin adds completion for the [git-flow (AVH Edition)](https://github.com/petervanderdoes/gitflow-avh).
 The AVH Edition of the git extensions that provides high-level repository operations for [Vincent Driessen's branching model](https://nvie.com/posts/a-successful-git-branching-model/).
 
-The git-flow tool has to be [installed](https://github.com/petervanderdoes/gitflow-avh#installing-git-flow) separately.
-
 To use it, add `git-flow-avh` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... git-flow-avh)
 ```
+
+## Requirements
+
+1. The git-flow tool has to be [installed](https://github.com/petervanderdoes/gitflow-avh#installing-git-flow)
+   separately.
+
+2. You have to use zsh's git completion instead of the git project's git completion. This is typically
+   done by default so you don't need to do anything else. If you installed git with Homebrew you
+   might have to uninstall the git completion it's bundled with.

--- a/plugins/git-flow-avh/README.md
+++ b/plugins/git-flow-avh/README.md
@@ -1,0 +1,12 @@
+# git-flow (AVH Edition) plugin
+
+This plugin adds completion for the [git-flow (AVH Edition)](https://github.com/petervanderdoes/gitflow-avh).
+The AVH Edition of the git extensions that provides high-level repository operations for [Vincent Driessen's branching model](https://nvie.com/posts/a-successful-git-branching-model/).
+
+The git-flow tool has to be [installed](https://github.com/petervanderdoes/gitflow-avh#installing-git-flow) separately.
+
+To use it, add `git-flow-avh` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... git-flow-avh)
+```

--- a/plugins/git-flow-avh/git-flow-avh.plugin.zsh
+++ b/plugins/git-flow-avh/git-flow-avh.plugin.zsh
@@ -1,25 +1,3 @@
-#!zsh
-#
-# Installation
-# ------------
-#
-# To achieve git-flow completion nirvana:
-#
-#  0. Update your zsh's git-completion module to the newest version.
-#     From here: https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_git
-#
-#  1. Install this file. Either:
-#
-#     a. Place it in your .zshrc:
-#
-#     b. Or, copy it somewhere (e.g. ~/.git-flow-completion.zsh) and put the following line in
-#        your .zshrc:
-#
-#            source ~/.git-flow-completion.zsh
-#
-#     c. Or, use this file as a oh-my-zsh plugin.
-#
-
 _git-flow ()
 {
     local curcontext="$curcontext" state line


### PR DESCRIPTION
This adds a readme file for the git-flow-avh plugin as requested in #7175

