### PR TITLE
Remove extra newline from prompt

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -1,7 +1,6 @@
 # AVIT ZSH Theme
 
-PROMPT='
-$(_user_host)${_current_dir} $(git_prompt_info) $(_ruby_version)
+PROMPT='$(_user_host)${_current_dir} $(git_prompt_info) $(_ruby_version)
 %{$fg[$CARETCOLOR]%}▶%{$resetcolor%} '
 
 PROMPT2='%{$fg[$CARETCOLOR]%}◀%{$reset_color%} '


### PR DESCRIPTION
There is an extra newline caused by how the prompt format string is written, removed the extra newline for correct prompt output.