### PR TITLE
Ads brew cask update to brew plugin

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -17,3 +17,5 @@ plugins=(... brew)
 | bubo   | `brew update && brew outdated` | Fetch the newest version of Homebrew and all formulae, then list outdated formulae. |
 | bubc   | `brew upgrade && brew cleanup` | Upgrade outdated, unpinned brews (with existing install options), then removes stale lock files and outdated downloads for formulae and casks, and removes old versions of installed formulae. |
 | bubu   | `bubo && bubc`       | Updates Homebrew, lists outdated formulae, upgrades oudated and unpinned formulae, and removes stale and outdated downloads and versions. |
+| bcubo  | `brew update && brew cask outdated` | Fetch the newest version of Homebrew and all formulae, then list outdated casks. |
+| bcubc  | `brew cask reinstall $(brew cask outdated) && brew cleanup` | Updates outdated casks, then runs cleanup. |

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -4,6 +4,8 @@ alias brewsp='brew list --pinned'
 alias bubo='brew update && brew outdated'
 alias bubc='brew upgrade && brew cleanup'
 alias bubu='bubo && bubc'
+alias bcubo='brew update && brew cask outdated'
+alias bcubc='brew cask reinstall $(brew cask outdated) && brew cleanup'
 
 if command mkdir "$ZSH_CACHE_DIR/.brew-completion-message" 2>/dev/null; then
 	print -P '%F{yellow}'Oh My Zsh brew plugin:


### PR DESCRIPTION
Technically we could use cask as a prefix too, as it should not cause any overlaps. 
for example caskout for outdated check and caskup for update.