### PR TITLE
Provide even spacing between marks

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -28,11 +28,18 @@ unmark() {
 }
 
 marks() {
+	local max=0
+	for link in $MARKPATH/*(@); do
+		if [[ ${#link:t} -gt $max ]]; then
+			max=${#link:t}
+		fi
+	done
+	local printf_markname_template="$(printf -- "%%%us " "$max")"
 	for link in $MARKPATH/*(@); do
 		local markname="$fg[cyan]${link:t}$reset_color"
 		local markpath="$fg[blue]$(readlink $link)$reset_color"
-		printf "%s\t" $markname
-		printf -- "-> %s \t\n" $markpath
+		printf -- "$printf_markname_template" "$markname"
+		printf -- "-> %s\n" "$markpath"
 	done
 }
 


### PR DESCRIPTION
Before, when typing the `marks` command, longer mark keys would cause
the tabs to spill over to the next tab stop, like so:

    rc      -> /home/ahlex/.rc
    repos   -> /home/ahlex/repos
    a-longer-string         -> /tmp

Implement better key display by running through all of the marks twice,
once to get the longest key length, and the second time to format
everything according to that length:

                 rc -> /home/ahlex/.rc
              repos -> /home/ahlex/repos
    a-longer-string -> /tmp