### PR TITLE
Add a completion plugin for dnote

### DIFF
--- a/plugins/dnote/README.md
+++ b/plugins/dnote/README.md
@@ -1,0 +1,51 @@
+# Dnote Plugin
+
+This plugin adds auto-completion for [Dnote](https://dnote.io) project.
+
+To use it, add `dnote` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(dnote)
+```
+
+## Usage
+
+At the basic level, this plugin completes all Dnote commands.
+
+```zsh
+$ dnote a(press <TAB> here)
+```
+
+would result in:
+
+```zsh
+$ dnote add
+```
+
+For some commands, this plugin dynamically suggests matching book names.
+
+For instance, if you have three books that begin with 'j': 'javascript', 'job', 'js',
+
+```zsh
+$ dnote view j(press <TAB> here)
+```
+
+would result in:
+
+```zsh
+$ dnote v j
+javascript  job         js
+```
+
+As another example,
+
+```zsh
+$ dnote edit ja(press <TAB> here)
+```
+
+would result in:
+
+
+```zsh
+$ dnote v javascript
+``````

--- a/plugins/dnote/_dnote
+++ b/plugins/dnote/_dnote
@@ -1,0 +1,39 @@
+#compdef dnote
+
+local -a _1st_arguments
+
+_1st_arguments=(
+  'add:add a new note'
+  'view:list books, notes, or view a content'
+  'edit:edit a note or a book'
+  'remove:remove a note or a book'
+  'find:find notes by keywords'
+  'sync:sync data with the server'
+  'login:login to the dnote server'
+  'logout:logout from the dnote server'
+  'version:print the current version'
+  'help:get help about any command'
+)
+
+get_booknames() {
+  local names=$(dnote view --name-only)
+  local -a ret
+
+  while read -r line; do
+    ret+=("${line}")
+  done <<< "$names"
+
+  echo "$ret"
+}
+
+if (( CURRENT == 2 )); then
+  _describe -t commands "dnote subcommand" _1st_arguments
+  return
+elif (( CURRENT == 3 )); then
+  case "$words[2]" in
+    v|view|a|add)
+      _alternative \
+        "names:book names:($(get_booknames))"
+  esac
+fi
+


### PR DESCRIPTION
This PR adds a completion plugin for Dnote (https://github.com/dnote/dnote) which is an open source note-taking software for developers.

I would like to contribute this so that users can save time.