### PR TITLE
Add Qwant Lite - Web Search plugin

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -17,6 +17,7 @@ function web_search() {
     ecosia      "https://www.ecosia.org/search?q="
     goodreads   "https://www.goodreads.com/search?q="
     qwant       "https://www.qwant.com/?q="
+    lqwant      "https://lite.qwant.com/?q="
   )
 
   # check whether the search engine is supported
@@ -51,6 +52,7 @@ alias baidu='web_search baidu'
 alias ecosia='web_search ecosia'
 alias goodreads='web_search goodreads'
 alias qwant='web_search qwant'
+alias lqwant='web_search lqwant'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
Add the [Qwant Lite](https://lite.qwant.com/) search engine to the web_search plugin.