### PR TITLE
frontend: add frontend search commands

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -1,9 +1,8 @@
-## Introduction ##
+## Introduction
 
 > Searches for your frontend web development made easier
 
-
-## Installation ##
+## Installation
 
 Open your `~/.zshrc` file and enable the `frontend-search` plugin:
 
@@ -13,54 +12,59 @@ plugins=( ... frontend-search)
 
 ```
 
-
-## Usage ##
+## Usage
 
 You can use the frontend-search plugin in these two forms:
 
-* `frontend <context> <term> [more terms if you want]`
-* `<context> <term> [more terms if you want]`
+- `frontend <context> <term> [more terms if you want]`
+- `<context> <term> [more terms if you want]`
 
 For example, these two are equivalent:
 
 ```zsh
-$ frontend angularjs dependency injection
-$ angularjs dependency injection
+$ angular dependency injection
+# Will turn into ...
+$ frontend angular dependency injection
 ```
 
 Available search contexts are:
 
-| context       | URL                                                                      |
-|---------------|--------------------------------------------------------------------------|
-| angular(>=2.0)| `https://angular.io/?search=`                                             |
-| angularjs(1.x)| `https://google.com/search?as_sitesearch=angularjs.org&as_q=`
-| aurajs        | `http://aurajs.com/api/#stq=`                                            |
-| bem           | `https://google.com/search?as_sitesearch=bem.info&as_q=`                 |
-| bootsnipp     | `https://bootsnipp.com/search?q=`                                         |
-| caniuse       | `https://caniuse.com/#search=`                                            |
-| codepen       | `https://codepen.io/search?q=`                                            |
-| compassdoc    | `http://compass-style.org/search?q=`                                     |
-| cssflow       | `http://www.cssflow.com/search?q=`                                       |
-| dartlang      | `https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:`  |
-| emberjs       | `https://emberjs.com/api/#stp=1&stq=`                                     |
-| fontello      | `http://fontello.com/#search=`                                           |
-| html5please   | `http://html5please.com/#`                                               |
-| jquery        | `https://api.jquery.com/?s=`                                             |
-| lodash        | `https://devdocs.io/lodash/index#`                                       |
-| mdn           | `https://developer.mozilla.org/search?q=`                                |
-| npmjs         | `https://www.npmjs.com/search?q=`                                        |
-| qunit         | `https://api.qunitjs.com/?s=`                                            |
-| reactjs       | `https://google.com/search?as_sitesearch=facebook.github.io/react&as_q=` |
-| smacss        | `https://google.com/search?as_sitesearch=smacss.com&as_q=`               |
-| stackoverflow | `https://stackoverflow.com/search?q=`                                     |
-| unheap        | `http://www.unheap.com/?s=`                                              |
+| context       | URL                                                                         |
+| ------------- | --------------------------------------------------------------------------- |
+| angular       | `https://angular.io/?search=`                                               |
+| angularjs     | `https://google.com/search?as_sitesearch=angularjs.org&as_q=`               |
+| bem           | `https://google.com/search?as_sitesearch=bem.info&as_q=`                    |
+| bootsnipp     | `https://bootsnipp.com/search?q=`                                           |
+| bundlephobia  | `https://bundlephobia.com/result?p=`                                        |
+| caniuse       | `https://caniuse.com/#search=`                                              |
+| codepen       | `https://codepen.io/search?q=`                                              |
+| compassdoc    | `http://compass-style.org/search?q=`                                        |
+| cssflow       | `http://www.cssflow.com/search?q=`                                          |
+| dartlang      | `https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:`     |
+| emberjs       | `https://www.google.com/search?as_sitesearch=emberjs.com/&as_q=`            |
+| flowtype      | `https://google.com/search?as_sitesearch=flow.org/en/docs/&as_q=`           |
+| fontello      | `http://fontello.com/#search=`                                              |
+| github        | `https://github.com/search?q=`                                              |
+| html5please   | `https://html5please.com/#`                                                 |
+| jestjs        | `https://www.google.com/search?as_sitesearch=jestjs.io&as_q=`               |
+| jquery        | `https://api.jquery.com/?s=`                                                |
+| lodash        | `https://devdocs.io/lodash/index#`                                          |
+| mdn           | `https://developer.mozilla.org/search?q=`                                   |
+| nodejs        | `https://www.google.com/search?as_sitesearch=nodejs.org/en/docs/&as_q=`     |
+| npmjs         | `https://www.npmjs.com/search?q=`                                           |
+| qunit         | `https://api.qunitjs.com/?s=`                                               |
+| reactjs       | `https://google.com/search?as_sitesearch=facebook.github.io/react&as_q=`    |
+| smacss        | `https://google.com/search?as_sitesearch=smacss.com&as_q=`                  |
+| stackoverflow | `https://stackoverflow.com/search?q=`                                       |
+| typescript    | `https://google.com/search?as_sitesearch=www.typescriptlang.org/docs&as_q=` |
+| unheap        | `http://www.unheap.com/?s=`                                                 |
+| vuejs         | `https://www.google.com/search?as_sitesearch=vuejs.org&as_q=`               |
 
 If you want to have another context, open an Issue and tell us!
-
 
 ## Author
 
 **Wilson Mendes (willmendesneto)**
-+ <https://plus.google.com/+WilsonMendes>
-+ <https://twitter.com/willmendesneto>
-+ <https://github.com/willmendesneto>
+
+- <https://twitter.com/willmendesneto>
+- <https://github.com/willmendesneto>

--- a/plugins/frontend-search/_frontend-search.sh
+++ b/plugins/frontend-search/_frontend-search.sh
@@ -17,28 +17,34 @@ function _frontend() {
   frontend_points=( "${(f)mapfile[$CONFIG]//$HOME/~}" )
 
   commands=(
-    'jquery: Search in jQuery website'
-    'mdn: Search in MDN website'
-    'compassdoc: Search in COMPASS website'
-    'html5please: Search in HTML5 Please website'
-    'caniuse: Search in Can I Use website'
-    'aurajs: Search in AuraJs website'
-    'dartlang: Search in Dart website'
-    'lodash: Search in Lo-Dash website'
-    'qunit: Search in Qunit website'
-    'fontello: Search in fontello website'
-    'bootsnipp: Search in bootsnipp website'
-    'cssflow: Search in cssflow website'
-    'codepen: Search in codepen website'
-    'unheap: Search in unheap website'
+    'angular: Search in Angular.io website'
+    'angularjs: Search in docs.angularjs.org website'
     'bem: Search in BEM website'
-    'smacss: Search in SMACSS website'
-    'angular: Search in Angular website for Angular 2.x'
-    'angularjs: Search in Angular website for Angular 1.x'
-    'reactjs: Search in React website'
+    'bootsnipp: Search in bootsnipp website'
+    'bundlephobia: Search in Bundlephobia website'
+    'caniuse: Search in Can I Use website'
+    'codepen: Search in codepen website'
+    'compassdoc: Search in COMPASS website'
+    'cssflow: Search in cssflow website'
+    'dartlang: Search in Dart website'
     'emberjs: Search in Ember website'
-    'stackoverflow: Search in StackOverflow website'
+    'flowtype: Search in Flowtype website'
+    'fontello: Search in fontello website'
+    'github: Search in GitHub website'
+    'html5please: Search in HTML5 Please website'
+    'jestjs: Search in Jest website'
+    'jquery: Search in jQuery website'
+    'lodash: Search in Lo-Dash website'
+    'mdn: Search in MDN website'
+    'nodejs: Search in NodeJS website'
     'npmjs: Search in NPMJS website'
+    'qunit: Search in Qunit website'
+    'reactjs: Search in React website'
+    'smacss: Search in SMACSS website'
+    'stackoverflow: Search in StackOverflow website'
+    'typescript: Search in TypeScript website'
+    'unheap: Search in unheap website'
+    'vuejs: Search in VueJS website'
   )
 
   _arguments -C \
@@ -67,9 +73,6 @@ function _frontend() {
         caniuse)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
-        aurajs)
-          _describe -t points "Warp points" frontend_points && ret=0
-          ;;
         dartlang)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
@@ -80,6 +83,9 @@ function _frontend() {
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         fontello)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        github)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         bootsnipp)
@@ -100,9 +106,6 @@ function _frontend() {
         smacss)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
-        angular)
-          _describe -t points "Warp points" frontend_points && ret=0
-        ;;
         angularjs)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
@@ -116,6 +119,24 @@ function _frontend() {
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         npmjs)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        bundlephobia)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        flowtype)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        typescript)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        vuejs)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        nodejs)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        jestjs)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
       esac

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -1,25 +1,31 @@
 alias angular='frontend angular'
 alias angularjs='frontend angularjs'
-alias aurajs='frontend aurajs'
 alias bem='frontend bem'
 alias bootsnipp='frontend bootsnipp'
+alias bundlephobia='frontend bundlephobia'
 alias caniuse='frontend caniuse'
 alias codepen='frontend codepen'
 alias compassdoc='frontend compassdoc'
 alias cssflow='frontend cssflow'
 alias dartlang='frontend dartlang'
 alias emberjs='frontend emberjs'
+alias flowtype='frontend flowtype'
 alias fontello='frontend fontello'
+alias github='frontend github'
 alias html5please='frontend html5please'
+alias jestjs='frontend jestjs'
 alias jquery='frontend jquery'
 alias lodash='frontend lodash'
 alias mdn='frontend mdn'
+alias nodejs='frontend nodejs'
 alias npmjs='frontend npmjs'
 alias qunit='frontend qunit'
 alias reactjs='frontend reactjs'
 alias smacss='frontend smacss'
 alias stackoverflow='frontend stackoverflow'
+alias typescript='frontend typescript'
 alias unheap='frontend unheap'
+alias vuejs='frontend vuejs'
 
 function frontend() {
   emulate -L zsh
@@ -29,26 +35,32 @@ function frontend() {
   urls=(
     angular        'https://angular.io/?search='
     angularjs      'https://google.com/search?as_sitesearch=angularjs.org&as_q='
-    aurajs         'http://aurajs.com/api/#stq='
     bem            'https://google.com/search?as_sitesearch=bem.info&as_q='
     bootsnipp      'https://bootsnipp.com/search?q='
+    bundlephobia   'https://bundlephobia.com/result?p='
     caniuse        'https://caniuse.com/#search='
     codepen        'https://codepen.io/search?q='
     compassdoc     'http://compass-style.org/search?q='
     cssflow        'http://www.cssflow.com/search?q='
     dartlang       'https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:'
-    emberjs        'https://emberjs.com/api/#stp=1&stq='
+    emberjs        'https://www.google.com/search?as_sitesearch=emberjs.com/&as_q='
+    flowtype       'https://google.com/search?as_sitesearch=flow.org/en/docs/&as_q='
     fontello       'http://fontello.com/#search='
-    html5please    'http://html5please.com/#'
+    github         'https://github.com/search?q='
+    html5please    'https://html5please.com/#'
+    jestjs         'https://www.google.com/search?as_sitesearch=jestjs.io&as_q='
     jquery         'https://api.jquery.com/?s='
     lodash         'https://devdocs.io/lodash/index#'
     mdn            'https://developer.mozilla.org/search?q='
+    nodejs         'https://www.google.com/search?as_sitesearch=nodejs.org/en/docs/&as_q='
     npmjs          'https://www.npmjs.com/search?q='
     qunit          'https://api.qunitjs.com/?s='
     reactjs        'https://google.com/search?as_sitesearch=facebook.github.io/react&as_q='
     smacss         'https://google.com/search?as_sitesearch=smacss.com&as_q='
     stackoverflow  'https://stackoverflow.com/search?q='
+    typescript     'https://google.com/search?as_sitesearch=www.typescriptlang.org/docs&as_q='
     unheap         'http://www.unheap.com/?s='
+    vuejs          'https://www.google.com/search?as_sitesearch=vuejs.org&as_q='
   )
 
   # show help for command list
@@ -59,9 +71,9 @@ function frontend() {
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
-      print -P "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen,"
-      print -P "  compassdoc, cssflow, dartlang, emberjs, fontello, html5please, jquery,"
-      print -P "  lodash, mdn, npmjs, qunit, reactjs, smacss, stackoverflow, unheap"
+      print -P "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
+      print -P "  dartlang, emberjs, fontello, flowtype, github, html5please, jestjs, jquery, lodash,"
+      print -P "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
       print -P ""
       print -P "For example: frontend npmjs mocha (or just: npmjs mocha)."
       print -P ""
@@ -75,9 +87,9 @@ function frontend() {
     echo ""
     echo "Valid contexts are:"
     echo ""
-    echo "  angular (>= 2.0), angularjs (1.x), aurajs, bem, bootsnipp, caniuse, codepen,"
-    echo "  compassdoc, cssflow, dartlang, emberjs, fontello, html5please, jquery,"
-    echo "  lodash, mdn, npmjs, qunit, reactjs, smacss, stackoverflow, unheap"
+    echo "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
+    echo "  dartlang, emberjs, fontello, github, html5please, jest, jquery, lodash,"
+    echo "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
     echo ""
     return 1
   fi


### PR DESCRIPTION
With this pull request I am:

- Updating docs;
- Removing `aurajs` command. It's not available anymore;
- Adding commands for:
  - jestjs;
  - typescript;
  - flowtype;
  - github;
  - vuejs;
  - nodejs;
  - bundlephobia;
