### PR TITLE
Fix fd-find completions for debian

### DIFF
--- a/plugins/fd/_fd
+++ b/plugins/fd/_fd
@@ -1,4 +1,4 @@
-#compdef fd
+#compdef fd fdfind
 
 autoload -U is-at-least
 


### PR DESCRIPTION
In debian package, fd executable is renamed to fdfind.
(https://packages.debian.org/buster/fd-find)