### PR TITLE
Colored ls output in FreeBSD #7565

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -19,7 +19,7 @@ if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
     # coreutils, so prefer it to "gls".
     gls --color -d . &>/dev/null && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null && alias ls='colorls -G'
-  elif [[ "$OSTYPE" == darwin* ]]; then
+  elif [[ "$OSTYPE" == (darwin|freebsd)* ]]; then
     # this is a good alias, it works by default just using $LSCOLORS
     ls -G . &>/dev/null && alias ls='ls -G'
 


### PR DESCRIPTION
Enable colored "ls" output in FreeBSD (#[7565](https://github.com/robbyrussell/oh-my-zsh/issues/7565))