### PR TITLE
[plugins/tmux] Allow to define a custom configuration path

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -37,3 +37,4 @@ The plugin also supports the following -
 | `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)          |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                |
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`            |
+| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`)                      |

--- a/plugins/tmux/tmux.extra.conf
+++ b/plugins/tmux/tmux.extra.conf
@@ -1,2 +1,2 @@
 set -g default-terminal $ZSH_TMUX_TERM
-source $HOME/.tmux.conf
+source $ZSH_TMUX_CONFIG

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -34,6 +34,8 @@ alias tkss='tmux kill-session -t'
 # Tmux states this should be screen-256color, but you may need to change it on
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
+# Set the configuration path
+: ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
 
 # Determine if the terminal supports 256 colors
 if [[ $terminfo[colors] == 256 ]]; then
@@ -43,7 +45,7 @@ else
 fi
 
 # Set the correct local config file to use.
-if [[ "$ZSH_TMUX_ITERM2" == "false" && -e "$HOME/.tmux.conf" ]]; then
+if [[ "$ZSH_TMUX_ITERM2" == "false" && -e "$ZSH_TMUX_CONFIG" ]]; then
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.extra.conf"
 else
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.only.conf"
@@ -65,8 +67,9 @@ function _zsh_tmux_plugin_run() {
 
   # If failed, just run tmux, fixing the TERM variable if requested.
   if [[ $? -ne 0 ]]; then
-    [[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
-    $tmux_cmd new-session
+    [[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG") || \
+    [[ -e "$ZSH_TMUX_CONFIG" ]] && tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")
+    $tmux_cmd new-session  
   fi
 
   if [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]]; then


### PR DESCRIPTION
Hello,
Tmux developers do not want to comply with XDG standards ([see here](https://github.com/tmux/tmux/issues/142)). With this variable, those who wish to do so will be able to comply with this standard, without the agreement of these developers.
Thank you very much.