### PR TITLE
Silence Errors

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -5,7 +5,7 @@ function git-fetch-all {
   dir=`git rev-parse --git-dir` &&
   [[ ! -f $dir/NO_AUTO_FETCH ]] &&
   (( `date +%s` - `date -r $dir/FETCH_LOG +%s 2>/dev/null || echo 0` > $GIT_AUTO_FETCH_INTERVAL )) &&
-  git fetch --all &>! $dir/FETCH_LOG &)
+  git fetch --all 2>/dev/null &>! $dir/FETCH_LOG &)
 }
 
 function git-auto-fetch {


### PR DESCRIPTION
Redirect stderr to avoid printing errors to the console when the ssh key is not unlocked.