### PR TITLE
Add style environment variable to colorize plugin

### DIFF
--- a/plugins/colorize/README.md
+++ b/plugins/colorize/README.md
@@ -11,6 +11,12 @@ To use it, add colorize to the plugins array of your zshrc file:
 plugins=(... colorize)
 ```
 
+## Styles
+
+Pygments offers multiple styles. By default, the `default` style is used, but you can choose another theme by setting the `ZSH_COLORIZE_STYLE` environment variable:
+
+`ZSH_COLORIZE_STYLE="colorful"`
+
 ## Usage
 
 * `ccat  <file> [files]`: colorize the contents of the file (or files, if more than one are provided). 

--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -1,6 +1,6 @@
 # easier alias to use the plugin
 alias ccat='colorize_via_pygmentize'
-alias cless='colorize_via_pygmentize_less'  
+alias cless='colorize_via_pygmentize_less'
 
 colorize_via_pygmentize() {
     if ! (( $+commands[pygmentize] )); then
@@ -8,36 +8,44 @@ colorize_via_pygmentize() {
         return 1
     fi
 
+    # If the environment varianle ZSH_COLORIZE_STYLE
+    # is set, use that theme instead. Otherwise,
+    # use the default.
+    if [ -z $ZSH_COLORIZE_STYLE ]; then
+        ZSH_COLORIZE_STYLE="default"
+    fi
+
     # pygmentize stdin if no arguments passed
     if [ $# -eq 0 ]; then
-        pygmentize -g
+        pygmentize -O style="$ZSH_COLORIZE_STYLE" -g
         return $?
     fi
 
     # guess lexer from file extension, or
     # guess it from file contents if unsuccessful
+
     local FNAME lexer
     for FNAME in "$@"
     do
         lexer=$(pygmentize -N "$FNAME")
         if [[ $lexer != text ]]; then
-            pygmentize -l "$lexer" "$FNAME"
+            pygmentize -O style="$ZSH_COLORIZE_STYLE" -l "$lexer" "$FNAME"
         else
-            pygmentize -g "$FNAME"
+            pygmentize -O style="$ZSH_COLORIZE_STYLE" -g "$FNAME"
         fi
     done
 }
 
-colorize_via_pygmentize_less() (   
+colorize_via_pygmentize_less() (
     # this function is a subshell so tmp_files can be shared to cleanup function
     declare -a tmp_files 
-    
+
     cleanup () {
         [[ ${#tmp_files} -gt 0 ]] && rm -f "${tmp_files[@]}"
         exit
     }
     trap 'cleanup' EXIT HUP TERM INT
-    
+
     while (( $# != 0 )); do     #TODO: filter out less opts
         tmp_file="$(mktemp --tmpdir "tmp.colorize.XXXX.$(sed 's/\//./g' <<< "$1")")"
         tmp_files+=("$tmp_file")


### PR DESCRIPTION
These commits add an environment variable, `ZSH_COLORIZE_STYLE`, which allows users to set a custom `Pygments` theme for use within the oh-my-zsh colorize plugin.