### PR TITLE
ubuntu: plugin cleanup and rename of ag alias to age

### DIFF
--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds completions and aliases for [Ubuntu](https://www.ubuntu.com/).
 
-To use it, add `ubuntu` to the plugins array in your zshrc file: 
+To use it, add `ubuntu` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... ubuntu)
@@ -10,34 +10,34 @@ plugins=(... ubuntu)
 
 ## Aliases
 
-Commands that use `$APT` will use apt if installed or defer to apt-get otherwise. 
+Commands that use `$APT` will use `apt` if installed or defer to `apt-get` otherwise.
 
-| Alias   | Command                                                                | Description                                                                                       |
-|---------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| acs     | `apt-cache search`                                                     | Search the apt-cache with the specified criteria                                                  |
-| acp     | `apt-cache policy`                                                     | Display the package source priorities                                                             | 
-| afs     | `apt-file search --regexp`                                             | Perform a regular expression apt-file search                                                      |
-| afu     | `sudo apt-file update`                                                 | Generates or updates the apt-file package database                                                | 
-| ag      | `sudo $APT`                                                            | Run apt-get with sudo                                                                             | 
-| aga     | `sudo $APT autoclean`                                                  | Clears out the local reposityory of retrieved package files that can no longer be downloaded      | 
-| agb     | `sudo $APT build-dep <source_pkg>`                                     | Installs/Removes packages to satisfy the dependencies of a specified build pkg                    | 
-| agc     | `sudo $APT clean`                                                      | Clears out the local repository of retrieved package files leaving everything from the lock files | 
-| agd     | `sudo $APT dselect-upgrade`                                            | Follows dselect choices for package installation                                                  | 
-| agi     | `sudo $APT install <pkg>`                                              | Install the specified package                                                                     | 
-| agli    | `apt list --installed`                                                 | List the installed packages                                                                       | 
-| aglu    | `sudo apt-get -u upgrade --assume-no`                                  | Run an apt-get upgrade assuming no to all prompts                                                 | 
-| agp     | `sudo $APT purge <pkg>`                                                | Remove a package including any configuration files                                                | 
-| agr     | `sudo $APT remove <pkg>`                                               | Remove a package                                                                                  | 
-| ags     | `$APT source <pkg>`                                                    | Fetch the source for the specified package                                                        | 
-| agu     | `sudo $APT update`                                                     | Update package list                                                                               | 
-| agud    | `sudo $APT update && sudo $APT dist-upgrade`                           | Update packages list and perform a distribution upgrade                                           | 
-| agug    | `sudo $APT upgrade`                                                    | Upgrade available packages                                                                        | 
-| agar    | `sudo $APT autoremove`                                                 | Remove automatically installed packages no longer needed                                          | 
-| aguu    | `sudo $APT update && sudo $APT upgrade`                                | Update packages list and upgrade available packages                                               | 
-| allpkgs | `dpkg --get-selections \| grep -v deinstall`                           | Print all installed packages                                                                      | 
-| kclean  | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))`  |Remove ALL kernel images and headers EXCEPT the one in use                                         |
-| mydeb   | `time dpkg-buildpackage -rfakeroot -us -uc`                            | Create a basic .deb package                                                                       |
-| ppap    | `sudo ppa-purge <ppa>`                                                 | Remove the specified PPA                                                                          | 
+| Alias   | Command                                                                  | Description                                                                                       |
+|---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
+| acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
+| afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |
+| afu     | `sudo apt-file update`                                                   | Generates or updates the apt-file package database                                                |
+| ag      | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
+| aga     | `sudo $APT autoclean`                                                    | Clears out the local reposityory of retrieved package files that can no longer be downloaded      |
+| agb     | `sudo $APT build-dep <source_pkg>`                                       | Installs/Removes packages to satisfy the dependencies of a specified build pkg                    |
+| agc     | `sudo $APT clean`                                                        | Clears out the local repository of retrieved package files leaving everything from the lock files |
+| agd     | `sudo $APT dselect-upgrade`                                              | Follows dselect choices for package installation                                                  |
+| agi     | `sudo $APT install <pkg>`                                                | Install the specified package                                                                     |
+| agli    | `apt list --installed`                                                   | List the installed packages                                                                       |
+| aglu    | `sudo apt-get -u upgrade --assume-no`                                    | Run an apt-get upgrade assuming no to all prompts                                                 |
+| agp     | `sudo $APT purge <pkg>`                                                  | Remove a package including any configuration files                                                |
+| agr     | `sudo $APT remove <pkg>`                                                 | Remove a package                                                                                  |
+| ags     | `$APT source <pkg>`                                                      | Fetch the source for the specified package                                                        |
+| agu     | `sudo $APT update`                                                       | Update package list                                                                               |
+| agud    | `sudo $APT update && sudo $APT dist-upgrade`                             | Update packages list and perform a distribution upgrade                                           |
+| agug    | `sudo $APT upgrade`                                                      | Upgrade available packages                                                                        |
+| agar    | `sudo $APT autoremove`                                                   | Remove automatically installed packages no longer needed                                          |
+| aguu    | `sudo $APT update && sudo $APT upgrade`                                  | Update packages list and upgrade available packages                                               |
+| allpkgs | `dpkg --get-selections \| grep -v deinstall`                             | Print all installed packages                                                                      |
+| kclean  | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))` |Remove ALL kernel images and headers EXCEPT the one in use                                         |
+| mydeb   | `time dpkg-buildpackage -rfakeroot -us -uc`                              | Create a basic .deb package                                                                       |
+| ppap    | `sudo ppa-purge <ppa>`                                                   | Remove the specified PPA                                                                          |
 
 
 ## Functions
@@ -47,6 +47,14 @@ Commands that use `$APT` will use apt if installed or defer to apt-get otherwise
 | aar               | `aar ppa:xxxxxx/xxxxxx [packagename]` | apt-add-repository with automatic install/upgrade of the desired package |
 | apt-history       | `apt-history <action>`                | Prints the Apt history of the specified action                           |
 | apt-list-packages | `apt-list-packages`                   | List packages by size                                                    |
-| kerndeb           | `kerndeb`                             | Kernel-package building shortcut                                         | 
+| kerndeb           | `kerndeb`                             | Kernel-package building shortcut                                         |
 
+## Authors:
 
+- [@AlexBio](https://github.com/AlexBio)
+- [@dbb](https://github.com/dbb)
+- [@Mappleconfusers](https://github.com/Mappleconfusers)
+- [@trinaldi](https://github.com/trinaldi)
+- [Nicolas Jonas](https://nextgenthemes.com)
+- [@loctauxphilippe](https://github.com/loctauxphilippe)
+- [@HaraldNordgren](https://github.com/HaraldNordgren)

--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -14,11 +14,11 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 
 | Alias   | Command                                                                  | Description                                                                                       |
 |---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| age     | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
 | acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
 | acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
 | afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |
 | afu     | `sudo apt-file update`                                                   | Generates or updates the apt-file package database                                                |
-| ag      | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
 | aga     | `sudo $APT autoclean`                                                    | Clears out the local reposityory of retrieved package files that can no longer be downloaded      |
 | agb     | `sudo $APT build-dep <source_pkg>`                                       | Installs/Removes packages to satisfy the dependencies of a specified build pkg                    |
 | agc     | `sudo $APT clean`                                                        | Clears out the local repository of retrieved package files leaving everything from the lock files |

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -1,76 +1,43 @@
-# Authors:
-# https://github.com/AlexBio
-# https://github.com/dbb
-# https://github.com/Mappleconfusers
-# https://github.com/trinaldi
-# Nicolas Jonas nextgenthemes.com
-# https://github.com/loctauxphilippe
-# https://github.com/HaraldNordgren
-#
-# Debian, Ubuntu and friends related zsh aliases and functions for zsh
-
 (( $+commands[apt] )) && APT=apt || APT=apt-get
 
 alias acs='apt-cache search'
-compdef _acs acs='apt-cache search'
 
 alias afs='apt-file search --regexp'
-compdef _afs afs='apt-file search --regexp'
 
 # These are apt/apt-get only
-alias ags="$APT source"   # asrc
-compdef _ags ags="$APT source"
+alias ags="$APT source"
 
-alias acp='apt-cache policy' # app
-compdef _acp acp='apt-cache policy'
+alias acp='apt-cache policy'
 
 #List all installed packages
 alias agli='apt list --installed'
-compdef _agli agli='apt list --installed'
 
 # superuser operations ######################################################
 
 # List available updates only
 alias aglu='sudo apt-get -u upgrade --assume-no'
-compdef _aglu aglu='sudo apt-get -u upgrade --assume-no'
 
 alias afu='sudo apt-file update'
-compdef _afu afu='sudo apt-file update'
 
 alias ppap='sudo ppa-purge'
-compdef _ppap ppap='sudo ppa-purge'
 
-alias ag="sudo $APT"               # age - but without sudo
-alias aga="sudo $APT autoclean"    # aac
-alias agb="sudo $APT build-dep"    # abd
-alias agc="sudo $APT clean"        # adc
-alias agd="sudo $APT dselect-upgrade" # ads
-alias agi="sudo $APT install"      # ai
-alias agp="sudo $APT purge"        # ap
-alias agr="sudo $APT remove"       # ar
-alias agu="sudo $APT update"       # ad
-alias agud="sudo $APT update && sudo $APT dist-upgrade" #adu
-alias agug="sudo $APT upgrade"     # ag
-alias aguu="sudo $APT update && sudo $APT upgrade"      #adg
+alias ag="sudo $APT"
+alias aga="sudo $APT autoclean"
+alias agb="sudo $APT build-dep"
+alias agc="sudo $APT clean"
+alias agd="sudo $APT dselect-upgrade"
+alias agi="sudo $APT install"
+alias agp="sudo $APT purge"
+alias agr="sudo $APT remove"
+alias agu="sudo $APT update"
+alias agud="sudo $APT update && sudo $APT dist-upgrade"
+alias agug="sudo $APT upgrade"
+alias aguu="sudo $APT update && sudo $APT upgrade"
 alias agar="sudo $APT autoremove"
 
-compdef _ag ag="sudo $APT"
-compdef _aga aga="sudo $APT autoclean"
-compdef _agb agb="sudo $APT build-dep"
-compdef _agc agc="sudo $APT clean"
-compdef _agd agd="sudo $APT dselect-upgrade"
-compdef _agi agi="sudo $APT install"
-compdef _agp agp="sudo $APT purge"
-compdef _agr agr="sudo $APT remove"
-compdef _agu agu="sudo $APT update"
-compdef _agud agud="sudo $APT update && sudo $APT dist-upgrade"
-compdef _agug agug="sudo $APT upgrade"
-compdef _aguu aguu="sudo $APT update && sudo $APT upgrade"
-compdef _agar agar="sudo $APT autoremove"
 
 # Remove ALL kernel images and headers EXCEPT the one in use
-alias kclean='sudo aptitude remove -P ?and(~i~nlinux-(ima|hea) \
-	?not(~n`uname -r`))'
+alias kclean='sudo aptitude remove -P ?and(~i~nlinux-(ima|hea) ?not(~n`uname -r`))'
 
 # Misc. #####################################################################
 # print all installed packages
@@ -89,11 +56,11 @@ aar() {
 	else
 		read "PACKAGE?Type in the package name to install/upgrade with this ppa [${1##*/}]: "
 	fi
-	
+
 	if [ -z "$PACKAGE" ]; then
 		PACKAGE=${1##*/}
 	fi
-	
+
 	sudo apt-add-repository $1 && sudo $APT update
 	sudo $APT install $PACKAGE
 }
@@ -136,22 +103,22 @@ apt-history () {
 
 # Kernel-package building shortcut
 kerndeb () {
-    # temporarily unset MAKEFLAGS ( '-j3' will fail )
-    MAKEFLAGS=$( print - $MAKEFLAGS | perl -pe 's/-j\s*[\d]+//g' )
-    print '$MAKEFLAGS set to '"'$MAKEFLAGS'"
-	appendage='-custom' # this shows up in $ (uname -r )
-    revision=$(date +"%Y%m%d") # this shows up in the .deb file name
+  # temporarily unset MAKEFLAGS ( '-j3' will fail )
+  MAKEFLAGS=$( print - $MAKEFLAGS | perl -pe 's/-j\s*[\d]+//g' )
+  print '$MAKEFLAGS set to '"'$MAKEFLAGS'"
+  appendage='-custom' # this shows up in $(uname -r)
+  revision=$(date +"%Y%m%d") # this shows up in the .deb file name
 
-    make-kpkg clean
+  make-kpkg clean
 
-    time fakeroot make-kpkg --append-to-version "$appendage" --revision \
-        "$revision" kernel_image kernel_headers
+  time fakeroot make-kpkg --append-to-version "$appendage" --revision \
+      "$revision" kernel_image kernel_headers
 }
 
 # List packages by size
 function apt-list-packages {
-    dpkg-query -W --showformat='${Installed-Size} ${Package} ${Status}\n' | \
-    grep -v deinstall | \
-    sort -n | \
-    awk '{print $1" "$2}'
+  dpkg-query -W --showformat='${Installed-Size} ${Package} ${Status}\n' | \
+  grep -v deinstall | \
+  sort -n | \
+  awk '{print $1" "$2}'
 }

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -21,7 +21,7 @@ alias afu='sudo apt-file update'
 
 alias ppap='sudo ppa-purge'
 
-alias ag="sudo $APT"
+alias age="sudo $APT"
 alias aga="sudo $APT autoclean"
 alias agb="sudo $APT build-dep"
 alias agc="sudo $APT clean"


### PR DESCRIPTION
- Clean up plugin and README
- Rename ag to age to avoid conflict with The Silver Searcher:
  * Fixes #3866
  * Closes #5752
