### PR TITLE
added shortcut for git fetch upstream

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -100,6 +100,7 @@ compdef _git gdv=git-diff
 alias gf='git fetch'
 alias gfa='git fetch --all --prune'
 alias gfo='git fetch origin'
+alias gfu='git fetch upstream'
 
 function gfg() { git ls-files | grep $@ }
 compdef _grep gfg


### PR DESCRIPTION
Since `git fetch upstream` is pretty common, we could have an alias for it. It does not conflict with anything else from this plugin.