### PR TITLE
ng: fix shwordsplit option use

### DIFF
--- a/plugins/ng/ng.plugin.zsh
+++ b/plugins/ng/ng.plugin.zsh
@@ -1,4 +1,3 @@
-
 ng_opts='addon asset-sizes b build completion d destroy doc e2e g generate get github-pages:deploy gh-pages:deploy h help i init install lint make-this-awesome new s serve server set t test update v version -h --help'
 
 _ng_completion () {
@@ -73,9 +72,7 @@ _ng_completion () {
       ;;
   esac
 
-  setopt shwordsplit
-  reply=($opts)
-  unsetopt shwordsplit
+  reply=(${=opts})
 }
 
 compctl -K _ng_completion ng

--- a/plugins/ng/ng.plugin.zsh
+++ b/plugins/ng/ng.plugin.zsh
@@ -75,7 +75,7 @@ _ng_completion () {
 
   setopt shwordsplit
   reply=($opts)
-  unset shwordsplit
+  unsetopt shwordsplit
 }
 
 compctl -K _ng_completion ng


### PR DESCRIPTION
I looked for an option with "word" and "split" and I found this piece of source code:

```
   setopt shwordsplit
   reply=($opts)
   unset shwordsplit
```

However, `unset`doesn't work for inverting the previous zsh option. 

This PR only replaces `unset`by `unsetopt`.
