### PR TITLE
[debian plugin] Add an update alias using apt list -u

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -51,6 +51,7 @@ if [[ $use_sudo -eq 1 ]]; then
     alias ac='sudo $apt_pref clean'
     alias ad='sudo $apt_pref update'
     alias adg='sudo $apt_pref update && sudo $apt_pref $apt_upgr'
+    alias alu='sudo $apt_pref update && sudo $apt_pref list -u && sudo $apt_pref $apt_upgr'
     alias adu='sudo $apt_pref update && sudo $apt_pref dist-upgrade'
     alias afu='sudo apt-file update'
     alias au='sudo $apt_pref $apt_upgr'


### PR DESCRIPTION
Add an update option which also lists the available updates before updating (`apt list -u`).
The new alias would be `alias alu='sudo $apt_pref update && sudo $apt_pref list -u && sudo $apt_pref $apt_upgr'`.
This is necessary to see the exact version change of a package