### PR TITLE
asdf: fix homebrew installation path

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,9 +1,11 @@
 # Find where asdf should be installed
 ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
+ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
-if [[ ! -d $ASDF_DIR ]] && (( $+commands[brew] )); then
+if [[ ! -f "$ASDF_DIR/asdf.sh" ]] && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)"
+   ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi
 
 # Load command
@@ -11,7 +13,7 @@ if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
     . "$ASDF_DIR/asdf.sh"
 
     # Load completions
-    if [[ -f "$ASDF_DIR/completions/asdf.bash" ]]; then
-        . "$ASDF_DIR/completions/asdf.bash"
+    if [[ -f "$ASDF_COMPLETIONS/asdf.bash" ]]; then
+        . "$ASDF_COMPLETIONS/asdf.bash"
     fi
 fi


### PR DESCRIPTION
* The check for the asdf installation directory is more precise.
* Completions, while installed with homebrew, are now expected on an alternative location.

——

The existence of the directory `$HOME/.asdf` does not mean that it is the installation directory of `asdf`. It will also be created after installing at least one asdf plugin.

@robbyrussell  @mcornella @RobLoach 