### PR TITLE
dotenv: add support for custom env file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,6 @@ You must log out and log back in to see this change.
 
 Once you open up a new terminal window, it should load zsh with Oh My Zsh's configuration.
 
-#### Settings & Configurations
-
-Custom `env` files can be configured by exporting your env file in `ZSH_DOTENV_FILE`.
-If nothing is exported to `ZSH_DOTENV_FILE` then it takes `.env` as default file name
-
 ### Installation Problems
 
 If you have any hiccups installing, here are a few common fixes.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ You must log out and log back in to see this change.
 
 Once you open up a new terminal window, it should load zsh with Oh My Zsh's configuration.
 
+#### Settings & Configurations
+
+Custom `env` files can be configured by exporting your env file in `ZSH_DOTENV_FILE`.
+If nothing is exported to `ZSH_DOTENV_FILE` then it takes `.env` as default file name
+
 ### Installation Problems
 
 If you have any hiccups installing, here are a few common fixes.

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -32,6 +32,9 @@ PORT=3001
 ```
 You can even mix both formats, although it's probably a bad idea.
 
+Custom `env` files can be configured by exporting your env file in `ZSH_DOTENV_FILE`.
+If nothing is exported to `ZSH_DOTENV_FILE` then it takes `.env` as default filename
+
 ## Version Control
 
 **It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it's supposed to be local only.

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -32,8 +32,16 @@ PORT=3001
 ```
 You can even mix both formats, although it's probably a bad idea.
 
-Custom `env` files can be configured by exporting your env file in `ZSH_DOTENV_FILE`.
-If nothing is exported to `ZSH_DOTENV_FILE` then it takes `.env` as default filename
+### ZSH_DOTENV_FILE
+
+You can also modify the name of the file to be loaded with the variable `ZSH_DOTENV_FILE`.
+If the variable isn't set, the plugin will default to use `.env`.
+For example, this will make the plugin look for files named `.dotenv` and load them:
+
+```
+# in ~/.zshrc, before Oh My Zsh is sourced:
+ZSH_DOTENV_FILE=.dotenv
+```
 
 ## Version Control
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,13 +1,13 @@
 source_env() {
-  if [[ -f .env ]]; then
+  if [[ -f $ZSH_DOTENV_FILE ]]; then
     # test .env syntax
-    zsh -fn .env || echo 'dotenv: error when sourcing `.env` file' >&2
+    zsh -fn $ZSH_DOTENV_FILE || echo "dotenv: error when sourcing '$ZSH_DOTENV_FILE' file" >&2
 
     if [[ -o a ]]; then
-      source .env
+      source $ZSH_DOTENV_FILE
     else
       set -a
-      source .env
+      source $ZSH_DOTENV_FILE
       set +a
     fi
   fi
@@ -15,5 +15,9 @@ source_env() {
 
 autoload -U add-zsh-hook
 add-zsh-hook chpwd source_env
+
+if [[ -z $ZSH_DOTENV_FILE ]]; then
+    ZSH_DOTENV_FILE=.env
+fi
 
 source_env


### PR DESCRIPTION
Fixes #7579 
-

- Reads env file from exported variable `ZSH_DOTENV_FILE`.
- If file, nothing is exported to the variable it takes `.env` as default file name