### PR TITLE
Revert cab1ac6e682038b2ceca9d16f8c458c0e79149ca

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -5,7 +5,7 @@ _emacsfun()
     # get list of emacs frames.
     frameslist=`emacsclient --alternate-editor '' --eval '(frame-list)' 2>/dev/null | egrep -o '(frame)+'`
 
-    if [ "$(echo "$frameslist" | sed -n '$=')" -ge 1 ] ;then
+    if [ "$(echo "$frameslist" | sed -n '$=')" -ge 2 ] ;then
         # prevent creating another X frame if there is at least one present.
         emacsclient --alternate-editor "" "$@"
     else


### PR DESCRIPTION
Revert cab1ac6e682038b2ceca9d16f8c458c0e79149ca

The change from the above commit breaks opening a new emacs frame if
there isn't a existing frame open.

When emacs is running in daemon mode, there will always be a frame
associated with the daemon, even if there are no visible frames.

The lisp function `frame-list`, will always return 1 frame.
```
emacsclient --eval '(frame-list)'
(#<frame F1 0xa3c680>)
```

When an real frame is open, two frames are reported by the `frame-list`
function.
```
emacsclient --eval '(frame-list)'
(#<frame F1 0xa3c680> #<frame emacs Prelude - ~/oh-my-zsh/plugins/emacs/emacsclient.sh 0xf50e10>)
```

See:
https://emacs.stackexchange.com/questions/44537/extra-frame-in-visible-frame-list-when-started-in-daemon-mode-is-causing-prob
https://emacs.stackexchange.com/questions/18859/dont-let-the-daemon-frame-make-a-file-visible