### PR TITLE
[Git plugin] Use stash 'push' instead of the deprecated 'save'

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,6 +33,11 @@ function work_in_progress() {
   fi
 }
 
+function _omz_git_stash_command() {
+  [[ `git --version 2>/dev/null` =~ '^git version ([[:digit:]]+.[[:digit:]]+)' && "$match[1]" >= '2.13' ]] \
+  && echo push || echo save
+}
+
 #
 # Aliases
 # (sorted alphabetically)
@@ -238,7 +243,7 @@ alias gsps='git show --pretty=short --show-signature'
 alias gsr='git svn rebase'
 alias gss='git status -s'
 alias gst='git status'
-alias gsta='git stash save'
+alias gsta="git stash $(_omz_git_stash_command)"
 alias gstaa='git stash apply'
 alias gstc='git stash clear'
 alias gstd='git stash drop'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,11 +33,6 @@ function work_in_progress() {
   fi
 }
 
-function _omz_git_stash_command() {
-  [[ `git --version 2>/dev/null` =~ '^git version ([[:digit:]]+.[[:digit:]]+)' && "$match[1]" >= '2.13' ]] \
-  && echo push || echo save
-}
-
 #
 # Aliases
 # (sorted alphabetically)
@@ -243,7 +238,12 @@ alias gsps='git show --pretty=short --show-signature'
 alias gsr='git svn rebase'
 alias gss='git status -s'
 alias gst='git status'
-alias gsta="git stash $(_omz_git_stash_command)"
+
+# use the default stash push on git 2.13 and newer
+[[ "$(git --version 2>/dev/null)" =~ '^git version ([0-9]+.[0-9]+)' && "$match" -ge '2.13' ]] \
+  && alias gsta='git stash push'
+  || alias gsta='git stash save'
+
 alias gstaa='git stash apply'
 alias gstc='git stash clear'
 alias gstd='git stash drop'


### PR DESCRIPTION
CC: @ncanceill 
> Migrating to `git stash push`
> As of late October 2017, there has been extensive discussion on the Git mailing list, wherein the command `git stash save` is being deprecated in favour of the existing alternative `git stash push`. The main reason for this is that `git stash push` introduces the option of stashing selected pathspecs, something `git stash save` does not support.
> 
> `git stash save` is not going away any time soon, so don’t worry about it suddenly disappearing. But you might want to start migrating over to the push alternative for the new functionality.

The Pro Git book, in the chapter about Stashing and Cleaning, now reports the above note. The new command was introduced with Git 2.13, which came out 2 years ago. I'm using the latest version of Git and although `stash save` is still present in the `git-stash`'s man page, `stash push` has taken its place in the command synopsis, as a sign that the latter should be preferred.
```
SYNOPSIS
       git stash list [<options>]
       git stash show [<stash>]
       git stash drop [-q|--quiet] [<stash>]
       git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]
       git stash branch <branchname> [<stash>]
       git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]
                    [-u|--include-untracked] [-a|--all] [-m|--message <message>]
                    [--] [<pathspec>...]]
       git stash clear
       git stash create [<message>]
       git stash store [-m|--message <message>] [-q|--quiet] <commit>
```
The two commands have mostly the same interface, except that with `stash push` the message is supplied via the `-m`/`--message` flag, while with `stash save` the message is the main argument of the `stash` command and requires no flags.

For this reason I think it's pretty safe to change the `gsta` alias to `git stash push`: the switch should be pretty seamless and hard to misuse as `stash push` will complain if a message is supplied with no flags as it expects a list of pathspecs.

Fixes #7474