### PR TITLE
ggl giving error, temporarily fixed by commenting the lines

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -117,15 +117,15 @@ ggfl() {
 }
 compdef _git ggf=git-checkout
 
-ggl() {
-  if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
-    git pull origin "${*}"
-  else
-    [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git pull origin "${b:=$1}"
-  fi
-}
-compdef _git ggl=git-checkout
+# ggl() {
+#   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
+#     git pull origin "${*}"
+#   else
+#     [[ "$#" == 0 ]] && local b="$(git_current_branch)"
+#     git pull origin "${b:=$1}"
+#   fi
+# }
+# compdef _git ggl=git-checkout
 
 ggp() {
   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then


### PR DESCRIPTION
/Users/my_username/.oh-my-zsh/plugins/git/git.plugin.zsh:120: defining function based on alias `ggl'
/Users/my_username/.oh-my-zsh/plugins/git/git.plugin.zsh:120: parse error near `()'

Error given on: macOS Mojave 10.14.2