### PR TITLE
grep.zsh: add --line-number/-n option if available

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,6 +5,13 @@ grep-flag-available() {
 
 GREP_OPTIONS=""
 
+# show line numbers in grep results
+if grep-flag-available --line-number; then
+    GREP_OPTIONS+=" --line-number"
+elif grep-flag-available -n; then
+    GREP_OPTIONS+=" -n"
+fi
+
 # color grep results
 if grep-flag-available --color=auto; then
     GREP_OPTIONS+=" --color=auto"


### PR DESCRIPTION
Hello,

Proposing this change which I think makes sense as a default option. Only worry is backwards-compatibility with scripts processing the output of `grep` commands and splitting lines on `:` separators. If not desired by default, I'd love to be able to customize the default `GREP_OPTIONS` value from my `.zshrc` file or something; let me know what's best.

Cheers,