### PR TITLE
bira: remove extra space

### DIFF
--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -22,7 +22,7 @@ fi
 local git_branch='$(git_prompt_info)%{$reset_color%}'
 local venv_prompt='$(virtualenv_prompt_info)%{$reset_color%}'
 
-PROMPT="╭─${venv_prompt} ${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
+PROMPT="╭─${venv_prompt}${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
 ╰─%B${user_symbol}%b "
 RPS1="%B${return_code}%b"
 
@@ -31,3 +31,4 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
 
 ZSH_THEME_VIRTUAL_ENV_PROMPT_PREFIX="%{$fg[green]%}‹"
 ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX="› %{$reset_color%}"
+ZSH_THEME_VIRTUALENV_SUFFIX="] "

--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -3,26 +3,26 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
 
 if [[ $UID -eq 0 ]]; then
-    local user_host='%{$terminfo[bold]$fg[red]%}%n@%m%{$reset_color%}'
+    local user_host='%{$terminfo[bold]$fg[red]%}%n@%m %{$reset_color%}'
     local user_symbol='#'
 else
-    local user_host='%{$terminfo[bold]$fg[green]%}%n@%m%{$reset_color%}'
+    local user_host='%{$terminfo[bold]$fg[green]%}%n@%m %{$reset_color%}'
     local user_symbol='$'
 fi
 
-local current_dir='%{$terminfo[bold]$fg[blue]%}%~%{$reset_color%}'
+local current_dir='%{$terminfo[bold]$fg[blue]%}%~ %{$reset_color%}'
 local rvm_ruby=''
 if which rvm-prompt &> /dev/null; then
-  rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
+  rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)› %{$reset_color%}'
 else
   if which rbenv &> /dev/null; then
-    rvm_ruby='%{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
+    rvm_ruby='%{$fg[red]%}‹$(rbenv version | sed -e "s/ (set.*$//")› %{$reset_color%}'
   fi
 fi
-local git_branch='$(git_prompt_info)%{$reset_color%}'
-local venv_prompt='$(virtualenv_prompt_info)%{$reset_color%}'
+local git_branch='$(git_prompt_info)'
+local venv_prompt='$(virtualenv_prompt_info)'
 
-PROMPT="╭─${venv_prompt}${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
+PROMPT="╭─${venv_prompt}${user_host}${current_dir}${rvm_ruby}${git_branch}
 ╰─%B${user_symbol}%b "
 RPS1="%B${return_code}%b"
 
@@ -31,4 +31,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
 
 ZSH_THEME_VIRTUAL_ENV_PROMPT_PREFIX="%{$fg[green]%}‹"
 ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX="› %{$reset_color%}"
-ZSH_THEME_VIRTUALENV_SUFFIX="] "
+
+ZSH_THEME_VIRTUALENV_PREFIX=$ZSH_THEME_VIRTUAL_ENV_PROMPT_PREFIX
+ZSH_THEME_VIRTUALENV_SUFFIX=$ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX


### PR DESCRIPTION
`venv_prompt` add extra space before `user_host` when is not activated. It's must be fixed to restore traditional behaviour:

![image](https://user-images.githubusercontent.com/18448635/56096799-3713d580-5f06-11e9-83d6-384c806c1bfb.png)

P.S. You can use [bira-original.zsh-theme](https://gist.github.com/KillWolfVlad/f9c65c8578f50ac969de15eafb7c31c6) to get this solution right now!
