### PR TITLE
vscode: handle command name differences with same aliases

### DIFF
--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -1,19 +1,23 @@
-# VScode zsh plugin
-# author: https://github.com/MarsiBarsi
+# Visual Studio Code aliases
+# Authors:
+#   - https://github.com/MarsiBarsi
+#   - https://github.com/jjangga0214
 
-alias vsc='code .'
-alias vsca='code --add'
-alias vscd='code --diff'
-alias vscg='code --goto'
-alias vscn='code --new-window'
-alias vscr='code --reuse-window'
-alias vscw='code --wait'
-alias vscu='code --user-data-dir'
+(( $+commands[vscode] )) && VSCODE=vscode || VSCODE=code
 
-alias vsced='code --extensions-dir'
-alias vscie='code --install-extension'
-alias vscue='code --uninstall-extension'
+alias vsc='$VSCODE .'
+alias vsca='$VSCODE --add'
+alias vscd='$VSCODE --diff'
+alias vscg='$VSCODE --goto'
+alias vscn='$VSCODE --new-window'
+alias vscr='$VSCODE --reuse-window'
+alias vscw='$VSCODE --wait'
+alias vscu='$VSCODE --user-data-dir'
 
-alias vscv='code --verbose'
-alias vscl='code --log'
-alias vscde='code --disable-extensions'
+alias vsced='$VSCODE --extensions-dir'
+alias vscie='$VSCODE --install-extension'
+alias vscue='$VSCODE --uninstall-extension'
+
+alias vscv='$VSCODE --verbose'
+alias vscl='$VSCODE --log'
+alias vscde='$VSCODE --disable-extensions'


### PR DESCRIPTION
- If vscode is installed from snap store(e.g. `snap install vscode`), the default command would be
_vscode_, whereas generally it is _code_. To provide a uniform
interface(aliases) to user with different commands(_vscode_ vs
_code_), 'command resolver' is added at the top of the file. The value
of `$VSCODE` will be **vscode** if vscode command exists in the system.
Otherwise, it will be **code**.
- Reformatted the comments and added an author(https://github.com/jjangga0214)