### PR TITLE
Add l1 alias as single column variant of ls

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -34,5 +34,6 @@ compdef _dirs d
 # List directory contents
 alias lsa='ls -lah'
 alias l='ls -lah'
+alias l1='ls -1'
 alias ll='ls -lh'
 alias la='ls -lAh'


### PR DESCRIPTION
_As title says_ it would be nice to have a shorthand out-of-the-box for the `ls -1` command.

Nothing fancy but makes piping through grep/other commands easier and quicker.

cc @mcornella