### PR TITLE
[git plugin] Add quotes to the branch name in ggpull and ggpush aliases

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -155,10 +155,10 @@ compdef _git ggu=git-checkout
 alias ggpur='ggu'
 compdef _git ggpur=git-checkout
 
-alias ggpull='git pull origin $(git_current_branch)'
+alias ggpull='git pull origin "$(git_current_branch)"'
 compdef _git ggpull=git-checkout
 
-alias ggpush='git push origin $(git_current_branch)'
+alias ggpush='git push origin "$(git_current_branch)"'
 compdef _git ggpush=git-checkout
 
 alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'


### PR DESCRIPTION
context: I had a branch name that started with `#`

/cc @ncanceill