### PR TITLE
#5569 ENV to disable magic

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,7 +1,7 @@
 ## Load smart urls if available
 # bracketed-paste-magic is known buggy in zsh 5.1.1 (only), so skip it there; see #4434
 autoload -Uz is-at-least
-if [[ $ZSH_VERSION != 5.1.1 ]]; then
+if [[ "$ZSH_VERSION" != "5.1.1" && "$ZSH_LOAD_MAGIC" != "false" ]]; then
   for d in $fpath; do
   	if [[ -e "$d/url-quote-magic" ]]; then
   		if is-at-least 5.1; then


### PR DESCRIPTION
Adding an environment variable to disable the magic loader instead of manipulating files as workaround for #5569