### PR TITLE
Detect pyenv from Homebrew faster

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -4,7 +4,7 @@
 FOUND_PYENV=$+commands[pyenv]
 
 if [[ $FOUND_PYENV -ne 1 ]]; then
-    pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv")
+    pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
     for dir in $pyenvdirs; do
         if [[ -d $dir/bin ]]; then
             export PATH="$PATH:$dir/bin"


### PR DESCRIPTION
This makes `pyenv` plugin load faster if `pyenv` is installed using Homebrew. Adding a new search path prevents `brew --prefix pyenv` from being called which is very slow.

**rb**env plugin already has a similar path:

https://github.com/robbyrussell/oh-my-zsh/blob/9509fd6a9193e32e5c2d460786253ba0e98fd741/plugins/rbenv/rbenv.plugin.zsh#L6