### PR TITLE
vi-mode: reset KEYMAP on accept-line

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -8,13 +8,24 @@ function zle-keymap-select() {
 }
 
 zle -N zle-keymap-select
-zle -N edit-command-line
+
+function vi-accept-line() {
+  VI_KEYMAP=main
+  zle accept-line
+}
+
+zle -N vi-accept-line
 
 
 bindkey -v
 
+# use custom accept-line widget to update $VI_KEYMAP
+bindkey -M vicmd '^J' vi-accept-line
+bindkey -M vicmd '^M' vi-accept-line
+
 # allow v to edit the command line (standard behaviour)
 autoload -Uz edit-command-line
+zle -N edit-command-line
 bindkey -M vicmd 'v' edit-command-line
 
 # allow ctrl-p, ctrl-n for navigate history (standard behaviour)


### PR DESCRIPTION
Fixes #7797

This resets the `$VI_KEYMAP` variable back to `main` when <kbd>Enter</kbd> is pressed. For some reason, `zle-keymap-select` isn't triggered when that happens.

Another option is using `zle-line-init` which *is* called when Enter is pressed, since a new command *line* is drawn, but it could have side-effects for multiline prompts (see https://unix.stackexchange.com/a/1019).