### PR TITLE
Add support for searching in thewirecutter.com

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -37,6 +37,7 @@ Available search contexts are:
 | `ecosia`              | `https://www.ecosia.org/search?q=`       |
 | `goodreads`           | `https://www.goodreads.com/search?q=`    |
 | `qwant`               | `https://www.qwant.com/?q=`              |
+| `wc`                  | `https://thewirecutter.com/search/?s=`   |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -18,6 +18,7 @@ function web_search() {
     goodreads   "https://www.goodreads.com/search?q="
     qwant       "https://www.qwant.com/?q="
     stackoverflow  "https://stackoverflow.com/search?q="
+    wirecutter  "https://thewirecutter.com/search/?s="
   )
 
   # check whether the search engine is supported
@@ -53,6 +54,7 @@ alias ecosia='web_search ecosia'
 alias goodreads='web_search goodreads'
 alias qwant='web_search qwant'
 alias stack='web_search stackoverflow'
+alias wc='web_search wirecutter'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
@robbyrussell Changes add support for doing web search in website, thewirecutter.com . Tested locally by replacing zsh in my plugins folder.