### PR TITLE
gitfast: downgrade to upstream v2.16

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -39,7 +39,7 @@ if [ -z "$script" ]; then
 		test -f $e && script="$e" && break
 	done
 fi
-GIT_SOURCING_ZSH_COMPLETION=y . "$script"
+ZSH_VERSION='' . "$script"
 
 __gitcomp ()
 {
@@ -93,22 +93,13 @@ __gitcomp_nl_append ()
 	compadd -Q -S "${4- }" -p "${2-}" -- ${=1} && _ret=0
 }
 
-__gitcomp_file_direct ()
-{
-	emulate -L zsh
-
-	local IFS=$'\n'
-	compset -P '*[=:]'
-	compadd -f -- ${=1} && _ret=0
-}
-
 __gitcomp_file ()
 {
 	emulate -L zsh
 
 	local IFS=$'\n'
 	compset -P '*[=:]'
-	compadd -p "${2-}" -f -- ${=1} && _ret=0
+	compadd -Q -p "${2-}" -f -- ${=1} && _ret=0
 }
 
 __git_zsh_bash_func ()

--- a/plugins/gitfast/git-completion.bash
+++ b/plugins/gitfast/git-completion.bash
@@ -29,8 +29,6 @@
 # tell the completion to use commit completion.  This also works with aliases
 # of form "!sh -c '...'".  For example, "!sh -c ': git commit ; ... '".
 #
-# Compatible with bash 3.2.57.
-#
 # You can set the following environment variables to influence the behavior of
 # the completion routines:
 #
@@ -92,70 +90,6 @@ __git ()
 {
 	git ${__git_C_args:+"${__git_C_args[@]}"} \
 		${__git_dir:+--git-dir="$__git_dir"} "$@" 2>/dev/null
-}
-
-# Removes backslash escaping, single quotes and double quotes from a word,
-# stores the result in the variable $dequoted_word.
-# 1: The word to dequote.
-__git_dequote ()
-{
-	local rest="$1" len ch
-
-	dequoted_word=""
-
-	while test -n "$rest"; do
-		len=${#dequoted_word}
-		dequoted_word="$dequoted_word${rest%%[\\\'\"]*}"
-		rest="${rest:$((${#dequoted_word}-$len))}"
-
-		case "${rest:0:1}" in
-		\\)
-			ch="${rest:1:1}"
-			case "$ch" in
-			$'\n')
-				;;
-			*)
-				dequoted_word="$dequoted_word$ch"
-				;;
-			esac
-			rest="${rest:2}"
-			;;
-		\')
-			rest="${rest:1}"
-			len=${#dequoted_word}
-			dequoted_word="$dequoted_word${rest%%\'*}"
-			rest="${rest:$((${#dequoted_word}-$len+1))}"
-			;;
-		\")
-			rest="${rest:1}"
-			while test -n "$rest" ; do
-				len=${#dequoted_word}
-				dequoted_word="$dequoted_word${rest%%[\\\"]*}"
-				rest="${rest:$((${#dequoted_word}-$len))}"
-				case "${rest:0:1}" in
-				\\)
-					ch="${rest:1:1}"
-					case "$ch" in
-					\"|\\|\$|\`)
-						dequoted_word="$dequoted_word$ch"
-						;;
-					$'\n')
-						;;
-					*)
-						dequoted_word="$dequoted_word\\$ch"
-						;;
-					esac
-					rest="${rest:2}"
-					;;
-				\")
-					rest="${rest:1}"
-					break
-					;;
-				esac
-			done
-			;;
-		esac
-	done
 }
 
 # The following function is based on code from:
@@ -330,32 +264,9 @@ __gitcomp ()
 	case "$cur_" in
 	--*=)
 		;;
-	--no-*)
-		local c i=0 IFS=$' \t\n'
-		for c in $1; do
-			if [[ $c == "--" ]]; then
-				continue
-			fi
-			c="$c${4-}"
-			if [[ $c == "$cur_"* ]]; then
-				case $c in
-				--*=*|*.) ;;
-				*) c="$c " ;;
-				esac
-				COMPREPLY[i++]="${2-}$c"
-			fi
-		done
-		;;
 	*)
 		local c i=0 IFS=$' \t\n'
 		for c in $1; do
-			if [[ $c == "--" ]]; then
-				c="--no-...${4-}"
-				if [[ $c == "$cur_"* ]]; then
-					COMPREPLY[i++]="${2-}$c "
-				fi
-				break
-			fi
 			c="$c${4-}"
 			if [[ $c == "$cur_"* ]]; then
 				case $c in
@@ -367,47 +278,6 @@ __gitcomp ()
 		done
 		;;
 	esac
-}
-
-# Clear the variables caching builtins' options when (re-)sourcing
-# the completion script.
-if [[ -n ${ZSH_VERSION-} ]]; then
-	unset $(set |sed -ne 's/^\(__gitcomp_builtin_[a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/p') 2>/dev/null
-else
-	unset $(compgen -v __gitcomp_builtin_)
-fi
-
-# This function is equivalent to
-#
-#    __gitcomp "$(git xxx --git-completion-helper) ..."
-#
-# except that the output is cached. Accept 1-3 arguments:
-# 1: the git command to execute, this is also the cache key
-# 2: extra options to be added on top (e.g. negative forms)
-# 3: options to be excluded
-__gitcomp_builtin ()
-{
-	# spaces must be replaced with underscore for multi-word
-	# commands, e.g. "git remote add" becomes remote_add.
-	local cmd="$1"
-	local incl="$2"
-	local excl="$3"
-
-	local var=__gitcomp_builtin_"${cmd/-/_}"
-	local options
-	eval "options=\$$var"
-
-	if [ -z "$options" ]; then
-		# leading and trailing spaces are significant to make
-		# option removal work correctly.
-		options=" $incl $(__git ${cmd/_/ } --git-completion-helper) "
-		for i in $excl; do
-			options="${options/ $i / }"
-		done
-		eval "$var=\"$options\""
-	fi
-
-	__gitcomp "$options"
 }
 
 # Variation of __gitcomp_nl () that appends to the existing list of
@@ -433,24 +303,6 @@ __gitcomp_nl ()
 	__gitcomp_nl_append "$@"
 }
 
-# Fills the COMPREPLY array with prefiltered paths without any additional
-# processing.
-# Callers must take care of providing only paths that match the current path
-# to be completed and adding any prefix path components, if necessary.
-# 1: List of newline-separated matching paths, complete with all prefix
-#    path components.
-__gitcomp_file_direct ()
-{
-	local IFS=$'\n'
-
-	COMPREPLY=($1)
-
-	# use a hack to enable file mode in bash < 4
-	compopt -o filenames +o nospace 2>/dev/null ||
-	compgen -f /non-existing-dir/ >/dev/null ||
-	true
-}
-
 # Generates completion reply with compgen from newline-separated possible
 # completion filenames.
 # It accepts 1 to 3 arguments:
@@ -470,8 +322,7 @@ __gitcomp_file ()
 
 	# use a hack to enable file mode in bash < 4
 	compopt -o filenames +o nospace 2>/dev/null ||
-	compgen -f /non-existing-dir/ >/dev/null ||
-	true
+	compgen -f /non-existing-dir/ > /dev/null
 }
 
 # Execute 'git ls-files', unless the --committable option is specified, in
@@ -481,12 +332,10 @@ __gitcomp_file ()
 __git_ls_files_helper ()
 {
 	if [ "$2" == "--committable" ]; then
-		__git -C "$1" -c core.quotePath=false diff-index \
-			--name-only --relative HEAD -- "${3//\\/\\\\}*"
+		__git -C "$1" diff-index --name-only --relative HEAD
 	else
 		# NOTE: $2 is not quoted in order to support multiple options
-		__git -C "$1" -c core.quotePath=false ls-files \
-			--exclude-standard $2 -- "${3//\\/\\\\}*"
+		__git -C "$1" ls-files --exclude-standard $2
 	fi
 }
 
@@ -497,103 +346,17 @@ __git_ls_files_helper ()
 #    If provided, only files within the specified directory are listed.
 #    Sub directories are never recursed.  Path must have a trailing
 #    slash.
-# 3: List only paths matching this path component (optional).
 __git_index_files ()
 {
-	local root="$2" match="$3"
+	local root="${2-.}" file
 
-	__git_ls_files_helper "$root" "$1" "$match" |
-	awk -F / -v pfx="${2//\\/\\\\}" '{
-		paths[$1] = 1
-	}
-	END {
-		for (p in paths) {
-			if (substr(p, 1, 1) != "\"") {
-				# No special characters, easy!
-				print pfx p
-				continue
-			}
-
-			# The path is quoted.
-			p = dequote(p)
-			if (p == "")
-				continue
-
-			# Even when a directory name itself does not contain
-			# any special characters, it will still be quoted if
-			# any of its (stripped) trailing path components do.
-			# Because of this we may have seen the same direcory
-			# both quoted and unquoted.
-			if (p in paths)
-				# We have seen the same directory unquoted,
-				# skip it.
-				continue
-			else
-				print pfx p
-		}
-	}
-	function dequote(p,    bs_idx, out, esc, esc_idx, dec) {
-		# Skip opening double quote.
-		p = substr(p, 2)
-
-		# Interpret backslash escape sequences.
-		while ((bs_idx = index(p, "\\")) != 0) {
-			out = out substr(p, 1, bs_idx - 1)
-			esc = substr(p, bs_idx + 1, 1)
-			p = substr(p, bs_idx + 2)
-
-			if ((esc_idx = index("abtvfr\"\\", esc)) != 0) {
-				# C-style one-character escape sequence.
-				out = out substr("\a\b\t\v\f\r\"\\",
-						 esc_idx, 1)
-			} else if (esc == "n") {
-				# Uh-oh, a newline character.
-				# We cant reliably put a pathname
-				# containing a newline into COMPREPLY,
-				# and the newline would create a mess.
-				# Skip this path.
-				return ""
-			} else {
-				# Must be a \nnn octal value, then.
-				dec = esc             * 64 + \
-				      substr(p, 1, 1) * 8  + \
-				      substr(p, 2, 1)
-				out = out sprintf("%c", dec)
-				p = substr(p, 3)
-			}
-		}
-		# Drop closing double quote, if there is one.
-		# (There isnt any if this is a directory, as it was
-		# already stripped with the trailing path components.)
-		if (substr(p, length(p), 1) == "\"")
-			out = out substr(p, 1, length(p) - 1)
-		else
-			out = out p
-
-		return out
-	}'
-}
-
-# __git_complete_index_file requires 1 argument:
-# 1: the options to pass to ls-file
-#
-# The exception is --committable, which finds the files appropriate commit.
-__git_complete_index_file ()
-{
-	local dequoted_word pfx="" cur_
-
-	__git_dequote "$cur"
-
-	case "$dequoted_word" in
-	?*/*)
-		pfx="${dequoted_word%/*}/"
-		cur_="${dequoted_word##*/}"
-		;;
-	*)
-		cur_="$dequoted_word"
-	esac
-
-	__gitcomp_file_direct "$(__git_index_files "$1" "$pfx" "$cur_")"
+	__git_ls_files_helper "$root" "$1" |
+	while read -r file; do
+		case "$file" in
+		?*/*) echo "${file%%/*}" ;;
+		*) echo "$file" ;;
+		esac
+	done | sort | uniq
 }
 
 # Lists branches from the local repository.
@@ -676,7 +439,7 @@ __git_refs ()
 			track=""
 			;;
 		*)
-			for i in HEAD FETCH_HEAD ORIG_HEAD MERGE_HEAD REBASE_HEAD; do
+			for i in HEAD FETCH_HEAD ORIG_HEAD MERGE_HEAD; do
 				case "$i" in
 				$match*)
 					if [ -e "$dir/$i" ]; then
@@ -831,7 +594,7 @@ __git_is_configured_remote ()
 
 __git_list_merge_strategies ()
 {
-	LANG=C LC_ALL=C git merge -s help 2>&1 |
+	git merge -s help 2>&1 |
 	sed -n -e '/[Aa]vailable strategies are: /,/^$/{
 		s/\.$//
 		s/.*://
@@ -855,7 +618,7 @@ __git_compute_merge_strategies ()
 
 __git_complete_revlist_file ()
 {
-	local dequoted_word pfx ls ref cur_="$cur"
+	local pfx ls ref cur_="$cur"
 	case "$cur_" in
 	*..?*:*)
 		return
@@ -863,18 +626,14 @@ __git_complete_revlist_file ()
 	?*:*)
 		ref="${cur_%%:*}"
 		cur_="${cur_#*:}"
-
-		__git_dequote "$cur_"
-
-		case "$dequoted_word" in
+		case "$cur_" in
 		?*/*)
-			pfx="${dequoted_word%/*}"
-			cur_="${dequoted_word##*/}"
+			pfx="${cur_%/*}"
+			cur_="${cur_##*/}"
 			ls="$ref:$pfx"
 			pfx="$pfx/"
 			;;
 		*)
-			cur_="$dequoted_word"
 			ls="$ref"
 			;;
 		esac
@@ -884,10 +643,21 @@ __git_complete_revlist_file ()
 		*)   pfx="$ref:$pfx" ;;
 		esac
 
-		__gitcomp_file "$(__git ls-tree "$ls" \
-				| sed 's/^.*	//
-				       s/$//')" \
-			"$pfx" "$cur_"
+		__gitcomp_nl "$(__git ls-tree "$ls" \
+				| sed '/^100... blob /{
+				           s,^.*	,,
+				           s,$, ,
+				       }
+				       /^120000 blob /{
+				           s,^.*	,,
+				           s,$, ,
+				       }
+				       /^040000 tree /{
+				           s,^.*	,,
+				           s,$,/,
+				       }
+				       s/^.*	//')" \
+			"$pfx" "$cur_" ""
 		;;
 	*...*)
 		pfx="${cur_%...*}..."
@@ -903,6 +673,26 @@ __git_complete_revlist_file ()
 		__git_complete_refs
 		;;
 	esac
+}
+
+
+# __git_complete_index_file requires 1 argument:
+# 1: the options to pass to ls-file
+#
+# The exception is --committable, which finds the files appropriate commit.
+__git_complete_index_file ()
+{
+	local pfx="" cur_="$cur"
+
+	case "$cur_" in
+	?*/*)
+		pfx="${cur_%/*}"
+		cur_="${cur_##*/}"
+		pfx="${pfx}/"
+		;;
+	esac
+
+	__gitcomp_file "$(__git_index_files "$1" ${pfx:+"$pfx"})" "$pfx" "$cur_"
 }
 
 __git_complete_file ()
@@ -936,7 +726,6 @@ __git_complete_remote_or_refspec ()
 			*) ;;
 			esac
 			;;
-		--multiple) no_complete_refspec=1; break ;;
 		-*) ;;
 		*) remote="$i"; break ;;
 		esac
@@ -1006,11 +795,126 @@ __git_complete_strategy ()
 	return 1
 }
 
+__git_commands () {
+	if test -n "${GIT_TESTING_COMMAND_COMPLETION:-}"
+	then
+		printf "%s" "${GIT_TESTING_COMMAND_COMPLETION}"
+	else
+		git help -a|egrep '^  [a-zA-Z0-9]'
+	fi
+}
+
+__git_list_all_commands ()
+{
+	local i IFS=" "$'\n'
+	for i in $(__git_commands)
+	do
+		case $i in
+		*--*)             : helper pattern;;
+		*) echo $i;;
+		esac
+	done
+}
+
 __git_all_commands=
 __git_compute_all_commands ()
 {
 	test -n "$__git_all_commands" ||
-	__git_all_commands=$(git --list-cmds=main,others,alias,nohelpers)
+	__git_all_commands=$(__git_list_all_commands)
+}
+
+__git_list_porcelain_commands ()
+{
+	local i IFS=" "$'\n'
+	__git_compute_all_commands
+	for i in $__git_all_commands
+	do
+		case $i in
+		*--*)             : helper pattern;;
+		applymbox)        : ask gittus;;
+		applypatch)       : ask gittus;;
+		archimport)       : import;;
+		cat-file)         : plumbing;;
+		check-attr)       : plumbing;;
+		check-ignore)     : plumbing;;
+		check-mailmap)    : plumbing;;
+		check-ref-format) : plumbing;;
+		checkout-index)   : plumbing;;
+		column)           : internal helper;;
+		commit-tree)      : plumbing;;
+		count-objects)    : infrequent;;
+		credential)       : credentials;;
+		credential-*)     : credentials helper;;
+		cvsexportcommit)  : export;;
+		cvsimport)        : import;;
+		cvsserver)        : daemon;;
+		daemon)           : daemon;;
+		diff-files)       : plumbing;;
+		diff-index)       : plumbing;;
+		diff-tree)        : plumbing;;
+		fast-import)      : import;;
+		fast-export)      : export;;
+		fsck-objects)     : plumbing;;
+		fetch-pack)       : plumbing;;
+		fmt-merge-msg)    : plumbing;;
+		for-each-ref)     : plumbing;;
+		hash-object)      : plumbing;;
+		http-*)           : transport;;
+		index-pack)       : plumbing;;
+		init-db)          : deprecated;;
+		local-fetch)      : plumbing;;
+		ls-files)         : plumbing;;
+		ls-remote)        : plumbing;;
+		ls-tree)          : plumbing;;
+		mailinfo)         : plumbing;;
+		mailsplit)        : plumbing;;
+		merge-*)          : plumbing;;
+		mktree)           : plumbing;;
+		mktag)            : plumbing;;
+		pack-objects)     : plumbing;;
+		pack-redundant)   : plumbing;;
+		pack-refs)        : plumbing;;
+		parse-remote)     : plumbing;;
+		patch-id)         : plumbing;;
+		prune)            : plumbing;;
+		prune-packed)     : plumbing;;
+		quiltimport)      : import;;
+		read-tree)        : plumbing;;
+		receive-pack)     : plumbing;;
+		remote-*)         : transport;;
+		rerere)           : plumbing;;
+		rev-list)         : plumbing;;
+		rev-parse)        : plumbing;;
+		runstatus)        : plumbing;;
+		sh-setup)         : internal;;
+		shell)            : daemon;;
+		show-ref)         : plumbing;;
+		send-pack)        : plumbing;;
+		show-index)       : plumbing;;
+		ssh-*)            : transport;;
+		stripspace)       : plumbing;;
+		symbolic-ref)     : plumbing;;
+		unpack-file)      : plumbing;;
+		unpack-objects)   : plumbing;;
+		update-index)     : plumbing;;
+		update-ref)       : plumbing;;
+		update-server-info) : daemon;;
+		upload-archive)   : plumbing;;
+		upload-pack)      : plumbing;;
+		write-tree)       : plumbing;;
+		var)              : infrequent;;
+		verify-pack)      : infrequent;;
+		verify-tag)       : plumbing;;
+		*) echo $i;;
+		esac
+	done
+}
+
+__git_porcelain_commands=
+__git_compute_porcelain_commands ()
+{
+	test -n "$__git_porcelain_commands" ||
+	__git_porcelain_commands=$(__git_list_porcelain_commands)
 }
 
 # Lists all set config variables starting with the given section prefix,
@@ -1026,6 +930,11 @@ __git_get_config_variables ()
 __git_pretty_aliases ()
 {
 	__git_get_config_variables "pretty"
+}
+
+__git_aliases ()
+{
+	__git_get_config_variables "alias"
 }
 
 # __git_aliased_command requires 1 argument
@@ -1163,13 +1072,12 @@ __git_count_arguments ()
 }
 
 __git_whitespacelist="nowarn warn error error-all fix"
-__git_am_inprogress_options="--skip --continue --resolved --abort --quit --show-current-patch"
 
 _git_am ()
 {
 	__git_find_repo_path
 	if [ -d "$__git_repo_path"/rebase-apply ]; then
-		__gitcomp "$__git_am_inprogress_options"
+		__gitcomp "--skip --continue --resolved --abort"
 		return
 	fi
 	case "$cur" in
@@ -1178,8 +1086,12 @@ _git_am ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin am "" \
-			"$__git_am_inprogress_options"
+		__gitcomp "
+			--3way --committer-date-is-author-date --ignore-date
+			--ignore-whitespace --ignore-space-change
+			--interactive --keep --no-utf8 --signoff --utf8
+			--whitespace= --scissors
+			"
 		return
 	esac
 }
@@ -1192,7 +1104,14 @@ _git_apply ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin apply
+		__gitcomp "
+			--stat --numstat --summary --check --index
+			--cached --index-info --reverse --reject --unidiff-zero
+			--apply --no-add --exclude=
+			--ignore-whitespace --ignore-space-change
+			--whitespace= --inaccurate-eof --verbose
+			--recount --directory=
+			"
 		return
 	esac
 }
@@ -1201,7 +1120,10 @@ _git_add ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin add
+		__gitcomp "
+			--interactive --refresh --patch --update --dry-run
+			--ignore-errors --intent-to-add --force --edit --chmod=
+			"
 		return
 	esac
 
@@ -1278,7 +1200,13 @@ _git_branch ()
 		__git_complete_refs --cur="${cur##--set-upstream-to=}"
 		;;
 	--*)
-		__gitcomp_builtin branch
+		__gitcomp "
+			--color --no-color --verbose --abbrev= --no-abbrev
+			--track --no-track --contains --no-contains --merged --no-merged
+			--set-upstream-to= --edit-description --list
+			--unset-upstream --delete --move --copy --remotes
+			--column --no-column --sort= --points-at
+			"
 		;;
 	*)
 		if [ $only_local_ref = "y" -a $has_r = "n" ]; then
@@ -1319,7 +1247,11 @@ _git_checkout ()
 		__gitcomp "diff3 merge" "" "${cur##--conflict=}"
 		;;
 	--*)
-		__gitcomp_builtin checkout
+		__gitcomp "
+			--quiet --ours --theirs --track --no-track --merge
+			--conflict= --orphan --patch --detach --ignore-skip-worktree-bits
+			--recurse-submodules --no-recurse-submodules
+			"
 		;;
 	*)
 		# check if --track, --no-track, or --no-guess was specified
@@ -1334,19 +1266,21 @@ _git_checkout ()
 	esac
 }
 
-__git_cherry_pick_inprogress_options="--continue --quit --abort"
+_git_cherry ()
+{
+	__git_complete_refs
+}
 
 _git_cherry_pick ()
 {
 	__git_find_repo_path
 	if [ -f "$__git_repo_path"/CHERRY_PICK_HEAD ]; then
-		__gitcomp "$__git_cherry_pick_inprogress_options"
+		__gitcomp "--continue --quit --abort"
 		return
 	fi
 	case "$cur" in
 	--*)
-		__gitcomp_builtin cherry-pick "" \
-			"$__git_cherry_pick_inprogress_options"
+		__gitcomp "--edit --no-commit --signoff --strategy= --mainline"
 		;;
 	*)
 		__git_complete_refs
@@ -1358,7 +1292,7 @@ _git_clean ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin clean
+		__gitcomp "--dry-run --quiet"
 		return
 		;;
 	esac
@@ -1371,7 +1305,26 @@ _git_clone ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin clone
+		__gitcomp "
+			--local
+			--no-hardlinks
+			--shared
+			--reference
+			--quiet
+			--no-checkout
+			--bare
+			--mirror
+			--origin
+			--upload-pack
+			--template=
+			--depth
+			--single-branch
+			--no-tags
+			--branch
+			--recurse-submodules
+			--no-single-branch
+			--shallow-submodules
+			"
 		return
 		;;
 	esac
@@ -1404,7 +1357,16 @@ _git_commit ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin commit
+		__gitcomp "
+			--all --author= --signoff --verify --no-verify
+			--edit --no-edit
+			--amend --include --only --interactive
+			--dry-run --reuse-message= --reedit-message=
+			--reset-author --file= --message= --template=
+			--cleanup= --untracked-files --untracked-files=
+			--verbose --quiet --fixup= --squash=
+			--patch --short --date --allow-empty
+			"
 		return
 	esac
 
@@ -1420,7 +1382,11 @@ _git_describe ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin describe
+		__gitcomp "
+			--all --tags --contains --abbrev= --candidates=
+			--exact-match --debug --long --match --always --first-parent
+			--exclude --dirty --broken
+			"
 		return
 	esac
 	__git_complete_refs
@@ -1445,7 +1411,7 @@ __git_diff_common_options="--stat --numstat --shortstat --summary
 			--dirstat --dirstat= --dirstat-by-file
 			--dirstat-by-file= --cumulative
 			--diff-algorithm=
-			--submodule --submodule= --ignore-submodules
+			--submodule --submodule=
 "
 
 _git_diff ()
@@ -1486,11 +1452,11 @@ _git_difftool ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin difftool "$__git_diff_common_options
-					--base --cached --ours --theirs
-					--pickaxe-all --pickaxe-regex
-					--relative --staged
-					"
+		__gitcomp "--cached --staged --pickaxe-all --pickaxe-regex
+			--base --ours --theirs
+			--no-renames --diff-filter= --find-copies-harder
+			--relative --ignore-submodules
+			--tool="
 		return
 		;;
 	esac
@@ -1498,6 +1464,12 @@ _git_difftool ()
 }
 
 __git_fetch_recurse_submodules="yes on-demand no"
+
+__git_fetch_options="
+	--quiet --verbose --append --upload-pack --force --keep --depth=
+	--tags --no-tags --all --prune --dry-run --recurse-submodules=
+	--unshallow --update-shallow
+"
 
 _git_fetch ()
 {
@@ -1507,16 +1479,20 @@ _git_fetch ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin fetch
+		__gitcomp "$__git_fetch_options"
 		return
 		;;
 	esac
 	__git_complete_remote_or_refspec
 }
 
-__git_format_patch_extra_options="
-	--full-index --not --all --no-prefix --src-prefix=
-	--dst-prefix= --notes
+__git_format_patch_options="
+	--stdout --attach --no-attach --thread --thread= --no-thread
+	--numbered --start-number --numbered-files --keep-subject --signoff
+	--signature --no-signature --in-reply-to= --cc= --full-index --binary
+	--not --all --cover-letter --no-prefix --src-prefix= --dst-prefix=
+	--inline --suffix= --ignore-if-in-upstream --subject-prefix=
+	--output-directory --reroll-count --to= --quiet --notes
 "
 
 _git_format_patch ()
@@ -1529,7 +1505,7 @@ _git_format_patch ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin format-patch "$__git_format_patch_extra_options"
+		__gitcomp "$__git_format_patch_options"
 		return
 		;;
 	esac
@@ -1540,7 +1516,20 @@ _git_fsck ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin fsck
+		__gitcomp "
+			--tags --root --unreachable --cache --no-reflogs --full
+			--strict --verbose --lost-found --name-objects
+			"
+		return
+		;;
+	esac
+}
+
+_git_gc ()
+{
+	case "$cur" in
+	--*)
+		__gitcomp "--prune --aggressive"
 		return
 		;;
 	esac
@@ -1596,7 +1585,21 @@ _git_grep ()
 
 	case "$cur" in
 	--*)
-		__gitcomp_builtin grep
+		__gitcomp "
+			--cached
+			--text --ignore-case --word-regexp --invert-match
+			--full-name --line-number
+			--extended-regexp --basic-regexp --fixed-strings
+			--perl-regexp
+			--threads
+			--files-with-matches --name-only
+			--files-without-match
+			--max-depth
+			--count
+			--and --or --not --all-match
+			--break --heading --show-function --function-context
+			--untracked --no-index
+			"
 		return
 		;;
 	esac
@@ -1614,16 +1617,17 @@ _git_help ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin help
+		__gitcomp "--all --guides --info --man --web"
 		return
 		;;
 	esac
-	if test -n "$GIT_TESTING_ALL_COMMAND_LIST"
-	then
-		__gitcomp "$GIT_TESTING_ALL_COMMAND_LIST $(git --list-cmds=alias,list-guide) gitk"
-	else
-		__gitcomp "$(git --list-cmds=main,nohelpers,alias,list-guide) gitk"
-	fi
+	__git_compute_all_commands
+	__gitcomp "$__git_all_commands $(__git_aliases)
+		attributes cli core-tutorial cvs-migration
+		diffcore everyday gitk glossary hooks ignore modules
+		namespaces repository-layout revisions tutorial tutorial-2
+		workflows
+		"
 }
 
 _git_init ()
@@ -1636,7 +1640,7 @@ _git_init ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin init
+		__gitcomp "--quiet --bare --template= --shared --shared="
 		return
 		;;
 	esac
@@ -1646,7 +1650,13 @@ _git_ls_files ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin ls-files
+		__gitcomp "--cached --deleted --modified --others --ignored
+			--stage --directory --no-empty-directory --unmerged
+			--killed --exclude= --exclude-from=
+			--exclude-per-directory= --exclude-standard
+			--error-unmatch --with-tree= --full-name
+			--abbrev --ignored --exclude-per-directory
+			"
 		return
 		;;
 	esac
@@ -1660,7 +1670,7 @@ _git_ls_remote ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin ls-remote
+		__gitcomp "--heads --tags --refs --get-url --symref"
 		return
 		;;
 	esac
@@ -1669,13 +1679,6 @@ _git_ls_remote ()
 
 _git_ls_tree ()
 {
-	case "$cur" in
-	--*)
-		__gitcomp_builtin ls-tree
-		return
-		;;
-	esac
-
 	__git_complete_file
 }
 
@@ -1791,13 +1794,22 @@ _git_log ()
 	__git_complete_revlist
 }
 
+# Common merge options shared by git-merge(1) and git-pull(1).
+__git_merge_options="
+	--no-commit --no-stat --log --no-log --squash --strategy
+	--commit --stat --no-squash --ff --no-ff --ff-only --edit --no-edit
+	--verify-signatures --no-verify-signatures --gpg-sign
+	--quiet --verbose --progress --no-progress
+"
+
 _git_merge ()
 {
 	__git_complete_strategy && return
 
 	case "$cur" in
 	--*)
-		__gitcomp_builtin merge
+		__gitcomp "$__git_merge_options
+			--rerere-autoupdate --no-rerere-autoupdate --abort --continue"
 		return
 	esac
 	__git_complete_refs
@@ -1811,7 +1823,7 @@ _git_mergetool ()
 		return
 		;;
 	--*)
-		__gitcomp "--tool= --prompt --no-prompt --gui --no-gui"
+		__gitcomp "--tool= --prompt --no-prompt"
 		return
 		;;
 	esac
@@ -1821,7 +1833,7 @@ _git_merge_base ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin merge-base
+		__gitcomp "--octopus --independent --is-ancestor --fork-point"
 		return
 		;;
 	esac
@@ -1832,7 +1844,7 @@ _git_mv ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin mv
+		__gitcomp "--dry-run"
 		return
 		;;
 	esac
@@ -1846,14 +1858,19 @@ _git_mv ()
 	fi
 }
 
+_git_name_rev ()
+{
+	__gitcomp "--tags --all --stdin"
+}
+
 _git_notes ()
 {
-	local subcommands='add append copy edit get-ref list merge prune remove show'
+	local subcommands='add append copy edit list prune remove show'
 	local subcommand="$(__git_find_on_cmdline "$subcommands")"
 
 	case "$subcommand,$cur" in
 	,--*)
-		__gitcomp_builtin notes
+		__gitcomp '--ref'
 		;;
 	,*)
 		case "$prev" in
@@ -1865,14 +1882,21 @@ _git_notes ()
 			;;
 		esac
 		;;
-	*,--reuse-message=*|*,--reedit-message=*)
+	add,--reuse-message=*|append,--reuse-message=*|\
+	add,--reedit-message=*|append,--reedit-message=*)
 		__git_complete_refs --cur="${cur#*=}"
 		;;
-	*,--*)
-		__gitcomp_builtin notes_$subcommand
+	add,--*|append,--*)
+		__gitcomp '--file= --message= --reedit-message=
+				--reuse-message='
 		;;
-	prune,*|get-ref,*)
-		# this command does not take a ref, do not complete it
+	copy,--*)
+		__gitcomp '--stdin'
+		;;
+	prune,--*)
+		__gitcomp '--dry-run --verbose'
+		;;
+	prune,*)
 		;;
 	*)
 		case "$prev" in
@@ -1896,8 +1920,12 @@ _git_pull ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin pull
-
+		__gitcomp "
+			--rebase --no-rebase
+			--autostash --no-autostash
+			$__git_merge_options
+			$__git_fetch_options
+		"
 		return
 		;;
 	esac
@@ -1948,36 +1976,27 @@ _git_push ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin push
+		__gitcomp "
+			--all --mirror --tags --dry-run --force --verbose
+			--quiet --prune --delete --follow-tags
+			--receive-pack= --repo= --set-upstream
+			--force-with-lease --force-with-lease= --recurse-submodules=
+		"
 		return
 		;;
 	esac
 	__git_complete_remote_or_refspec
 }
 
-_git_range_diff ()
-{
-	case "$cur" in
-	--*)
-		__gitcomp "
-			--creation-factor= --no-dual-color
-			$__git_diff_common_options
-		"
-		return
-		;;
-	esac
-	__git_complete_revlist
-}
-
 _git_rebase ()
 {
 	__git_find_repo_path
 	if [ -f "$__git_repo_path"/rebase-merge/interactive ]; then
-		__gitcomp "--continue --skip --abort --quit --edit-todo --show-current-patch"
+		__gitcomp "--continue --skip --abort --quit --edit-todo"
 		return
 	elif [ -d "$__git_repo_path"/rebase-apply ] || \
 	     [ -d "$__git_repo_path"/rebase-merge ]; then
-		__gitcomp "--continue --skip --abort --quit --show-current-patch"
+		__gitcomp "--continue --skip --abort --quit"
 		return
 	fi
 	__git_complete_strategy && return
@@ -1989,7 +2008,7 @@ _git_rebase ()
 	--*)
 		__gitcomp "
 			--onto --merge --strategy --interactive
-			--rebase-merges --preserve-merges --stat --no-stat
+			--preserve-merges --stat --no-stat
 			--committer-date-is-author-date --ignore-date
 			--ignore-whitespace --whitespace=
 			--autosquash --no-autosquash
@@ -1997,7 +2016,6 @@ _git_rebase ()
 			--autostash --no-autostash
 			--verify --no-verify
 			--keep-empty --root --force-rebase --no-ff
-			--rerere-autoupdate
 			--exec
 			"
 
@@ -2059,16 +2077,16 @@ _git_send_email ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin send-email "--annotate --bcc --cc --cc-cmd --chain-reply-to
+		__gitcomp "--annotate --bcc --cc --cc-cmd --chain-reply-to
 			--compose --confirm= --dry-run --envelope-sender
 			--from --identity
 			--in-reply-to --no-chain-reply-to --no-signed-off-by-cc
-			--no-suppress-from --no-thread --quiet --reply-to
+			--no-suppress-from --no-thread --quiet
 			--signed-off-by-cc --smtp-pass --smtp-server
 			--smtp-server-port --smtp-encryption= --smtp-user
 			--subject --suppress-cc= --suppress-from --thread --to
 			--validate --no-validate
-			$__git_format_patch_extra_options"
+			$__git_format_patch_options"
 		return
 		;;
 	esac
@@ -2101,7 +2119,11 @@ _git_status ()
 		return
 		;;
 	--*)
-		__gitcomp_builtin status
+		__gitcomp "
+			--short --branch --porcelain --long --verbose
+			--untracked-files= --ignore-submodules= --ignored
+			--column= --no-column
+			"
 		return
 		;;
 	esac
@@ -2148,24 +2170,9 @@ __git_config_get_set_variables ()
 	__git config $config_file --name-only --list
 }
 
-__git_config_vars=
-__git_compute_config_vars ()
-{
-	test -n "$__git_config_vars" ||
-	__git_config_vars="$(git help --config-for-completion | sort | uniq)"
-}
-
 _git_config ()
 {
-	local varname
-
-	if [ "${BASH_VERSINFO[0]:-0}" -ge 4 ]; then
-		varname="${prev,,}"
-	else
-		varname="$(echo "$prev" |tr A-Z a-z)"
-	fi
-
-	case "$varname" in
+	case "$prev" in
 	branch.*.remote|branch.*.pushremote)
 		__gitcomp_nl "$(__git_remotes)"
 		return
@@ -2175,7 +2182,7 @@ _git_config ()
 		return
 		;;
 	branch.*.rebase)
-		__gitcomp "false true merges preserve interactive"
+		__gitcomp "false true preserve interactive"
 		return
 		;;
 	remote.pushdefault)
@@ -2232,7 +2239,7 @@ _git_config ()
 		__gitcomp "$__git_log_date_formats"
 		return
 		;;
-	sendemail.aliasfiletype)
+	sendemail.aliasesfiletype)
 		__gitcomp "mutt mailrc pine elm gnus"
 		return
 		;;
@@ -2258,25 +2265,32 @@ _git_config ()
 	esac
 	case "$cur" in
 	--*)
-		__gitcomp_builtin config
+		__gitcomp "
+			--system --global --local --file=
+			--list --replace-all
+			--get --get-all --get-regexp
+			--add --unset --unset-all
+			--remove-section --rename-section
+			--name-only
+			"
 		return
 		;;
 	branch.*.*)
 		local pfx="${cur%.*}." cur_="${cur##*.}"
-		__gitcomp "remote pushRemote merge mergeOptions rebase" "$pfx" "$cur_"
+		__gitcomp "remote pushremote merge mergeoptions rebase" "$pfx" "$cur_"
 		return
 		;;
 	branch.*)
 		local pfx="${cur%.*}." cur_="${cur#*.}"
 		__gitcomp_direct "$(__git_heads "$pfx" "$cur_" ".")"
-		__gitcomp_nl_append $'autoSetupMerge\nautoSetupRebase\n' "$pfx" "$cur_"
+		__gitcomp_nl_append $'autosetupmerge\nautosetuprebase\n' "$pfx" "$cur_"
 		return
 		;;
 	guitool.*.*)
 		local pfx="${cur%.*}." cur_="${cur##*.}"
 		__gitcomp "
-			argPrompt cmd confirm needsFile noConsole noRescan
-			prompt revPrompt revUnmerged title
+			argprompt cmd confirm needsfile noconsole norescan
+			prompt revprompt revunmerged title
 			" "$pfx" "$cur_"
 		return
 		;;
@@ -2305,14 +2319,14 @@ _git_config ()
 		local pfx="${cur%.*}." cur_="${cur##*.}"
 		__gitcomp "
 			url proxy fetch push mirror skipDefaultUpdate
-			receivepack uploadpack tagOpt pushurl
+			receivepack uploadpack tagopt pushurl
 			" "$pfx" "$cur_"
 		return
 		;;
 	remote.*)
 		local pfx="${cur%.*}." cur_="${cur#*.}"
 		__gitcomp_nl "$(__git_remotes)" "$pfx" "$cur_" "."
-		__gitcomp_nl_append "pushDefault" "$pfx" "$cur_"
+		__gitcomp_nl_append "pushdefault" "$pfx" "$cur_"
 		return
 		;;
 	url.*.*)
@@ -2320,14 +2334,332 @@ _git_config ()
 		__gitcomp "insteadOf pushInsteadOf" "$pfx" "$cur_"
 		return
 		;;
-	*.*)
-		__git_compute_config_vars
-		__gitcomp "$__git_config_vars"
-		;;
-	*)
-		__git_compute_config_vars
-		__gitcomp "$(echo "$__git_config_vars" | sed 's/\.[^ ]*/./g')"
 	esac
+	__gitcomp "
+		add.ignoreErrors
+		advice.amWorkDir
+		advice.commitBeforeMerge
+		advice.detachedHead
+		advice.implicitIdentity
+		advice.pushAlreadyExists
+		advice.pushFetchFirst
+		advice.pushNeedsForce
+		advice.pushNonFFCurrent
+		advice.pushNonFFMatching
+		advice.pushUpdateRejected
+		advice.resolveConflict
+		advice.rmHints
+		advice.statusHints
+		advice.statusUoption
+		advice.ignoredHook
+		alias.
+		am.keepcr
+		am.threeWay
+		apply.ignorewhitespace
+		apply.whitespace
+		branch.autosetupmerge
+		branch.autosetuprebase
+		browser.
+		clean.requireForce
+		color.branch
+		color.branch.current
+		color.branch.local
+		color.branch.plain
+		color.branch.remote
+		color.decorate.HEAD
+		color.decorate.branch
+		color.decorate.remoteBranch
+		color.decorate.stash
+		color.decorate.tag
+		color.diff
+		color.diff.commit
+		color.diff.frag
+		color.diff.func
+		color.diff.meta
+		color.diff.new
+		color.diff.old
+		color.diff.plain
+		color.diff.whitespace
+		color.grep
+		color.grep.context
+		color.grep.filename
+		color.grep.function
+		color.grep.linenumber
+		color.grep.match
+		color.grep.selected
+		color.grep.separator
+		color.interactive
+		color.interactive.error
+		color.interactive.header
+		color.interactive.help
+		color.interactive.prompt
+		color.pager
+		color.showbranch
+		color.status
+		color.status.added
+		color.status.changed
+		color.status.header
+		color.status.localBranch
+		color.status.nobranch
+		color.status.remoteBranch
+		color.status.unmerged
+		color.status.untracked
+		color.status.updated
+		color.ui
+		commit.cleanup
+		commit.gpgSign
+		commit.status
+		commit.template
+		commit.verbose
+		core.abbrev
+		core.askpass
+		core.attributesfile
+		core.autocrlf
+		core.bare
+		core.bigFileThreshold
+		core.checkStat
+		core.commentChar
+		core.compression
+		core.createObject
+		core.deltaBaseCacheLimit
+		core.editor
+		core.eol
+		core.excludesfile
+		core.fileMode
+		core.fsyncobjectfiles
+		core.gitProxy
+		core.hideDotFiles
+		core.hooksPath
+		core.ignoreStat
+		core.ignorecase
+		core.logAllRefUpdates
+		core.loosecompression
+		core.notesRef
+		core.packedGitLimit
+		core.packedGitWindowSize
+		core.packedRefsTimeout
+		core.pager
+		core.precomposeUnicode
+		core.preferSymlinkRefs
+		core.preloadindex
+		core.protectHFS
+		core.protectNTFS
+		core.quotepath
+		core.repositoryFormatVersion
+		core.safecrlf
+		core.sharedRepository
+		core.sparseCheckout
+		core.splitIndex
+		core.sshCommand
+		core.symlinks
+		core.trustctime
+		core.untrackedCache
+		core.warnAmbiguousRefs
+		core.whitespace
+		core.worktree
+		credential.helper
+		credential.useHttpPath
+		credential.username
+		credentialCache.ignoreSIGHUP
+		diff.autorefreshindex
+		diff.external
+		diff.ignoreSubmodules
+		diff.mnemonicprefix
+		diff.noprefix
+		diff.renameLimit
+		diff.renames
+		diff.statGraphWidth
+		diff.submodule
+		diff.suppressBlankEmpty
+		diff.tool
+		diff.wordRegex
+		diff.algorithm
+		difftool.
+		difftool.prompt
+		fetch.recurseSubmodules
+		fetch.unpackLimit
+		format.attach
+		format.cc
+		format.coverLetter
+		format.from
+		format.headers
+		format.numbered
+		format.pretty
+		format.signature
+		format.signoff
+		format.subjectprefix
+		format.suffix
+		format.thread
+		format.to
+		gc.
+		gc.aggressiveDepth
+		gc.aggressiveWindow
+		gc.auto
+		gc.autoDetach
+		gc.autopacklimit
+		gc.logExpiry
+		gc.packrefs
+		gc.pruneexpire
+		gc.reflogexpire
+		gc.reflogexpireunreachable
+		gc.rerereresolved
+		gc.rerereunresolved
+		gc.worktreePruneExpire
+		gitcvs.allbinary
+		gitcvs.commitmsgannotation
+		gitcvs.dbTableNamePrefix
+		gitcvs.dbdriver
+		gitcvs.dbname
+		gitcvs.dbpass
+		gitcvs.dbuser
+		gitcvs.enabled
+		gitcvs.logfile
+		gitcvs.usecrlfattr
+		guitool.
+		gui.blamehistoryctx
+		gui.commitmsgwidth
+		gui.copyblamethreshold
+		gui.diffcontext
+		gui.encoding
+		gui.fastcopyblame
+		gui.matchtrackingbranch
+		gui.newbranchtemplate
+		gui.pruneduringfetch
+		gui.spellingdictionary
+		gui.trustmtime
+		help.autocorrect
+		help.browser
+		help.format
+		http.lowSpeedLimit
+		http.lowSpeedTime
+		http.maxRequests
+		http.minSessions
+		http.noEPSV
+		http.postBuffer
+		http.proxy
+		http.sslCipherList
+		http.sslVersion
+		http.sslCAInfo
+		http.sslCAPath
+		http.sslCert
+		http.sslCertPasswordProtected
+		http.sslKey
+		http.sslVerify
+		http.useragent
+		i18n.commitEncoding
+		i18n.logOutputEncoding
+		imap.authMethod
+		imap.folder
+		imap.host
+		imap.pass
+		imap.port
+		imap.preformattedHTML
+		imap.sslverify
+		imap.tunnel
+		imap.user
+		init.templatedir
+		instaweb.browser
+		instaweb.httpd
+		instaweb.local
+		instaweb.modulepath
+		instaweb.port
+		interactive.singlekey
+		log.date
+		log.decorate
+		log.showroot
+		mailmap.file
+		man.
+		man.viewer
+		merge.
+		merge.conflictstyle
+		merge.log
+		merge.renameLimit
+		merge.renormalize
+		merge.stat
+		merge.tool
+		merge.verbosity
+		mergetool.
+		mergetool.keepBackup
+		mergetool.keepTemporaries
+		mergetool.prompt
+		notes.displayRef
+		notes.rewrite.
+		notes.rewrite.amend
+		notes.rewrite.rebase
+		notes.rewriteMode
+		notes.rewriteRef
+		pack.compression
+		pack.deltaCacheLimit
+		pack.deltaCacheSize
+		pack.depth
+		pack.indexVersion
+		pack.packSizeLimit
+		pack.threads
+		pack.window
+		pack.windowMemory
+		pager.
+		pretty.
+		pull.octopus
+		pull.twohead
+		push.default
+		push.followTags
+		rebase.autosquash
+		rebase.stat
+		receive.autogc
+		receive.denyCurrentBranch
+		receive.denyDeleteCurrent
+		receive.denyDeletes
+		receive.denyNonFastForwards
+		receive.fsckObjects
+		receive.unpackLimit
+		receive.updateserverinfo
+		remote.pushdefault
+		remotes.
+		repack.usedeltabaseoffset
+		rerere.autoupdate
+		rerere.enabled
+		sendemail.
+		sendemail.aliasesfile
+		sendemail.aliasfiletype
+		sendemail.bcc
+		sendemail.cc
+		sendemail.cccmd
+		sendemail.chainreplyto
+		sendemail.confirm
+		sendemail.envelopesender
+		sendemail.from
+		sendemail.identity
+		sendemail.multiedit
+		sendemail.signedoffbycc
+		sendemail.smtpdomain
+		sendemail.smtpencryption
+		sendemail.smtppass
+		sendemail.smtpserver
+		sendemail.smtpserveroption
+		sendemail.smtpserverport
+		sendemail.smtpuser
+		sendemail.suppresscc
+		sendemail.suppressfrom
+		sendemail.thread
+		sendemail.to
+		sendemail.tocmd
+		sendemail.validate
+		sendemail.smtpbatchsize
+		sendemail.smtprelogindelay
+		showbranch.default
+		status.relativePaths
+		status.showUntrackedFiles
+		status.submodulesummary
+		submodule.
+		tar.umask
+		transfer.unpackLimit
+		url.
+		user.email
+		user.name
+		user.signingkey
+		web.browser
+		branch. remote.
+	"
 }
 
 _git_remote ()
@@ -2340,7 +2672,7 @@ _git_remote ()
 	if [ -z "$subcommand" ]; then
 		case "$cur" in
 		--*)
-			__gitcomp_builtin remote
+			__gitcomp "--verbose"
 			;;
 		*)
 			__gitcomp "$subcommands"
@@ -2351,33 +2683,33 @@ _git_remote ()
 
 	case "$subcommand,$cur" in
 	add,--*)
-		__gitcomp_builtin remote_add
+		__gitcomp "--track --master --fetch --tags --no-tags --mirror="
 		;;
 	add,*)
 		;;
 	set-head,--*)
-		__gitcomp_builtin remote_set-head
+		__gitcomp "--auto --delete"
 		;;
 	set-branches,--*)
-		__gitcomp_builtin remote_set-branches
+		__gitcomp "--add"
 		;;
 	set-head,*|set-branches,*)
 		__git_complete_remote_or_refspec
 		;;
 	update,--*)
-		__gitcomp_builtin remote_update
+		__gitcomp "--prune"
 		;;
 	update,*)
-		__gitcomp "$(__git_remotes) $(__git_get_config_variables "remotes")"
+		__gitcomp "$(__git_get_config_variables "remotes")"
 		;;
 	set-url,--*)
-		__gitcomp_builtin remote_set-url
+		__gitcomp "--push --add --delete"
 		;;
 	get-url,--*)
-		__gitcomp_builtin remote_get-url
+		__gitcomp "--push --all"
 		;;
 	prune,--*)
-		__gitcomp_builtin remote_prune
+		__gitcomp "--dry-run"
 		;;
 	*)
 		__gitcomp_nl "$(__git_remotes)"
@@ -2389,7 +2721,7 @@ _git_replace ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin replace
+		__gitcomp "--edit --graft --format= --list --delete"
 		return
 		;;
 	esac
@@ -2413,26 +2745,26 @@ _git_reset ()
 
 	case "$cur" in
 	--*)
-		__gitcomp_builtin reset
+		__gitcomp "--merge --mixed --hard --soft --patch --keep"
 		return
 		;;
 	esac
 	__git_complete_refs
 }
 
-__git_revert_inprogress_options="--continue --quit --abort"
-
 _git_revert ()
 {
 	__git_find_repo_path
 	if [ -f "$__git_repo_path"/REVERT_HEAD ]; then
-		__gitcomp "$__git_revert_inprogress_options"
+		__gitcomp "--continue --quit --abort"
 		return
 	fi
 	case "$cur" in
 	--*)
-		__gitcomp_builtin revert "" \
-			"$__git_revert_inprogress_options"
+		__gitcomp "
+			--edit --mainline --no-edit --no-commit --signoff
+			--strategy= --strategy-option=
+			"
 		return
 		;;
 	esac
@@ -2443,7 +2775,7 @@ _git_rm ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin rm
+		__gitcomp "--cached --dry-run --ignore-unmatch --quiet"
 		return
 		;;
 	esac
@@ -2501,7 +2833,12 @@ _git_show_branch ()
 {
 	case "$cur" in
 	--*)
-		__gitcomp_builtin show-branch
+		__gitcomp "
+			--all --remotes --topo-order --date-order --current --more=
+			--list --independent --merge-base --no-name
+			--color --no-color
+			--sha1-name --sparse --topics --reflog
+			"
 		return
 		;;
 	esac
@@ -2511,20 +2848,12 @@ _git_show_branch ()
 _git_stash ()
 {
 	local save_opts='--all --keep-index --no-keep-index --quiet --patch --include-untracked'
-	local subcommands='push list show apply clear drop pop create branch'
-	local subcommand="$(__git_find_on_cmdline "$subcommands save")"
-	if [ -n "$(__git_find_on_cmdline "-p")" ]; then
-		subcommand="push"
-	fi
+	local subcommands='push save list show apply clear drop pop create branch'
+	local subcommand="$(__git_find_on_cmdline "$subcommands")"
 	if [ -z "$subcommand" ]; then
 		case "$cur" in
 		--*)
 			__gitcomp "$save_opts"
-			;;
-		sa*)
-			if [ -z "$(__git_find_on_cmdline "$save_opts")" ]; then
-				__gitcomp "save"
-			fi
 			;;
 		*)
 			if [ -z "$(__git_find_on_cmdline "$save_opts")" ]; then
@@ -2545,9 +2874,6 @@ _git_stash ()
 			;;
 		drop,--*)
 			__gitcomp "--quiet"
-			;;
-		list,--*)
-			__gitcomp "--name-status --oneline --patch-with-stat"
 			;;
 		show,--*|branch,--*)
 			;;
@@ -2719,7 +3045,7 @@ _git_tag ()
 	while [ $c -lt $cword ]; do
 		i="${words[c]}"
 		case "$i" in
-		-d|--delete|-v|--verify)
+		-d|-v)
 			__gitcomp_direct "$(__git_tags "" "$cur" " ")"
 			return
 			;;
@@ -2745,7 +3071,11 @@ _git_tag ()
 
 	case "$cur" in
 	--*)
-		__gitcomp_builtin tag
+		__gitcomp "
+			--list --delete --verify --annotate --message --file
+			--sign --cleanup --local-user --force --column --sort=
+			--contains --no-contains --points-at --merged --no-merged --create-reflog
+			"
 		;;
 	esac
 }
@@ -2757,76 +3087,27 @@ _git_whatchanged ()
 
 _git_worktree ()
 {
-	local subcommands="add list lock move prune remove unlock"
+	local subcommands="add list lock prune unlock"
 	local subcommand="$(__git_find_on_cmdline "$subcommands")"
 	if [ -z "$subcommand" ]; then
 		__gitcomp "$subcommands"
 	else
 		case "$subcommand,$cur" in
 		add,--*)
-			__gitcomp_builtin worktree_add
+			__gitcomp "--detach"
 			;;
 		list,--*)
-			__gitcomp_builtin worktree_list
+			__gitcomp "--porcelain"
 			;;
 		lock,--*)
-			__gitcomp_builtin worktree_lock
+			__gitcomp "--reason"
 			;;
 		prune,--*)
-			__gitcomp_builtin worktree_prune
-			;;
-		remove,--*)
-			__gitcomp "--force"
+			__gitcomp "--dry-run --expire --verbose"
 			;;
 		*)
 			;;
 		esac
-	fi
-}
-
-__git_complete_common () {
-	local command="$1"
-
-	case "$cur" in
-	--*)
-		__gitcomp_builtin "$command"
-		;;
-	esac
-}
-
-__git_cmds_with_parseopt_helper=
-__git_support_parseopt_helper () {
-	test -n "$__git_cmds_with_parseopt_helper" ||
-		__git_cmds_with_parseopt_helper="$(__git --list-cmds=parseopt)"
-
-	case " $__git_cmds_with_parseopt_helper " in
-	*" $1 "*)
-		return 0
-		;;
-	*)
-		return 1
-		;;
-	esac
-}
-
-__git_complete_command () {
-	local command="$1"
-	local completion_func="_git_${command//-/_}"
-	if ! declare -f $completion_func >/dev/null 2>/dev/null &&
-		declare -f _completion_loader >/dev/null 2>/dev/null
-	then
-		_completion_loader "git-$command"
-	fi
-	if declare -f $completion_func >/dev/null 2>/dev/null
-	then
-		$completion_func
-		return 0
-	elif __git_support_parseopt_helper "$command"
-	then
-		__git_complete_common "$command"
-		return 0
-	else
-		return 1
 	fi
 }
 
@@ -2883,24 +3164,20 @@ __git_main ()
 			--help
 			"
 			;;
-		*)
-			if test -n "$GIT_TESTING_PORCELAIN_COMMAND_LIST"
-			then
-				__gitcomp "$GIT_TESTING_PORCELAIN_COMMAND_LIST"
-			else
-				__gitcomp "$(git --list-cmds=list-mainporcelain,others,nohelpers,alias,list-complete,config)"
-			fi
-			;;
+		*)     __git_compute_porcelain_commands
+		       __gitcomp "$__git_porcelain_commands $(__git_aliases)" ;;
 		esac
 		return
 	fi
 
-	__git_complete_command "$command" && return
+	local completion_func="_git_${command//-/_}"
+	declare -f $completion_func >/dev/null 2>/dev/null && $completion_func && return
 
 	local expansion=$(__git_aliased_command "$command")
 	if [ -n "$expansion" ]; then
 		words[1]=$expansion
-		__git_complete_command "$expansion"
+		completion_func="_git_${expansion//-/_}"
+		declare -f $completion_func >/dev/null 2>/dev/null && $completion_func
 	fi
 }
 
@@ -2928,10 +3205,7 @@ __gitk_main ()
 	__git_complete_revlist
 }
 
-if [[ -n ${ZSH_VERSION-} ]] &&
-   # Don't define these functions when sourced from 'git-completion.zsh',
-   # it has its own implementations.
-   [[ -z ${GIT_SOURCING_ZSH_COMPLETION-} ]]; then
+if [[ -n ${ZSH_VERSION-} ]]; then
 	echo "WARNING: this script is deprecated, please see git-completion.zsh" 1>&2
 
 	autoload -U +X compinit && compinit
@@ -2980,22 +3254,13 @@ if [[ -n ${ZSH_VERSION-} ]] &&
 		compadd -Q -S "${4- }" -p "${2-}" -- ${=1} && _ret=0
 	}
 
-	__gitcomp_file_direct ()
-	{
-		emulate -L zsh
-
-		local IFS=$'\n'
-		compset -P '*[=:]'
-		compadd -f -- ${=1} && _ret=0
-	}
-
 	__gitcomp_file ()
 	{
 		emulate -L zsh
 
 		local IFS=$'\n'
 		compset -P '*[=:]'
-		compadd -p "${2-}" -f -- ${=1} && _ret=0
+		compadd -Q -p "${2-}" -f -- ${=1} && _ret=0
 	}
 
 	_git ()

--- a/plugins/gitfast/update
+++ b/plugins/gitfast/update
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 url="https://git.kernel.org/pub/scm/git/git.git/plain/contrib/completion"
-version="2.21.0"
+version="2.16.0"
 
 curl -s -o _git "${url}/git-completion.zsh?h=v${version}" &&
 curl -s -o git-completion.bash "${url}/git-completion.bash?h=v${version}" &&


### PR DESCRIPTION
The new completions require a version of Git that is at least v2.17, better use the completions right before that so our users don't run into issues inadvertently.