### PR TITLE
rbenv: improve rbenv loading based on pyenv

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -38,4 +38,4 @@ else
     }
 fi
 
-unset FOUND_PYENV dir
+unset FOUND_PYENV pyenvdirs dir

--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -1,60 +1,65 @@
-_homebrew-installed() {
-  type brew &> /dev/null
-}
+# This plugin loads rbenv into the current shell and provides prompt info via
+# the 'rbenv_prompt_info' function.
 
-FOUND_RBENV=0
-rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
-if _homebrew-installed && rbenv_homebrew_path=$(brew --prefix rbenv 2>/dev/null); then
-    rbenvdirs=($rbenv_homebrew_path "${rbenvdirs[@]}")
-    unset rbenv_homebrew_path
-    if [[ $RBENV_ROOT = '' ]]; then 
-      RBENV_ROOT="$HOME/.rbenv"
+FOUND_RBENV=$+commands[rbenv]
+
+if [[ $FOUND_RBENV -ne 1 ]]; then
+    rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" "/usr/local/opt/rbenv")
+    for dir in $rbenvdirs; do
+        if [[ -d $dir/bin ]]; then
+            export PATH="$dir/bin:$PATH"
+            FOUND_RBENV=1
+            break
+        fi
+    done
+fi
+
+if [[ $FOUND_RBENV -ne 1 ]]; then
+    if (( $+commands[brew] )) && dir=$(brew --prefix rbenv 2>/dev/null); then
+        if [[ -d $dir/bin ]]; then
+            export PATH="$dir/bin:$PATH"
+            FOUND_RBENV=1
+        fi
     fi
 fi
 
-for rbenvdir in "${rbenvdirs[@]}" ; do
-  if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then
-    FOUND_RBENV=1
-    if [[ $RBENV_ROOT = '' ]]; then
-      RBENV_ROOT=$rbenvdir
-    fi
-    export RBENV_ROOT
-    export PATH=${rbenvdir}/bin:$PATH
+if [[ $FOUND_RBENV -eq 1 ]]; then
     eval "$(rbenv init --no-rehash - zsh)"
 
     alias rubies="rbenv versions"
     alias gemsets="rbenv gemset list"
 
     function current_ruby() {
-      echo "$(rbenv version-name)"
+        echo "$(rbenv version-name)"
     }
 
     function current_gemset() {
-      echo "$(rbenv gemset active 2&>/dev/null | sed -e ":a" -e '$ s/\n/+/gp;N;b a' | head -n1)"
+        echo "$(rbenv gemset active 2&>/dev/null | sed -e ":a" -e '$ s/\n/+/gp;N;b a' | head -n1)"
     }
 
-    function gems {
-      local rbenv_path=$(rbenv prefix)
-      gem list $@ | sed -E \
-        -e "s/\([0-9a-z, \.]+( .+)?\)/$fg[blue]&$reset_color/g" \
-        -e "s|$(echo $rbenv_path)|$fg[magenta]\$rbenv_path$reset_color|g" \
-        -e "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
-        -e "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
+    function gems() {
+        local rbenv_path=$(rbenv prefix)
+        gem list $@ | sed -E \
+          -e "s/\([0-9a-z, \.]+( .+)?\)/$fg[blue]&$reset_color/g" \
+          -e "s|$(echo $rbenv_path)|$fg[magenta]\$rbenv_path$reset_color|g" \
+          -e "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
+          -e "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
     }
 
     function rbenv_prompt_info() {
-      if [[ -n $(current_gemset) ]] ; then
-        echo "$(current_ruby)@$(current_gemset)"
-      else
-        echo "$(current_ruby)"
-      fi
+        if [[ -n $(current_gemset) ]] ; then
+            echo "$(current_ruby)@$(current_gemset)"
+        else
+            echo "$(current_ruby)"
+        fi
     }
-  fi
-done
-unset rbenvdir
-
-if [ $FOUND_RBENV -eq 0 ] ; then
-  alias rubies='ruby -v'
-  function gemsets() { echo 'not supported' }
-  function rbenv_prompt_info() { echo "system: $(ruby -v | cut -f-2 -d ' ')" }
+else
+    alias rubies="ruby -v"
+    function gemsets() { echo "not supported" }
+    function current_ruby() { echo "not supported" }
+    function current_gemset() { echo "not supported" }
+    function gems() { echo "not supported" }
+    function rbenv_prompt_info() { echo "system: $(ruby -v | cut -f-2 -d ' ')" }
 fi
+
+unset FOUND_RBENV rbenvdirs dir


### PR DESCRIPTION
This should speed up the loading due to lazy-searching for homebrew-installed rbenvs.

This PR makes the the rbenv-related changes in #6637 unnecessary.
closes #6168
closes #4998
fixes #3093
closes #3931
closes #3808