### PR TITLE
Enable tmux window title updates when using proper tmux* $TERM values.

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -21,7 +21,7 @@ function title {
       print -Pn "\e]2;$2:q\a" # set window name
       print -Pn "\e]1;$1:q\a" # set tab name
       ;;
-    screen*)
+    screen*|tmux*)
       print -Pn "\ek$1:q\e\\" # set screen hardstatus
       ;;
     *)


### PR DESCRIPTION
There are minor but important differences between tmux and screen terminal features. Modern GNU distributions now come with `tmux` and `tmux-256color` termcaps and it is preferable to use these when using tmux. The small change in this PR allows functional tmux window title updates using existing oh-my-zsh functionality when using a "tmux*" `$TERM` .