### PR TITLE
More informative warning if plugin not found

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -53,7 +53,7 @@ for plugin ($plugins); do
   elif is_plugin $ZSH $plugin; then
     fpath=($ZSH/plugins/$plugin $fpath)
   else
-    echo "Warning: Oh My Zsh plugin '$plugin' not found"
+    echo "[oh-my-zsh] plugin '$plugin' not found"
   fi
 done
 

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -53,7 +53,7 @@ for plugin ($plugins); do
   elif is_plugin $ZSH $plugin; then
     fpath=($ZSH/plugins/$plugin $fpath)
   else
-    echo "Warning: plugin $plugin not found"
+    echo "Warning: Oh My Zsh plugin '$plugin' not found"
   fi
 done
 


### PR DESCRIPTION
A simple change to make the warning more informative when requesting a plugin in `~/.zshrc` that is not found.

In my case I just received the following text at the top of a new console window:

`Warning: plugin hub not found`

I surmised it must be an Oh My Zsh error but it took me a while to realise it was referring to the plugin called 'hub' not something called the 'plugin hub'. With the new version it would have said:

`Warning: Oh My Zsh plugin 'hub' not found`

which would have been easier to debug.