### PR TITLE
aws_porfiles completion problem

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -35,7 +35,7 @@ function asp {
 }
 
 function aws_profiles {
-  reply=($(grep profile "${AWS_CONFIG_FILE:-$HOME/.aws/config}"|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
+  reply=($(grep '\[profile' "${AWS_CONFIG_FILE:-$HOME/.aws/config}"|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
 }
 compctl -K aws_profiles asp
 


### PR DESCRIPTION
aws_porfiles regex is catching more lines than profiles, thus breaking completion.

Example is when have a profile with assume_role like this:

[profile sandbox]
region = eu-west-1
output = json
role_arn = arn:aws:iam::XXXXXXXXX:role/XXX
source_profile = admin
mfa_serial = arn:aws:iam::XXXXXXXXX:mfa/XXX

