### PR TITLE
Git -> 🐐, Kubectl -> ☁️

### DIFF
--- a/lib/kubectl.zsh
+++ b/lib/kubectl.zsh
@@ -1,0 +1,6 @@
+# Outputs current kubectl in prompt format
+function kubectl_prompt_info() {
+  local ref
+  ref=$(cat ~/.kube/config | grep "current-context:" | sed "s/current-context: //") || return 0
+  echo "$ZSH_THEME_KUBECTL_PROMPT_PREFIX${ref}$ZSH_THEME_KUBECTL_PROMPT_SUFFIX"
+}

--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -15,6 +15,7 @@ function chruby_prompt_info hg_prompt_info pyenv_prompt_info \
   virtualenv_prompt_info jenv_prompt_info {
   return 1
 }
+# virtualenv_prompt_info jenv_prompt_info kubectl_prompt_info {
 
 # oh-my-zsh supports an rvm prompt by default
 # get the name of the rvm ruby version

--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -1,7 +1,10 @@
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
-PROMPT='${ret_status} %{$fg[cyan]%}%c%{$reset_color%} $(git_prompt_info)'
+PROMPT='${ret_status} %{$fg[cyan]%}%c%{$reset_color%} $(kubectl_prompt_info)$(git_prompt_info)'
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_PREFIX="🐐:%{$fg_bold[blue]%}(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"
+
+ZSH_THEME_KUBECTL_PROMPT_PREFIX="☁️ :%{$fg_bold[blue]%}(%{$fg[red]%}"
+ZSH_THEME_KUBECTL_PROMPT_SUFFIX="%{$fg[blue]%})%{$reset_color%} "


### PR DESCRIPTION
Default theme:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/193115/51602805-33287680-1f08-11e9-94d0-53cb55ae88a4.png">

TO consider `if [[ command kubectl &2>/dev/null ]]; then; EVEEERYTHING; fi`

This seems to cause issues with spacing when doing reverse-searches; see linked issue. I'd love an explanation as to why this might happen from this change.
