### PR TITLE
frontend-search: add Angular 2 context

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -32,7 +32,8 @@ Available search contexts are:
 
 | context       | URL                                                                      |
 |---------------|--------------------------------------------------------------------------|
-| angularjs     | `https://angular.io/?search=`                                             |
+| angular(>=2.0)| `https://angular.io/?search=`                                             |
+| angularjs(1.x)| `https://google.com/search?as_sitesearch=angularjs.org&as_q=`
 | aurajs        | `http://aurajs.com/api/#stq=`                                            |
 | bem           | `https://google.com/search?as_sitesearch=bem.info&as_q=`                 |
 | bootsnipp     | `https://bootsnipp.com/search?q=`                                         |

--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -32,7 +32,7 @@ Available search contexts are:
 
 | context       | URL                                                                      |
 |---------------|--------------------------------------------------------------------------|
-| angularjs     | `https://google.com/search?as_sitesearch=angularjs.org&as_q=`            |
+| angularjs     | `https://angular.io/?search=`                                             |
 | aurajs        | `http://aurajs.com/api/#stq=`                                            |
 | bem           | `https://google.com/search?as_sitesearch=bem.info&as_q=`                 |
 | bootsnipp     | `https://bootsnipp.com/search?q=`                                         |

--- a/plugins/frontend-search/_frontend-search.sh
+++ b/plugins/frontend-search/_frontend-search.sh
@@ -33,7 +33,8 @@ function _frontend() {
     'unheap: Search in unheap website'
     'bem: Search in BEM website'
     'smacss: Search in SMACSS website'
-    'angularjs: Search in Angular website'
+    'angular: Search in Angular website for Angular 2.x'
+    'angularjs: Search in Angular website for Angular 1.x'
     'reactjs: Search in React website'
     'emberjs: Search in Ember website'
     'stackoverflow: Search in StackOverflow website'
@@ -99,6 +100,9 @@ function _frontend() {
         smacss)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
+        angular)
+          _describe -t points "Warp points" frontend_points && ret=0
+        ;;
         angularjs)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -26,7 +26,7 @@ function frontend() {
   # define search context URLS
   typeset -A urls
   urls=(
-    angularjs      'https://google.com/search?as_sitesearch=angularjs.org&as_q='
+    angularjs      'https://angular.io/?search='
     aurajs         'http://aurajs.com/api/#stq='
     bem            'https://google.com/search?as_sitesearch=bem.info&as_q='
     bootsnipp      'https://bootsnipp.com/search?q='
@@ -53,7 +53,7 @@ function frontend() {
   if [[ $# -lt 2 ]]
   then
       print -P "Usage: frontend %Ucontext%u %Uterm%u [...%Umore%u] (or just: %Ucontext%u %Uterm%u [...%Umore%u])"
-      print -P ""
+      print -P "sample"
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -26,7 +26,8 @@ function frontend() {
   # define search context URLS
   typeset -A urls
   urls=(
-    angularjs      'https://angular.io/?search='
+    angular        'https://angular.io/?search='
+    angularjs      'https://google.com/search?as_sitesearch=angularjs.org&as_q='
     aurajs         'http://aurajs.com/api/#stq='
     bem            'https://google.com/search?as_sitesearch=bem.info&as_q='
     bootsnipp      'https://bootsnipp.com/search?q='
@@ -57,7 +58,7 @@ function frontend() {
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
-      print -P "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
+      print -P "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
       print -P "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,"
       print -P "  qunit, reactjs, smacss, stackoverflow, unheap"
       print -P ""
@@ -73,7 +74,7 @@ function frontend() {
     echo ""
     echo "Valid contexts are:"
     echo ""
-    echo "  angularjs, aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, "
+    echo "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, "
     echo "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,  "
     echo "  qunit, reactjs, smacss, stackoverflow, unheap"
     echo ""

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -53,7 +53,7 @@ function frontend() {
   if [[ $# -lt 2 ]]
   then
       print -P "Usage: frontend %Ucontext%u %Uterm%u [...%Umore%u] (or just: %Ucontext%u %Uterm%u [...%Umore%u])"
-      print -P "sample"
+      print -P ""
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
@@ -83,7 +83,7 @@ function frontend() {
   # build search url:
   # join arguments passed with '+', then append to search context URL
   # TODO substitute for proper urlencode method
-  url="${urls[$1]}${(j:+:)@[2,-1]}"
+  url="${urls[$1]}${(j:%20:)@[2,-1]}"
 
   echo "Opening $url ..."
 

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -1,3 +1,4 @@
+alias angular='frontend angular'
 alias angularjs='frontend angularjs'
 alias aurajs='frontend aurajs'
 alias bem='frontend bem'
@@ -58,9 +59,9 @@ function frontend() {
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
-      print -P "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
-      print -P "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,"
-      print -P "  qunit, reactjs, smacss, stackoverflow, unheap"
+      print -P "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen,"
+      print -P "  compassdoc, cssflow, dartlang, emberjs, fontello, html5please, jquery,"
+      print -P "  lodash, mdn, npmjs, qunit, reactjs, smacss, stackoverflow, unheap"
       print -P ""
       print -P "For example: frontend npmjs mocha (or just: npmjs mocha)."
       print -P ""
@@ -74,15 +75,15 @@ function frontend() {
     echo ""
     echo "Valid contexts are:"
     echo ""
-    echo "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, "
-    echo "  dartlang, emberjs, fontello, html5please, jquery, lodash, mdn, npmjs,  "
-    echo "  qunit, reactjs, smacss, stackoverflow, unheap"
+    echo "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen,"
+    echo "  compassdoc, cssflow, dartlang, emberjs, fontello, html5please, jquery,"
+    echo "  lodash, mdn, npmjs, qunit, reactjs, smacss, stackoverflow, unheap"
     echo ""
     return 1
   fi
 
   # build search url:
-  # join arguments passed with '+', then append to search context URL
+  # join arguments passed with '%20', then append to search context URL
   # TODO substitute for proper urlencode method
   url="${urls[$1]}${(j:%20:)@[2,-1]}"
 


### PR DESCRIPTION
### Problem
As described in #7802, the angularjs URL for the frontend-search zsh plugin was outdated. An update was needed to point to the new URL when the user runs "frontend angularjs ...".

### What I did
I updated the README.md of the frontend-search plugin to include the new URL for angularjs, and made the appropriate change in frontend-search.plugin.zsh to point to the new URL 'https://angular.io/?search='. I also updated the code that adds a + between the search terms when appending them to the URL to be encoded (so + now becomes %20). I did this because the new search URL for angular drops the search terms in the angular search bar with the + included, instead of a space. I verified that this does not break any of the existing searches we have.

### What this fixes
Fixes #7802