### PR TITLE
add terrafrom workspace label to prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -236,12 +236,19 @@ prompt_aws() {
   esac
 }
 
+prompt_terraform() {
+  local terraform_info=$(tf_prompt_info)
+  [[ -z "$terraform_info" ]] && return
+  prompt_segment magenta yellow "TF: $terraform_info"
+}
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
   prompt_aws
+  prompt_terraform
   prompt_context
   prompt_dir
   prompt_git


### PR DESCRIPTION
Adds a label to the propmpt showing the current Terraform workspace

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/22946190/58604291-388f3680-82d7-11e9-8e94-065278657e97.png">
