### PR TITLE
aws: really unset AWS*PROFILE variables in asp function

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -5,14 +5,15 @@ function agp {
 }
 
 function asp {
+  if [[ -z "$1" ]]; then
+    unset AWS_DEFAULT_PROFILE AWS_PROFILE AWS_EB_PROFILE
+    echo AWS profile cleared.
+    return
+  fi
+
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
   export AWS_EB_PROFILE=$1
-
-  if [[ -z "$1" ]]; then
-    unset -v AWS_DEFAULT_PROFILE AWS_PROFILE AWS_EB_PROFILE
-    echo AWS profile cleared.
-  fi
 }
 
 function aws_change_access_key {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -10,6 +10,7 @@ function asp {
   export AWS_EB_PROFILE=$1
 
   if [[ -z "$1" ]]; then
+    unset -v AWS_DEFAULT_PROFILE AWS_PROFILE AWS_EB_PROFILE
     echo AWS profile cleared.
   fi
 }


### PR DESCRIPTION
When running `asp` without arguments to clear an exported profile, the variables `AWS_DEFAULT_PROFILE`, `AWS_PROFILE` and `AWS_EB_PROFILE` are left "blank". There are not removed from the envrionment variables.

This causes the AWS CLI (and I guess some SDKs also) to try to find a profile with an empty name.

Example when no profile is exported (no `AWS*PROFILE` variable is exported):
```bash
$ aws s3 ls
Unable to locate credentials. You can configure credentials by running "aws configure".
```

Example  when `asp` is run without arguments to clear an exported profile:
```bash
$ aws s3 ls
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/local/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 59, in main
    rc = driver.main()
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 193, in main
    command_table = self._get_command_table()
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 102, in _get_command_table
    self._command_table = self._build_command_table()
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 122, in _build_command_table
    command_object=self)
  File "/usr/local/lib/python3.6/site-packages/botocore/session.py", line 671, in emit
    return self._events.emit(event_name, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/awscli/customizations/preview.py", line 69, in mark_as_preview
    service_name=original_command.service_model.service_name,
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 318, in service_model
    return self._get_service_model()
  File "/usr/local/lib/python3.6/site-packages/awscli/clidriver.py", line 335, in _get_service_model
    api_version = self.session.get_config_variable('api_versions').get(
  File "/usr/local/lib/python3.6/site-packages/botocore/session.py", line 233, in get_config_variable
    logical_name)
  File "/usr/local/lib/python3.6/site-packages/botocore/configprovider.py", line 226, in get_config_variable
    return provider.provide()
  File "/usr/local/lib/python3.6/site-packages/botocore/configprovider.py", line 323, in provide
    value = provider.provide()
  File "/usr/local/lib/python3.6/site-packages/botocore/configprovider.py", line 382, in provide
    config = self._session.get_scoped_config()
  File "/usr/local/lib/python3.6/site-packages/botocore/session.py", line 334, in get_scoped_config
    raise ProfileNotFound(profile=profile_name)
botocore.exceptions.ProfileNotFound: The config profile () could not be found
```

This PR explicitly unset these environment variables :-)
 - zsh 5.3 (x86_64-apple-darwin18.0)
 - aws-cli/1.16.139 Python/3.6.7 Darwin/18.5.0 botocore/1.12.129