### PR TITLE
python: Fix and extend pyclean

### DIFF
--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -1,13 +1,14 @@
 # Find python file
 alias pyfind='find . -name "*.py"'
 
-# Remove python compiled byte-code and mypy cache in either current directory or in a
-# list of specified directories
+# Remove python compiled byte-code and mypy/pytest cache in either the current
+# directory or in a list of specified directories (including sub directories).
 function pyclean() {
     ZSH_PYCLEAN_PLACES=${*:-'.'}
     find ${ZSH_PYCLEAN_PLACES} -type f -name "*.py[co]" -delete
     find ${ZSH_PYCLEAN_PLACES} -type d -name "__pycache__" -delete
-    find ${ZSH_PYCLEAN_PLACES} -type d -name ".mypy_cache" -delete
+    find ${ZSH_PYCLEAN_PLACES} -depth -type d -name ".mypy_cache" -exec rm -r "{}" +
+    find ${ZSH_PYCLEAN_PLACES} -depth -type d -name ".pytest_cache" -exec rm -r "{}" +
 }
 
 # Grep among .py files


### PR DESCRIPTION
Deleting `.mypy_cache` did not work, because the directories were not empty.  They contain JSON files instead of compiled byte-code.  (ref PR robbyrussell/oh-my-zsh#7151)

This extends the cleanup by also getting rid of `.pytest_cache` directories.

`-O1` takes care of reordering expressions in order to perform the test based on `-name` first.