### PR TITLE
Allow automation tools to manage plugins by removing multiple lines in template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -62,9 +62,7 @@ ZSH_THEME="robbyrussell"
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(
-  git
-)
+plugins=(git)
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
The OMZ template used to have the plugins section defined as `plugins=(git)` which was very easy to manage using provisioning tools like puppet and salt. Since it was a single line, simple regex was required to match and update them. 

However, it was changed in 7a7480b987c00bd916e2abf7179f92164ac44362 to improve readability.

I maintain a module for puppet that allows automated deployment and management of OMZ on puppet nodes. Currently it clones the OMZ repo and copies the template before applying user defined themes and plugins. However, since the `plugins` section is no longer a single line, puppet is unable to reliably match and replace this section. and we have made many attempts to fix this as following:

- https://github.com/rehanone/puppet-ohmyzsh/pull/11
- https://github.com/rehanone/puppet-ohmyzsh/pull/12

All of these have limitations due to the fact that puppet does not support multi line regex to replace this section in the template.

The only solution for now is for us to maintain a local copy of the template in our module rather than using the one that comes with OMZ as per:

- https://github.com/rehanone/puppet-ohmyzsh/pull/14

However, this is not a very optimal solution as we do not want to keep and maintain a local copy of the template in our code.

This change simply reverts the template to its original single line form.

