### PR TITLE
ssh-agent: allow using external helper to ask for passwords (and store them in a keychain)

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -33,6 +33,13 @@ The lifetime may be specified in seconds or as described in sshd_config(5)
 zstyle :omz:plugins:ssh-agent lifetime 4h
 ```
 
+To set an **external helper** to ask for the passwords and possibly store 
+them in the system keychain use the `helper` style. For example:
+
+```zsh
+zstyle :omz:plugins:ssh-agent helper ksshaskpass
+```
+
 ## Credits
 
 Based on code from Joseph M. Reagle: https://www.cygwin.com/ml/cygwin/2001-06/msg00537.html

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -46,7 +46,19 @@ function _add_identities() {
 		fi
 	done
 
-	[[ -n "$not_loaded" ]] && ssh-add ${^not_loaded}
+	# use user specified helper to ask for password (ksshaskpass, etc)
+	zstyle -s :omz:plugins:ssh-agent helper helper
+	in_from='/dev/stdin'
+	if [ ! -z "$helper" ]; then
+		if [ -z `command -v "$helper"` ]; then
+			echo "ssh-agent: the helper '$helper' has not been found."
+		else
+			export SSH_ASKPASS="$helper"
+			in_from='/dev/null'
+		fi
+	fi
+
+	[[ -n "$not_loaded" ]] && ssh-add ${^not_loaded} < "$in_from"
 }
 
 # Get the filename to store/lookup the environment from


### PR DESCRIPTION
By setting `SSH_ASKPASS=ksshaskpass` for example it is possible to use an helper to ask for the passwords to unlock the SSH keys. The helper may also able to store the password in the system keychain, without having to enter the passwords at every boot.

To make this mechanism work it is necessary to call 
```
ssh-add {identities} < /dev/null
```
