### PR TITLE
Refactoring aws plugin.

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -1,8 +1,6 @@
 # aws
 
-This plugin provides completion support for [awscli](https://docs.aws.amazon.com/cli/latest/reference/index.html)
-and a few utilities to manage AWS profiles: a function to change profiles with autocompletion support
-and a function to get the current AWS profile. The current AWS profile is also displayed in `RPROMPT`.
+This plugin provides completion support for [awscli](https://docs.aws.amazon.com/cli/latest/reference/index.html). It also offers management utilities and theming for AWS profiles.
 
 To use it, add `aws` to the plugins array in your zshrc file.
 
@@ -12,9 +10,18 @@ plugins=(... aws)
 
 ## Plugin commands
 
-* `asp <profile>`: Sets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
-It also adds it to your RPROMPT.
+* `aws_set_profile <profile>`: Sets `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
 
-* `agp`: Gets the current value of `AWS_PROFILE`.
+* `aws_unset_profile`: Unsets `AWS_PROFILE` and `AWS_DEFAULT_RPOFILE` (legacy).
 
-* `aws_profiles`: Lists the available profiles in the file referenced in `AWS_CONFIG_FILE` (default: ~/.aws/config). Used to provide completion for the `asp` function.
+* `aws_get_profile`: Prints the current value of `AWS_PROFILE`.
+
+* `aws_profiles`: Lists the available profiles in the file referenced in `AWS_CONFIG_FILE` (default: ~/.aws/config). Used to provide completion for the `aws_set_profile` function.
+
+## Theme
+
+The plugin creates a `aws_profile_prompt_info` function that you can use in your theme, which displays the current `$AWS_PROFILE`. It uses two variables to control how that is shown:
+
+- ZSH_THEME_AWS_PREFIX: sets the prefix of the AWS_PROFILE. Defaults to [.
+
+- ZSH_THEME_AWS_SUFFIX: sets the suffix of the AWS_PROFILE. Defaults to ].

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -21,23 +21,29 @@ _awscli-homebrew-installed() {
   [ -r $_brew_prefix/libexec/bin/aws_zsh_completer.sh ] &> /dev/null
 }
 
-function agp {
+function aws_get_profile {
   echo $AWS_PROFILE
 }
 
-function asp {
-  local rprompt=${RPROMPT/<aws:$(agp)>/}
-
+function aws_set_profile {
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
+}
 
-  export RPROMPT="<aws:$AWS_PROFILE>$rprompt"
+function aws_unset_profile {
+  export AWS_DEFAULT_PROFILE=
+  export AWS_PROFILE=
+}
+
+function aws_profile_prompt_info() {
+  [[ -n ${AWS_PROFILE} ]] || return
+  echo "${ZSH_THEME_AWS_PREFIX:=[}${AWS_PROFILE:t}${ZSH_THEME_AWS_SUFFIX:=]}"
 }
 
 function aws_profiles {
   reply=($(grep '\[profile' "${AWS_CONFIG_FILE:-$HOME/.aws/config}"|sed -e 's/.*profile \([a-zA-Z0-9_\.-]*\).*/\1/'))
 }
-compctl -K aws_profiles asp
+compctl -K aws_profiles aws_set_profile
 
 if which aws_zsh_completer.sh &>/dev/null; then
   _aws_zsh_completer_path=$(which aws_zsh_completer.sh 2>/dev/null)


### PR DESCRIPTION
Adding new utility function for unsetting aws profile.
Renaming old functions with self-explainable names.
Exposing customizable `aws_profile_prompt_info` function to be used in themes.
Showing info if `$AWS_PROFILE` is set, not only when using aws_set_profile.
Removed obligatory addition of aws profile information to `$RPROMPT`.