### PR TITLE
Fix helm-plugin completion

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -3,5 +3,5 @@
 # Copy from kubectl : https://github.com/pstadler
 
 if [ $commands[helm] ]; then
-  source <(helm completion zsh)
+  source <(helm completion zsh | sed -E 's/\["(.+)"\]/\[\1\]/g')
 fi


### PR DESCRIPTION
Currently helm completion fails in ZSH shell https://github.com/helm/helm/issues/5046:

```bash
$ source <(helm completion zsh)
$
# Typing 'helm' and hitting "Tab"
$ helm _helm_root_command:12: bad math expression: operand expected at `"del"'
$
$ helm version -c
Client: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
```

This PR provides temporary fix proposed [here](https://github.com/helm/helm/issues/5046#issuecomment-463576351) till the issue is actually fixed inside helm upstream.