### PR TITLE
Improve adb -s completion to show helpful info

### DIFF
--- a/plugins/adb/_adb
+++ b/plugins/adb/_adb
@@ -49,7 +49,7 @@ _arguments \
 case "$state" in
 	specify_device)
 	_values -C 'devices' ${$(adb devices -l|awk 'NR>1&& $1 \
-		{sub(/ +/," ",$0);gsub(":","\\:",$1); printf "%s[%s] ",$1, $NF}'):-""}
+		{sub(/ +/," ",$0);gsub(":","\\:",$1);split($3,m,":");split($4,d,":"); printf "%s[%s(%s)] ",$1, d[2], m[2]}'):-""}
 	return
 	;;
 esac

--- a/plugins/adb/_adb
+++ b/plugins/adb/_adb
@@ -49,7 +49,12 @@ _arguments \
 case "$state" in
 	specify_device)
 	_values -C 'devices' ${$(adb devices -l|awk 'NR>1&& $1 \
-		{sub(/ +/," ",$0);gsub(":","\\:",$1);split($3,m,":");split($4,d,":"); printf "%s[%s(%s)] ",$1, d[2], m[2]}'):-""}
+		{sub(/ +/," ",$0); \
+		gsub(":","\\:",$1); \
+		for(i=1;i<=NF;i++) {
+			if($i ~ /model:/) { split($i,m,":") } \
+			else if($i ~ /product:/) { split($i,p,":") } } \
+		printf "%s[%s(%s)] ",$1, p[2], m[2]}'):-""}
 	return
 	;;
 esac


### PR DESCRIPTION
Currently it shows for example the following
DEVICE_ID  -- transport_id:2
Which doesn't really ease device selection, I've adapted the awk script to print device name with it's model name, see the example below
DEVICE_ID  -- Pixel_3(blueline)
