### PR TITLE
[debian plugin] Fixes, cleanups and minor feature enrichment

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -31,7 +31,7 @@ alias api='aptitude'
 
 # Some self-explanatory aliases
 alias acs="apt-cache search"
-alias aps='aptitude search'
+alias aps='$apt_pref search'
 alias as="aptitude -F \"* %p -> %d \n(%v/%V)\" \
 		--no-gui --disable-columns search"	# search package
 

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -67,7 +67,9 @@ if [[ $use_sudo -eq 1 ]]; then
     # apt-get only
     alias ads='sudo apt-get dselect-upgrade'
     alias aar='sudo apt-get autoremove'
-    alias alu='sudo apt-get update && apt list -u && sudo apt-get upgrade'
+    
+    # apt only
+    alias alu='sudo apt update && apt list -u && sudo apt upgrade'
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -2,6 +2,7 @@
 # https://github.com/AlexBio
 # https://github.com/dbb
 # https://github.com/Mappleconfusers
+# https://github.com/BjoernDaase
 #
 # Debian-related zsh aliases and functions for zsh
 

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -66,7 +66,7 @@ if [[ $use_sudo -eq 1 ]]; then
 
     # apt-get only
     alias ads='sudo apt-get dselect-upgrade'
-    alias aar='sudo apt-get autore'
+    alias aar='sudo apt-get autoremove'
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -30,19 +30,21 @@ fi
 alias age='apt-get'
 alias api='aptitude'
 
-# Some self-explanatory aliases
-alias acs="apt-cache search"
+# Search for packages
 alias aps='$apt_pref search'
+
+# These are aptitude only
 alias as="aptitude -F \"* %p -> %d \n(%v/%V)\" \
-		--no-gui --disable-columns search"	# search package
-
-# apt-file
-alias afs='apt-file search --regexp'
-
+        --no-gui --disable-columns search"  # search package
 
 # These are apt-get only
 alias asrc='apt-get source'
+alias acs='apt-cache search'
 alias app='apt-cache policy'
+
+
+# apt-file
+alias afs='apt-file search --regexp'
 
 # superuser operations ######################################################
 if [[ $use_sudo -eq 1 ]]; then

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -33,11 +33,11 @@ alias api='aptitude'
 # Search for packages
 alias aps='$apt_pref search'
 
-# These are aptitude only
+# aptitude only
 alias as="aptitude -F \"* %p -> %d \n(%v/%V)\" \
         --no-gui --disable-columns search"  # search package
 
-# These are apt-get only
+# apt-get only
 alias asrc='apt-get source'
 alias acs='apt-cache search'
 alias app='apt-cache policy'
@@ -66,6 +66,7 @@ if [[ $use_sudo -eq 1 ]]; then
 
     # apt-get only
     alias ads='sudo apt-get dselect-upgrade'
+    alias aar='sudo apt-get autoremove'
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -67,6 +67,7 @@ if [[ $use_sudo -eq 1 ]]; then
     # apt-get only
     alias ads='sudo apt-get dselect-upgrade'
     alias aar='sudo apt-get autoremove'
+    alias alu='sudo apt-get update && apt list -u && sudo apt-get upgrade'
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -66,7 +66,7 @@ if [[ $use_sudo -eq 1 ]]; then
 
     # apt-get only
     alias ads='sudo apt-get dselect-upgrade'
-    alias aar='sudo apt-get autoremove'
+    alias aar='sudo apt-get autore'
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:
@@ -154,7 +154,7 @@ apt_pref_compdef ads "dselect-upgrade"
 
 # Misc. #####################################################################
 # print all installed packages
-alias allpkgs='aptitude search -F "%p" --disable-columns ~i'
+alias allpkgs='aptitude search -F "%p" --disable-columns "~i"'
 
 # Create a basic .deb package
 alias mydeb='time dpkg-buildpackage -rfakeroot -us -uc'


### PR DESCRIPTION
- Fixes an issue with printing all installed packages
- Makes some cleanups.
- Makes `as` accessible no matter if you are using `apt-get` or `aptitude`.
- Adds an update alias which also lists the available updates before updating (`apt list -u`). The new alias would be alias `alu=sudo apt update && sudo apt list -u && sudo apt upgrade`. This is necessary to see the exact version change of a package.
- Adds an `apt-get autoremove` alias