### PR TITLE
Current check in compfix fails for empty strings

### DIFF
--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -18,7 +18,7 @@ function handle_completion_insecurities() {
   insecure_dirs=( ${(f@):-"$(compaudit 2>/dev/null)"} )
 
   # If no such directories exist, get us out of here.
-  [ -n ${#insecure_dirs+1} ] && return
+  [[ -z "${insecure_dirs}" ]] && return
 
   # List ownership and permissions of all insecure directories.
   print "[oh-my-zsh] Insecure completion-dependent directories detected:"

--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -18,7 +18,7 @@ function handle_completion_insecurities() {
   insecure_dirs=( ${(f@):-"$(compaudit 2>/dev/null)"} )
 
   # If no such directories exist, get us out of here.
-  (( ! ${#insecure_dirs} )) && return
+  [ -n ${#insecure_dirs+1} ] && return
 
   # List ownership and permissions of all insecure directories.
   print "[oh-my-zsh] Insecure completion-dependent directories detected:"


### PR DESCRIPTION
Issue produces following output on login:
```zsh
[oh-my-zsh] Insecure completion-dependent directories detected:
ls: cannot access : No such file or directory

[oh-my-zsh] For safety, we will not load completions from these directories until
[oh-my-zsh] you fix their permissions and ownership and restart zsh.
[oh-my-zsh] See the above list for directories with group or other writability.

[oh-my-zsh] To fix your permissions you can do so by disabling
[oh-my-zsh] the write permission of "group" and "others" and making sure that the
[oh-my-zsh] owner of these directories is either root or your current user.
[oh-my-zsh] The following command may help:
[oh-my-zsh]     compaudit | xargs chmod g-w,o-w

[oh-my-zsh] If the above didn't help or you want to skip the verification of
[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
```
For debug, added an `echo "${insecure_dirs}"` under `insecure_dirs` assignment, which produced an empty string.

This pull request fixes that with a POSIX-portable check.