### PR TITLE
Update the swiftpm plugin autocompletion for Swift 5.0

### DIFF
--- a/plugins/swiftpm/README.md
+++ b/plugins/swiftpm/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager).
+This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager), as well as autocompletion for Swift 5.0.
 
 To start using it, add the `swiftpm` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -20,22 +20,3 @@ plugins=(... swiftpm)
 | `spx` | Generates an Xcode project          | `swift package generate-xcodeproj` |
 | `sps` | Print the resolved dependency graph | `swift package show-dependencies`  |
 | `spd` | Print parsed Package.swift as JSON  | `swift package dump-package`       |
-
-## Autocompletion
-
-The `_swift` file enables autocompletion for Swift Package Manager. Current version supports Swift 5.0
-
-
-### Updating the autocompletion for new version of Swift
-
-To update autocompletion to the Swift version present on your system:
-```
-swift package completion-tool generate-zsh-script > ~/.oh-my-zsh/plugins/swiftpm/_swift
-```
-
-### Known issues
-
-If `swiftpm` is not added to your zsh plugins list, autocompletion will still be triggered but will result in errors:
-```
-_values:compvalues:10: not enough arguments
-```

--- a/plugins/swiftpm/README.md
+++ b/plugins/swiftpm/README.md
@@ -20,3 +20,22 @@ plugins=(... swiftpm)
 | `spx` | Generates an Xcode project          | `swift package generate-xcodeproj` |
 | `sps` | Print the resolved dependency graph | `swift package show-dependencies`  |
 | `spd` | Print parsed Package.swift as JSON  | `swift package dump-package`       |
+
+## Autocompletion
+
+The `_swift` file enables autocompletion for Swift Package Manager. Current version supports Swift 5.0
+
+
+### Updating the autocompletion for new version of Swift
+
+To update autocompletion to the Swift version present on your system:
+```
+swift package completion-tool generate-zsh-script > ~/.oh-my-zsh/plugins/swiftpm/_swift
+```
+
+### Known issues
+
+If `swiftpm` is not added to your zsh plugins list, autocompletion will still be triggered but will result in errors:
+```
+_values:compvalues:10: not enough arguments
+```

--- a/plugins/swiftpm/_swift
+++ b/plugins/swiftpm/_swift
@@ -72,16 +72,23 @@ _swift_build() {
         "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
         "(--chdir -C)"{--chdir,-C}"[]: :_files"
         "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]'}"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
         "--disable-prefetching[]"
         "--skip-update[Skip updating dependencies from their remote during a resolution]"
         "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
         "--version[]"
         "--destination[]: :_files"
         "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
         "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
         "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--enable-build-manifest-caching[Enable llbuild manifest caching \[Experimental\]]"
+        "--enable-llbuild-library[Enable building with the llbuild library]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
         "--build-tests[Build both source and test targets]"
         "--product[Build the specified product]:Build the specified product: "
         "--target[Build the specified target]:Build the specified target: "
@@ -108,17 +115,26 @@ _swift_run() {
         "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
         "(--chdir -C)"{--chdir,-C}"[]: :_files"
         "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]'}"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
         "--disable-prefetching[]"
         "--skip-update[Skip updating dependencies from their remote during a resolution]"
         "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
         "--version[]"
         "--destination[]: :_files"
         "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
         "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
         "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--enable-build-manifest-caching[Enable llbuild manifest caching \[Experimental\]]"
+        "--enable-llbuild-library[Enable building with the llbuild library]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
         "--skip-build[Skip building the executable product]"
+        "--build-tests[Build both source and test targets]"
+        "--repl[Launch Swift REPL for the package]"
     )
     _arguments $arguments && return
 }
@@ -140,16 +156,23 @@ _swift_package() {
         "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
         "(--chdir -C)"{--chdir,-C}"[]: :_files"
         "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]'}"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
         "--disable-prefetching[]"
         "--skip-update[Skip updating dependencies from their remote during a resolution]"
         "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
         "--version[]"
         "--destination[]: :_files"
         "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
         "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
         "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--enable-build-manifest-caching[Enable llbuild manifest caching \[Experimental\]]"
+        "--enable-llbuild-library[Enable building with the llbuild library]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
         '(-): :->command'
         '(-)*:: :->arg'
     )
@@ -158,114 +181,74 @@ _swift_package() {
         (command)
             local modes
             modes=(
-                'edit:Put a package in editable mode'
-                'clean:Delete build artifacts'
-                'init:Initialize a new package'
-                'dump-package:Print parsed Package.swift as JSON'
-                'describe:Describe the current package'
-                'unedit:Remove a package from editable mode'
                 'update:Update package dependencies'
-                'completion-tool:Completion tool (for shell completions)'
-                'tools-version:Manipulate tools version of the current package'
-                'reset:Reset the complete cache/build directory'
+                'describe:Describe the current package'
                 'resolve:Resolve package dependencies'
-                'generate-xcodeproj:Generates an Xcode project'
-                'fetch:'
+                'tools-version:Manipulate tools version of the current package'
+                'unedit:Remove a package from editable mode'
                 'show-dependencies:Print the resolved dependency graph'
+                'fetch:'
+                'dump-package:Print parsed Package.swift as JSON'
+                'edit:Put a package in editable mode'
+                'config:Manipulate configuration of the package'
+                'completion-tool:Completion tool (for shell completions)'
+                'clean:Delete build artifacts'
+                'generate-xcodeproj:Generates an Xcode project'
+                'reset:Reset the complete cache/build directory'
+                'init:Initialize a new package'
             )
             _describe "mode" modes
             ;;
         (arg)
             case ${words[1]} in
-                (edit)
-                    _swift_package_edit
-                    ;;
-                (clean)
-                    _swift_package_clean
-                    ;;
-                (init)
-                    _swift_package_init
-                    ;;
-                (dump-package)
-                    _swift_package_dump-package
+                (update)
+                    _swift_package_update
                     ;;
                 (describe)
                     _swift_package_describe
                     ;;
-                (unedit)
-                    _swift_package_unedit
-                    ;;
-                (update)
-                    _swift_package_update
-                    ;;
-                (completion-tool)
-                    _swift_package_completion-tool
+                (resolve)
+                    _swift_package_resolve
                     ;;
                 (tools-version)
                     _swift_package_tools-version
                     ;;
-                (reset)
-                    _swift_package_reset
-                    ;;
-                (resolve)
-                    _swift_package_resolve
-                    ;;
-                (generate-xcodeproj)
-                    _swift_package_generate-xcodeproj
-                    ;;
-                (fetch)
-                    _swift_package_fetch
+                (unedit)
+                    _swift_package_unedit
                     ;;
                 (show-dependencies)
                     _swift_package_show-dependencies
                     ;;
+                (fetch)
+                    _swift_package_fetch
+                    ;;
+                (dump-package)
+                    _swift_package_dump-package
+                    ;;
+                (edit)
+                    _swift_package_edit
+                    ;;
+                (config)
+                    _swift_package_config
+                    ;;
+                (completion-tool)
+                    _swift_package_completion-tool
+                    ;;
+                (clean)
+                    _swift_package_clean
+                    ;;
+                (generate-xcodeproj)
+                    _swift_package_generate-xcodeproj
+                    ;;
+                (reset)
+                    _swift_package_reset
+                    ;;
+                (init)
+                    _swift_package_init
+                    ;;
             esac
             ;;
     esac
-}
-
-_swift_package_edit() {
-    arguments=(
-        ":The name of the package to edit:_swift_dependency"
-        "--revision[The revision to edit]:The revision to edit: "
-        "--branch[The branch to create]:The branch to create: "
-        "--path[Create or use the checkout at this path]:Create or use the checkout at this path:_files"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_clean() {
-    arguments=(
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_init() {
-    arguments=(
-        "--type[empty|library|executable|system-module]: :{_values '' 'empty[generates an empty project]' 'library[generates project for a dynamic library]' 'executable[generates a project for a cli executable]' 'system-module[generates a project for a system module]'}"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_dump-package() {
-    arguments=(
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_describe() {
-    arguments=(
-        "--type[json|text]: :{_values '' 'text[describe using text format]' 'json[describe using JSON format]'}"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_unedit() {
-    arguments=(
-        ":The name of the package to unedit:_swift_dependency"
-        "--force[Unedit the package even if it has uncommited and unpushed changes.]"
-    )
-    _arguments $arguments && return
 }
 
 _swift_package_update() {
@@ -274,23 +257,9 @@ _swift_package_update() {
     _arguments $arguments && return
 }
 
-_swift_package_completion-tool() {
+_swift_package_describe() {
     arguments=(
-        ": :{_values '' 'generate-bash-script[generate Bash completion script]' 'generate-zsh-script[generate Bash completion script]' 'list-dependencies[list all dependencies' names]' 'list-executables[list all executables' names]'}"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_tools-version() {
-    arguments=(
-        "--set[Set tools version of package to the given value]:Set tools version of package to the given value: "
-        "--set-current[Set tools version of package to the current tools version in use]"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_reset() {
-    arguments=(
+        "--type[json|text]: :{_values '' 'text[describe using text format]' 'json[describe using JSON format]'}"
     )
     _arguments $arguments && return
 }
@@ -305,13 +274,25 @@ _swift_package_resolve() {
     _arguments $arguments && return
 }
 
-_swift_package_generate-xcodeproj() {
+_swift_package_tools-version() {
     arguments=(
-        "--xcconfig-overrides[Path to xcconfig file]:Path to xcconfig file:_files"
-        "--enable-code-coverage[Enable code coverage in the generated project]"
-        "--output[Path where the Xcode project should be generated]:Path where the Xcode project should be generated:_files"
-        "--legacy-scheme-generator[Use the legacy scheme generator]"
-        "--watch[Watch for changes to the Package manifest to regenerate the Xcode project]"
+        "--set[Set tools version of package to the given value]:Set tools version of package to the given value: "
+        "--set-current[Set tools version of package to the current tools version in use]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_unedit() {
+    arguments=(
+        ":The name of the package to unedit:_swift_dependency"
+        "--force[Unedit the package even if it has uncommited and unpushed changes.]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_show-dependencies() {
+    arguments=(
+        "--format[text|dot|json|flatlist]: :{_values '' 'text[list dependencies using text format]' 'dot[list dependencies using dot format]' 'json[list dependencies using JSON format]'}"
     )
     _arguments $arguments && return
 }
@@ -322,9 +303,112 @@ _swift_package_fetch() {
     _arguments $arguments && return
 }
 
-_swift_package_show-dependencies() {
+_swift_package_dump-package() {
     arguments=(
-        "--format[text|dot|json|flatlist]: :{_values '' 'text[list dependencies using text format]' 'dot[list dependencies using dot format]' 'json[list dependencies using JSON format]'}"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_edit() {
+    arguments=(
+        ":The name of the package to edit:_swift_dependency"
+        "--revision[The revision to edit]:The revision to edit: "
+        "--branch[The branch to create]:The branch to create: "
+        "--path[Create or use the checkout at this path]:Create or use the checkout at this path:_files"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config() {
+    arguments=(
+        '(-): :->command'
+        '(-)*:: :->arg'
+    )
+    _arguments $arguments && return
+    case $state in
+        (command)
+            local modes
+            modes=(
+                'unset-mirror:Remove an existing mirror'
+                'set-mirror:Set a mirror for a dependency'
+                'get-mirror:Print mirror configuration for the given package dependency'
+            )
+            _describe "mode" modes
+            ;;
+        (arg)
+            case ${words[1]} in
+                (unset-mirror)
+                    _swift_package_config_unset-mirror
+                    ;;
+                (set-mirror)
+                    _swift_package_config_set-mirror
+                    ;;
+                (get-mirror)
+                    _swift_package_config_get-mirror
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_swift_package_config_unset-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+        "--mirror-url[The mirror url]:The mirror url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config_set-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+        "--mirror-url[The mirror url]:The mirror url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_config_get-mirror() {
+    arguments=(
+        "--package-url[The package dependency url]:The package dependency url: "
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_completion-tool() {
+    arguments=(
+        ": :{_values '' 'generate-bash-script[generate Bash completion script]' 'generate-zsh-script[generate Bash completion script]' 'list-dependencies[list all dependencies' names]' 'list-executables[list all executables' names]'}"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_clean() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_generate-xcodeproj() {
+    arguments=(
+        "--xcconfig-overrides[Path to xcconfig file]:Path to xcconfig file:_files"
+        "--enable-code-coverage[Enable code coverage in the generated project]"
+        "--output[Path where the Xcode project should be generated]:Path where the Xcode project should be generated:_files"
+        "--legacy-scheme-generator[Use the legacy scheme generator]"
+        "--watch[Watch for changes to the Package manifest to regenerate the Xcode project]"
+        "--skip-extra-files[Do not add file references for extra files to the generated Xcode project]"
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_reset() {
+    arguments=(
+    )
+    _arguments $arguments && return
+}
+
+_swift_package_init() {
+    arguments=(
+        "--type[empty|library|executable|system-module]: :{_values '' 'empty[generates an empty project]' 'library[generates project for a dynamic library]' 'executable[generates a project for a cli executable]' 'system-module[generates a project for a system module]'}"
+        "--name[Provide custom package name]:Provide custom package name: "
     )
     _arguments $arguments && return
 }
@@ -346,23 +430,32 @@ _swift_test() {
         "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
         "(--chdir -C)"{--chdir,-C}"[]: :_files"
         "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]'}"
+        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
         "--disable-prefetching[]"
         "--skip-update[Skip updating dependencies from their remote during a resolution]"
         "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
+        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
         "--version[]"
         "--destination[]: :_files"
         "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
         "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
         "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--enable-build-manifest-caching[Enable llbuild manifest caching \[Experimental\]]"
+        "--enable-llbuild-library[Enable building with the llbuild library]"
+        "--force-resolved-versions[]"
+        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
+        "--enable-index-store[Enable indexing-while-building feature]"
+        "--disable-index-store[Disable indexing-while-building feature]"
+        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
+        "--enable-parseable-module-interfaces[]"
         "--skip-build[Skip building the test target]"
         "(--list-tests -l)"{--list-tests,-l}"[Lists test methods in specifier format]"
         "--generate-linuxmain[Generate LinuxMain.swift entries for the package]"
         "--parallel[Run the tests in parallel.]"
+        "--num-workers[Number of tests to execute in parallel.]:Number of tests to execute in parallel.: "
         "(--specifier -s)"{--specifier,-s}"[]: : "
         "--xunit-output[]: :_files"
         "--filter[Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>]:Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>: "
+        "--enable-code-coverage[Test with code coverage enabled]"
     )
     _arguments $arguments && return
 }


### PR DESCRIPTION
Fixes #7743
Updates autocompletion to Swift 5.0

Generated automatically using:
```
swift package completion-tool generate-zsh-script > ~/.oh-my-zsh/plugins/swiftpm/_swift
```