### PR TITLE
make it explicit that oh-my-zsh.sh needs to be sourced in between

### DIFF
--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -52,7 +52,7 @@ plugins=(
   git
   kube-ps1
 )
-
+source $ZSH/oh-my-zsh.sh
 PROMPT=$PROMPT'$(kube_ps1) '
 ```
 


### PR DESCRIPTION
make it explicit that oh-my-zsh.sh needs to be sourced in between plugins and prompt. doesn't work if you do it in a different order.