### PR TITLE
add brew install path to search

### DIFF
--- a/plugins/jenv/jenv.plugin.zsh
+++ b/plugins/jenv/jenv.plugin.zsh
@@ -1,4 +1,4 @@
-jenvdirs=("$HOME/.jenv" "/usr/local/jenv" "/opt/jenv")
+jenvdirs=("$HOME/.jenv" "/usr/local" "/usr/local/jenv" "/opt/jenv")
 
 FOUND_JENV=0
 for jenvdir in $jenvdirs; do


### PR DESCRIPTION
recent `brew install jenv` installs to `/usr/local/bin/jenv`, auto-discover it for recent brew installs to avoid secondary, slower search