### PR TITLE
kube-ps1: fix color bleeding in prompt

### DIFF
--- a/plugins/kube-ps1/kube-ps1.plugin.zsh
+++ b/plugins/kube-ps1/kube-ps1.plugin.zsh
@@ -41,9 +41,9 @@ KUBE_PS1_SUFFIX="${KUBE_PS1_SUFFIX-)}"
 KUBE_PS1_LAST_TIME=0
 KUBE_PS1_ENABLED=true
 
-KUBE_PS1_COLOR_SYMBOL="%F{blue}"
-KUBE_PS1_COLOR_CONTEXT="%F{red}"
-KUBE_PS1_COLOR_NS="%F{cyan}"
+KUBE_PS1_COLOR_SYMBOL="%{$fg[blue]%}"
+KUBE_PS1_COLOR_CONTEXT="%{$fg[red]%}"
+KUBE_PS1_COLOR_NS="%{$fg[cyan]%}"
 
 _kube_ps1_binary_check() {
   command -v "$1" >/dev/null


### PR DESCRIPTION
This fixes color bleeding when using tab complete with the kube-ps1 plugin active.

Steps to reproduce
* Enable the kube-ps1 plugin, and add `$(kube_ps1)` in your prompt
* start typing a command, and press <TAB>

The command you just typed would change color, and the color would bleed out to other output from the command.