### PR TITLE
ssh-agent: check for loaded id filenames first

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -13,7 +13,7 @@ function _start_agent() {
 
 function _add_identities() {
 	local id line sig
-	local -a identities loaded not_loaded signatures
+	local -a identities loaded_sigs loaded_ids not_loaded
 	zstyle -a :omz:plugins:ssh-agent identities identities
 
 	# check for .ssh folder presence
@@ -31,19 +31,19 @@ function _add_identities() {
 		done
 	fi
 
-	# get list of loaded identities' signatures
-	for line in ${(f)"$(ssh-add -l)"}; do loaded+=${${(z)line}[2]}; done
-
-	# get signatures of private keys
-	for id in $identities; do
-		signatures+="$(ssh-keygen -lf "$HOME/.ssh/$id" | awk '{print $2}')	$id"
+	# get list of loaded identities' signatures and filenames
+	for line in ${(f)"$(ssh-add -l)"}; do
+		loaded_sigs+=${${(z)line}[2]}
+		loaded_ids+=${${(z)line}[3]}
 	done
 
 	# add identities if not already loaded
-	for sig in $signatures; do
-		id="$(cut -f2 <<< $sig)"
-		sig="$(cut -f1 <<< $sig)"
-		[[ ${loaded[(I)$sig]} -le 0 ]] && not_loaded+="$HOME/.ssh/$id"
+	for id in $identities; do
+		# check for filename match, otherwise try for signature match
+		if [[ ${loaded_ids[(I)$HOME/.ssh/$id]} -le 0 ]]; then
+			sig="$(ssh-keygen -lf "$HOME/.ssh/$id" | awk '{print $2}')"
+			[[ ${loaded_sigs[(I)$sig]} -le 0 ]] && not_loaded+="$HOME/.ssh/$id"
+		fi
 	done
 
 	[[ -n "$not_loaded" ]] && ssh-add ${^not_loaded}


### PR DESCRIPTION
This change makes the plugin check if an identity is loaded by looking first at the key filename reported by `ssh-add -l`. This fixes the use case where ssh-keygen is not able to output the fingerprint of a key, such as the one reported on #7516.
    
Now, for an identity to be passed onto ssh-add, it has to fail both the match for a loaded identity's filename and signature.

Fixes #7516