### PR TITLE
Add non-interactive option to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ If you have any hiccups installing, here are a few common fixes.
 * You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after switching to `oh-my-zsh`.
 * If you installed manually or changed the install location, check the `ZSH` environment variable in `~/.zshrc`.
 
+### Non-Interactive Installation
+
+If you would prefer not to enter zsh after the installation script finishes, set the `NO_INTERACTIVE` env variable
+```shell
+NO_INTERACTIVE=true sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+```
+
 ### Custom Plugins and Themes
 
 If you want to override any of the default behaviors, just add a new file (ending in `.zsh`) in the `custom/` directory.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -108,7 +108,18 @@ main() {
   echo 'p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh'
   echo ''
   printf "${NORMAL}"
-  env zsh -l
+
+	if [ ${no_interactive} ]; then
+		exit
+	fi
+
+	env zsh -l
 }
 
-main
+for arg in "$@"; do
+	case "$arg" in
+		--no-interactive) no_interactive=true
+	esac
+done
+
+main ${no_interactive}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -109,17 +109,11 @@ main() {
   echo ''
   printf "${NORMAL}"
 
-  if [ ${no_interactive} ]; then
+  if [ $NO_INTERACTIVE ]; then
     exit
   fi
 
   env zsh -l
 }
 
-for arg in "$@"; do
-	case "$arg" in
-		--no-interactive) no_interactive=true
-	esac
-done
-
-main ${no_interactive}
+main

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -109,11 +109,11 @@ main() {
   echo ''
   printf "${NORMAL}"
 
-	if [ ${no_interactive} ]; then
-		exit
-	fi
+  if [ ${no_interactive} ]; then
+    exit
+  fi
 
-	env zsh -l
+  env zsh -l
 }
 
 for arg in "$@"; do


### PR DESCRIPTION
The install script drops into `zsh` when its finished installing. For this PR, that behavior has been retained as the default, but if the `NO_INTERACTIVE` environmental variable is set, it will exit rather than entering `zsh`.

The purpose of this change is to make the script more amenable to use inside other scripts.