### PR TITLE
Fix showing aws prompt out of the box for 'fishy' theme

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -24,7 +24,9 @@ plugins=(... aws)
 
 ## Plugin options
 
-* Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT. Some plugins overwrite the value of RPROMPT instead of appending to it, so they need to be fixed to see a default aws plugin RPROMPT message (for example theme fishy is fixed).
+* Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT.
+  Some themes might overwrite the value of RPROMPT instead of appending to it, so they'll need to be fixed to
+  see the AWS profile prompt.
 
 ## Theme
 

--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -24,7 +24,7 @@ plugins=(... aws)
 
 ## Plugin options
 
-* Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT.
+* Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT. Some plugins overwrite the value of RPROMPT instead of appending to it, so they need to be fixed to see a default aws plugin RPROMPT message (for example theme fishy is fixed).
 
 ## Theme
 

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -44,7 +44,7 @@ function aws_prompt_info() {
 }
 
 if [ "$SHOW_AWS_PROMPT" != false ]; then
-  export RPROMPT='$(aws_prompt_info)'"$RPROMPT"
+  RPROMPT='$(aws_prompt_info)'"$RPROMPT"
 fi
 
 

--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -14,7 +14,7 @@ PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>)
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 
 local return_status="%{$fg_bold[red]%}%(?..%?)%{$reset_color%}"
-RPROMPT='${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
+RPROMPT="${RPROMPT}"'${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" "
 ZSH_THEME_GIT_PROMPT_SUFFIX=""


### PR DESCRIPTION
Fix issue related to #7615
After the update, aws prompt (which should be visible out of the box) disappears when a user uses a theme fishy, because of fact that plugins are loaded before themes.
This line:
```
/Users/jw/.oh-my-zsh/plugins/aws/aws.plugin.zsh:47> export RPROMPT='$(aws_prompt_info)${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
```
is overwritten during startup by below line:
```
/Users/jw/.oh-my-zsh/themes/fishy.zsh-theme:17> RPROMPT='${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
```
This pull request fixes issue with not showing aws prompt in theme fishy, by appending RPROMPT in theme fishy instead overwriting (way mentioned in #6346) and adds information about it in documentation.