### PR TITLE
Update the AWS plugin to support disabling RPROMT display

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -1,8 +1,7 @@
 # aws
 
 This plugin provides completion support for [awscli](https://docs.aws.amazon.com/cli/latest/reference/index.html)
-and a few utilities to manage AWS profiles: a function to change profiles with autocompletion support
-and a function to get the current AWS profile. The current AWS profile is also displayed in `RPROMPT`.
+and a few utilities to manage AWS profiles and display them in the prompt.
 
 To use it, add `aws` to the plugins array in your zshrc file.
 
@@ -13,7 +12,6 @@ plugins=(... aws)
 ## Plugin commands
 
 * `asp <profile>`: Sets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
-It also adds it to your RPROMPT.
 
 * `agp`: Gets the current value of `AWS_PROFILE`.
 
@@ -22,3 +20,11 @@ It also adds it to your RPROMPT.
 ## Plugin options
 
 * Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT.
+
+## Theme
+
+The plugin creates a `aws_profile_prompt_info` function that you can use in your theme, which displays the current `$AWS_PROFILE`. It uses two variables to control how that is shown:
+
+- ZSH_THEME_AWS_PREFIX: sets the prefix of the AWS_PROFILE. Defaults to [.
+
+- ZSH_THEME_AWS_SUFFIX: sets the suffix of the AWS_PROFILE. Defaults to ].

--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -11,11 +11,13 @@ plugins=(... aws)
 
 ## Plugin commands
 
-* `asp <profile>`: Sets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
+* `asp [<profile>]`: Sets `$AWS_PROFILE` and `$AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
+  Run `asp` without arguments to clear the profile.
 
-* `agp`: Gets the current value of `AWS_PROFILE`.
+* `agp`: Gets the current value of `$AWS_PROFILE`.
 
-* `aws_profiles`: Lists the available profiles in the file referenced in `AWS_CONFIG_FILE` (default: ~/.aws/config). Used to provide completion for the `asp` function.
+* `aws_profiles`: Lists the available profiles in the  `$AWS_CONFIG_FILE` (default: `~/.aws/config`).
+  Used to provide completion for the `asp` function.
 
 ## Plugin options
 
@@ -23,8 +25,9 @@ plugins=(... aws)
 
 ## Theme
 
-The plugin creates a `aws_profile_prompt_info` function that you can use in your theme, which displays the current `$AWS_PROFILE`. It uses two variables to control how that is shown:
+The plugin creates an `aws_prompt_info` function that you can use in your theme, which displays
+the current `$AWS_PROFILE`. It uses two variables to control how that is shown:
 
-- ZSH_THEME_AWS_PREFIX: sets the prefix of the AWS_PROFILE. Defaults to [.
+- ZSH_THEME_AWS_PREFIX: sets the prefix of the AWS_PROFILE. Defaults to `<aws:`.
 
-- ZSH_THEME_AWS_SUFFIX: sets the suffix of the AWS_PROFILE. Defaults to ].
+- ZSH_THEME_AWS_SUFFIX: sets the suffix of the AWS_PROFILE. Defaults to `>`.

--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -18,3 +18,7 @@ It also adds it to your RPROMPT.
 * `agp`: Gets the current value of `AWS_PROFILE`.
 
 * `aws_profiles`: Lists the available profiles in the file referenced in `AWS_CONFIG_FILE` (default: ~/.aws/config). Used to provide completion for the `asp` function.
+
+## Plugin options
+
+* Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT.

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -7,6 +7,10 @@ function agp {
 function asp {
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
+
+  if [[ -z "$1" ]]; then
+    echo AWS profile cleared.
+  fi
 }
 
 function aws_profiles {
@@ -18,8 +22,8 @@ compctl -K aws_profiles asp
 # AWS prompt
 
 function aws_prompt_info() {
-  [[ -n ${AWS_PROFILE} ]] || return
-  echo "${ZSH_THEME_AWS_PREFIX:=[}${AWS_PROFILE:t}${ZSH_THEME_AWS_SUFFIX:=]}"
+  [[ -z $AWS_PROFILE ]] && return
+  echo "${ZSH_THEME_AWS_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_SUFFIX:=>}"
 }
 
 if [ "$SHOW_AWS_PROMPT" != false ]; then

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -1,21 +1,30 @@
+# AWS profile selection
+
 function agp {
   echo $AWS_PROFILE
 }
 
 function asp {
-  local rprompt=${RPROMPT/<aws:$AWS_PROFILE>/}
-
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
-  if [ "$SHOW_AWS_PROMPT" != false ]; then
-    export RPROMPT="<aws:$AWS_PROFILE>$rprompt"
-  fi
 }
 
 function aws_profiles {
   reply=($(grep '\[profile' "${AWS_CONFIG_FILE:-$HOME/.aws/config}"|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
 }
 compctl -K aws_profiles asp
+
+
+# AWS prompt
+
+function aws_prompt_info() {
+  [[ -n ${AWS_PROFILE} ]] || return
+  echo "${ZSH_THEME_AWS_PREFIX:=[}${AWS_PROFILE:t}${ZSH_THEME_AWS_SUFFIX:=]}"
+}
+
+if [ "$SHOW_AWS_PROMPT" != false ]; then
+  export RPROMPT='$(aws_prompt_info)'"$RPROMPT"
+fi
 
 
 # Load awscli completions

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -7,8 +7,9 @@ function asp {
 
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
-
-  export RPROMPT="<aws:$AWS_PROFILE>$rprompt"
+  if [ "$SHOW_AWS_PROMPT" != false ]; then
+    export RPROMPT="<aws:$AWS_PROFILE>$rprompt"
+  fi
 }
 
 function aws_profiles {


### PR DESCRIPTION
Many popular themes display the current profile inline so this update adds the option to disable the addition to the RPROMT if required.

~~update aws.plugin.zsh to use a $HIDE_AWS_PROMPT option~~
update aws.plugin.zsh to use a $SHOW_AWS_PROMPT option
add usage to the readme

Tagging @cristim (Are you still the primary maintainer?)

----

UPDATED: fixes #6127 