### PR TITLE
ssh-agent: use hash signature to check ids

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -12,8 +12,8 @@ function _start_agent() {
 }
 
 function _add_identities() {
-	local id line
-	local -a identities ids sigs
+	local id line sig
+	local -a identities loaded signatures
 	zstyle -a :omz:plugins:ssh-agent identities identities
 
 	# check for .ssh folder presence
@@ -21,19 +21,19 @@ function _add_identities() {
 		return
 	fi
 
-	# get list of loaded identities signatures
-	for line in ${(f)"$(ssh-add -l)"}; do ids+=${${(z)line}[2]}; done
+	# get list of loaded identities' signatures
+	for line in ${(f)"$(ssh-add -l)"}; do loaded+=${${(z)line}[2]}; done
 
 	# get signatures of private keys
-	for id in ${^identities}; do
-		sigs+="$(ssh-keygen -lf $HOME/.ssh/$id | awk '{ print $2 }')	${id}"
+	for id in $identities; do
+		signatures+="$(ssh-keygen -lf "$HOME/.ssh/$id" | awk '{print $2}')	$id"
 	done
 
 	# add identities if not already loaded
-	for sigid in ${sigs}; do
-		id="$(echo ${sigid}|cut -f2)"
-		sig="$(echo ${sigid}|cut -f1)"
-		[[ ${ids[(I)$sig]} -le 0 ]] && ssh-add $HOME/.ssh/$id
+	for sig in $signatures; do
+		id="$(cut -f2 <<< $sig)"
+		sig="$(cut -f1 <<< $sig)"
+		[[ ${loaded[(I)$sig]} -le 0 ]] && ssh-add $HOME/.ssh/$id
 	done
 }
 


### PR DESCRIPTION
Fixes ssh-agent plugin.

With the last change, the plugin check each time if all identities are loaded, using *ssh-add -l command* and check the id file presence. But the command can return the key comment instead of the key file. Thus, the check miss and the key is re-loaded each time.

To fix that, I changed the function to use the key fingerprint to check if it is loaded or not.

Fixes #5128
Closes #5537