### PR TITLE
Fix ggfl command not found error

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -112,8 +112,8 @@ ggf() {
   git push --force origin "${b:=$1}"
 }
 ggfl() {
-[[ "$#" != 1 ]] && local b="$(git_current_branch)"
-git push --force-with-lease origin "${b:=$1}"
+  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
+  git push --force-with-lease origin "${b:=$1}"
 }
 compdef _git ggf=git-checkout
 


### PR DESCRIPTION
On my MacOS (Mojave) ggfl aliast is not working:
```
> ggfl
zsh: command not found: ggfl
```

Looks like these spaces were missing, because it works now.
