### PR TITLE
Consolidate uppercase echo in ssh-agent plugin

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -5,7 +5,7 @@ function _start_agent() {
 	zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
 	# start ssh-agent and setup environment
-	echo starting ssh-agent...
+	echo Starting ssh-agent...
 	ssh-agent -s ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! $_ssh_env_cache
 	chmod 600 $_ssh_env_cache
 	. $_ssh_env_cache > /dev/null


### PR DESCRIPTION
### Plugin `ssh-agent` minor alteration:
- Simple edit from `starting ...` to `Starting ...`

**Background**
In zsh and in most operating systems the log messages are capitalized. Yet when the `ssh-agent` plugin runs (screenshot below) we see a lowercase log message. This doesn't look too good...
<img width="119" alt="Screen Shot 2019-05-07 at 18 34 23" src="https://user-images.githubusercontent.com/6362150/57316807-ece1d680-70f6-11e9-8594-6c6ab102c509.png">

Even in the zsh / oh-my-zsh documentation images show mostly uppercased log messages:

![70f58fb6-ba03-11e4-82c9-c083bf9a6574](https://user-images.githubusercontent.com/6362150/57317178-d25c2d00-70f7-11e9-9cd8-f74dd136c9b4.png)
