### PR TITLE
pip: Fixes no such file or directory: /tmp/zsh_tmp_cache

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -29,6 +29,7 @@ zsh-pip-cache-packages() {
   if [[ ! -f $ZSH_PIP_CACHE_FILE ]]; then
       echo -n "(...caching package index...)"
       tmp_cache=/tmp/zsh_tmp_cache
+      touch $tmp_cache
       for index in $ZSH_PIP_INDEXES ; do
           # well... I've already got two problems
           curl -L $index 2>/dev/null | \


### PR DESCRIPTION
Zsh may be configured such that ">>" will error if the file doesn't exist.