### PR TITLE
Allow mvnw to be eligible to completion suggestions

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -288,5 +288,5 @@ function listMavenCompletions {
 }
 
 compctl -K listMavenCompletions mvn
-compctl -K listMavenCompletions mvn-or-mvnw
+compctl -K listMavenCompletions mvnw
 


### PR DESCRIPTION
This pull requests enable zsh to suggests completions for the maven wrapper `./mvnw` when used directly. The current plugin only enable completion for `mvn` or for the `mvn-or-mvnw` function.

The [gradle plugin](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/gradle/gradle.plugin.zsh#L182-L183) activates the completion for both `gradle` and `gradlew`, not for the _redirecting_ function. I'd like to align the functionnality so one can benefit of the completion when using `./mvnw` as well.