### PR TITLE
Git Plugin: Add the git alias 'gtl', that list the tags that match the pattern(s)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -250,7 +250,7 @@ alias gsu='git submodule update'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'
-alias gtl='function _gtl(){ git tag -n -l ${1:-"*"}* --sort=-v:refname; };_gtl'
+alias gtl='gtl(){ git tag --sort=-v:refname -n -l ${1}* }; noglob gtl'
 
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -250,6 +250,7 @@ alias gsu='git submodule update'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'
+alias gtl='function _gtl(){ git tag -n -l ${1:-"*"}* --sort=-v:refname; };_gtl'
 
 alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'


### PR DESCRIPTION
Add the alias 'gtl', which does the following:

1. List the tags that match the pattern(s) passed through the argument.
2. Displays the first line of the annotation message along with the tag, or the line of the first commit message if the tag is not annotated.
3. Sorts and displays tags in descending order.

Suppose there are several tags:
v1.2.1
v2.5.1
v2.5.2
v3.5.1
...

When running gtl v2.5 this will result in

v2.5.2  -commit message 
v2.5.1  -commit message