### PR TITLE
jira: fix error when assigned or reported are default

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -43,7 +43,11 @@ function jira() {
     echo "Opening new issue"
     open_command "${jira_url}/secure/CreateIssue!default.jspa"
   elif [[ "$action" == "assigned" || "$action" == "reported" ]]; then
-    _jira_query $@
+	if [[ -z "$@" ]]; then
+		_jira_query $action
+	else
+		_jira_query $@
+	fi
   elif [[ "$action" == "dashboard" ]]; then
     echo "Opening dashboard"
     if [[ "$JIRA_RAPID_BOARD" == "true" ]]; then

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -43,11 +43,7 @@ function jira() {
     echo "Opening new issue"
     open_command "${jira_url}/secure/CreateIssue!default.jspa"
   elif [[ "$action" == "assigned" || "$action" == "reported" ]]; then
-	if [[ -z "$@" ]]; then
-		_jira_query $action
-	else
-		_jira_query $@
-	fi
+    _jira_query ${@:-$action}
   elif [[ "$action" == "dashboard" ]]; then
     echo "Opening dashboard"
     if [[ "$JIRA_RAPID_BOARD" == "true" ]]; then


### PR DESCRIPTION
_git_query() expects command line arguments to be passed in but when set as default action, both assigned and reported fail with an error.