### PR TITLE
Remove TRAPWINCH from vi-mode plugin

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -4,11 +4,6 @@ function zle-keymap-select() {
   zle -R
 }
 
-# Ensure that the prompt is redrawn when the terminal size changes.
-TRAPWINCH() {
-  zle && { zle -R; zle reset-prompt }
-}
-
 zle -N zle-keymap-select
 zle -N edit-command-line
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,5 +1,8 @@
 # Updates editor information when the keymap changes.
 function zle-keymap-select() {
+  # update keymap variable for the prompt
+  VI_KEYMAP=$KEYMAP
+
   zle reset-prompt
   zle -R
 }
@@ -37,7 +40,7 @@ if [[ "$MODE_INDICATOR" == "" ]]; then
 fi
 
 function vi_mode_prompt_info() {
-  echo "${${KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/}"
+  echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/}"
 }
 
 # define right prompt, if it wasn't defined by a theme


### PR DESCRIPTION
Given that traps are global, it's uncool to set them without a good reason. vi-mode plugin traps SIGWINCH with a generic function unrelated to the functionality of the plugin. This PR removes it.

If calling `zle reset-prompt` on SIGWINCH was generally useful (it isn't), it would've been done in zsh itself or in the core of oh-my-zsh.

Note that `reset-prompt` triggers a bug in zsh that causes completion menu disappear. See https://www.zsh.org/mla/workers//2019/msg00161.html.