### PR TITLE
make installation script configurable for forks

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,4 +1,7 @@
 main() {
+  # change this for forks, so that it would point to your fork
+  OWNER=robbyrussell
+
   # Use colors, but only if connected to a terminal, and that terminal
   # supports them.
   if which tput >/dev/null 2>&1; then
@@ -59,7 +62,7 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/robbyrussell/oh-my-zsh.git "$ZSH" || {
+  env git clone --depth=1 https://github.com/$OWNER/oh-my-zsh.git "$ZSH" || {
     printf "Error: git clone of oh-my-zsh repo failed\n"
     exit 1
   }


### PR DESCRIPTION
This branch replaces the hardcoded `robbyrussell` repo owner with a configurable variable in the `install.sh` script, so that fork maintainers (or private forks) can replace it with their namespace, and install the forked version of `oh-my-zsh` pointing at their fork.

This preserves original behavior by defaulting the said variable to `robbyrussell`.