### PR TITLE
Minor improvements to the gitignore plugins

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,6 +33,11 @@ function work_in_progress() {
   fi
 }
 
+function _omz_git_stash_command() {
+  [[ `git --version 2>/dev/null` =~ '^git version ([[:digit:]]+.[[:digit:]]+)' && "$match[1]" >= '2.13' ]] \
+  && echo push || echo save
+}
+
 #
 # Aliases
 # (sorted alphabetically)
@@ -238,7 +243,7 @@ alias gsps='git show --pretty=short --show-signature'
 alias gsr='git svn rebase'
 alias gss='git status -s'
 alias gst='git status'
-alias gsta='git stash save'
+alias gsta="git stash $(_omz_git_stash_command)"
 alias gstaa='git stash apply'
 alias gstc='git stash clear'
 alias gstd='git stash drop'

--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl -fL https://www.gitignore.io/api/${(j:,:)@} }
+function gi() { curl -fLw '\n' https://www.gitignore.io/api/${(j:,:)@} }
 
 _gitignoreio_get_command_list() {
   curl -sfL https://www.gitignore.io/api/list | tr "," "\n"

--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl -fLw '\n' https://www.gitignore.io/api/${(j:,:)@} }
+function gi() { curl -fLw '\n' https://www.gitignore.io/api/"${(j:,:)@}" }
 
 _gitignoreio_get_command_list() {
   curl -sfL https://www.gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Using the `gi` command provided by the gitignore plugin was causing a `%` to be shown in the terminal at the end of output.
[I opened an issue](https://github.com/joeblau/gitignore.io/issues/442#issuecomment-461357115) on the gitignore.io repository and they suggested adding `-w '\n'` to the `curl` command in order to make `curl` add the new line character at the end. The linked issue explains what my problem was in more detail.
This PR applies the suggested fix.

Further, arguments expansion has been double-quoted for security reasons.
See https://unix.stackexchange.com/a/171347/222786.