### PR TITLE
kubectl: rename k alias

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -13,7 +13,7 @@ plugins=(... kubectl)
 
 | Alias   | Command                             | Description                                                                                      |
 |:--------|:------------------------------------|:-------------------------------------------------------------------------------------------------|
-| k       | `kubectl`                           | The kubectl command                                                                              |
+| k / ku  | `kubectl`                           | The kubectl command                                                                              |
 | kca     | `kubectl --all-namespaces`          | The kubectl command targeting all namespaces                                                     |
 | kaf     | `kubectl apply -f`                  | Apply a YML file                                                                                 |
 | keti    | `kubectl exec -ti`                  | Drop into an interactive terminal on a container                                                 |

--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -13,7 +13,7 @@ plugins=(... kubectl)
 
 | Alias   | Command                             | Description                                                                                      |
 |:--------|:------------------------------------|:-------------------------------------------------------------------------------------------------|
-| k / ku  | `kubectl`                           | The kubectl command                                                                              |
+| ku      | `kubectl`                           | The kubectl command                                                                              |
 | kca     | `kubectl --all-namespaces`          | The kubectl command targeting all namespaces                                                     |
 | kaf     | `kubectl apply -f`                  | Apply a YML file                                                                                 |
 | keti    | `kubectl exec -ti`                  | Drop into an interactive terminal on a container                                                 |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -10,9 +10,7 @@ if (( $+commands[kubectl] )); then
     unset __KUBECTL_COMPLETION_FILE
 fi
 
-# This command is used a LOT both below and in daily life
-# If supercrabtree/k exists use ku instead of k
-(( $+functions[k] )) && alias k=kubectl || alias ku=kubectl
+alias ku=kubectl
 
 # Execute a kubectl command against all namespaces
 alias kca='f(){ kubectl "$@" --all-namespaces;  unset -f f; }; f'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -11,7 +11,8 @@ if (( $+commands[kubectl] )); then
 fi
 
 # This command is used a LOT both below and in daily life
-alias k=kubectl
+# If supercrabtree/k exists use ku instead of k
+(( $+functions[k] )) && alias k=kubectl || alias ku=kubectl
 
 # Execute a kubectl command against all namespaces
 alias kca='f(){ kubectl "$@" --all-namespaces;  unset -f f; }; f'


### PR DESCRIPTION
This uses `ku` instead of `k` as an alias for kubectl ~~if [supercrabtree/k](https://github.com/supercrabtree/k) has been installed. Requires that k has been sourced before the kubectl plugin.~~

Fixes #6408