### PR TITLE
Remove a dot from twitter url in installer

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -103,7 +103,7 @@ main() {
   echo ''
   echo 'Please look over the ~/.zshrc file to select plugins, themes, and options.'
   echo ''
-  echo 'p.s. Follow us at https://twitter.com/ohmyzsh.'
+  echo 'p.s. Follow us at https://twitter.com/ohmyzsh'
   echo ''
   echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh.'
   echo ''

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -105,7 +105,7 @@ main() {
   echo ''
   echo 'p.s. Follow us at https://twitter.com/ohmyzsh'
   echo ''
-  echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh.'
+  echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh'
   echo ''
   printf "${NORMAL}"
   env zsh -l


### PR DESCRIPTION
When oh-my-zsh is installed, the welcome message has twitter url, when click it redirects to non existent profile.