### PR TITLE
history: fix issues with nounset and parameters being used before defined

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -12,12 +12,12 @@ function omz_history {
     builtin fc "$@"
   else
     # unless a number is provided, show all history events (starting from 1)
-    [[ ${@[-1]} = *[0-9]* ]] && builtin fc -l "$@" || builtin fc -l "$@" 1
+    [[ ${@[-1]-} = *[0-9]* ]] && builtin fc -l "$@" || builtin fc -l "$@" 1
   fi
 }
 
 # Timestamp format
-case $HIST_STAMPS in
+case ${HIST_STAMPS-} in
   "mm/dd/yyyy") alias history='omz_history -f' ;;
   "dd.mm.yyyy") alias history='omz_history -E' ;;
   "yyyy-mm-dd") alias history='omz_history -i' ;;


### PR DESCRIPTION
When using the history wrapper and not passing any parameters the usage of @[-1] on line 15 throws an error. This can be resolved by allowing zsh to have a default parameter value during the usage.

HIST_STAMPS also is undefined when trying to source this file directly which also can be resolved by using a default value.

Fixes #7432