### PR TITLE
Fixed themes link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Most plugins (should! we're working on this) include a __README__, which documen
 
 ### Themes
 
-We'll admit it. Early in the Oh My Zsh world, we may have gotten a bit too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://wiki.github.com/robbyrussell/oh-my-zsh/themes) on the wiki. Check them out!
+We'll admit it. Early in the Oh My Zsh world, we may have gotten a bit too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://github.com/robbyrussell/oh-my-zsh/wiki/Themes) on the wiki. Check them out!
 
 #### Selecting a Theme
 


### PR DESCRIPTION
Just a very simple README change.  The existing link to the themes section no longer works.  Hopefully this follows the guidelines!