### PR TITLE
Update colorize.plugin.zsh

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -45,5 +45,5 @@ colorize_via_pygmentize_less() (
         shift 1
     done
 
-    less -f "${tmp_files[@]}"
+    less -L -f "${tmp_files[@]}"
 )


### PR DESCRIPTION
use -L with less to ignore LESSOPEN, otherwise if also uses pygmentize, the colorizing escape codes are exposed.