### PR TITLE
Add new kubectl alias to list all contexts

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -22,6 +22,7 @@ plugins=(... kubectl)
 | kcsc    | `kubectl config set-context`        | Set a context entry in kubeconfig                                                                |
 | kcdc    | `kubectl config delete-context`     | Delete the specified context from the kubeconfig                                                 |
 | kccc    | `kubectl config current-context`    | Display the current-context                                                                      |
+| kcgc    | `kubectl config get-contexts` | List of contexts available
 |         |                                     | **General aliases**                                                                              |
 | kdel    | `kubectl delete`                    | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
 | kdelf   | `kubectl delete -f`                 | Delete a pod using the type and name specified in -f argument                                    |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -28,6 +28,9 @@ alias kcsc='kubectl config set-context'
 alias kcdc='kubectl config delete-context'
 alias kccc='kubectl config current-context'
 
+# List all contexts
+alias kcgc='kubectl config get-contexts'
+
 # General aliases
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'


### PR DESCRIPTION
Small tweak to add an alias for listing all contexts. Tried to use it and realised it wasn't here.