### PR TITLE
Update fasd `v` alias to evaluate $EDITOR lazily.

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -6,7 +6,7 @@ if [ $commands[fasd] ]; then # check if fasd is installed
   source "$fasd_cache"
   unset fasd_cache
 
-  alias v="f -e \"$EDITOR\""
+  alias v='f -e "$EDITOR"'
   alias o='a -e xdg-open'
   alias j='zz'
 fi


### PR DESCRIPTION
For the `v` alias to work in its current state, the environment variable
EDITOR must already be defined by the time `source $ZSH/oh-my-zsh.sh`
happens. However, in the included zshrc template, EDITOR is set from
within the "User configuration" section, which begins immediately after
the above line. This means that, unless the user knows to move their
`export EDITOR` statements, EDITOR will be undefined when fasd.plugin.zsh
loads, and therefore the alias will have the value 'f -e ""', preventing
it from functioning.

With this change, `"$EDITOR"` will be evaluated each time the alias is
invoked, instead of just once when the alias is created. This allows for
EDITOR to be set from "User configuration" in the zshrc, and has the
additional flexibility of allowing a user to specify a different EDITOR
for a single session or invocation of the alias.