### PR TITLE
Prettier output for AWS EKS

### DIFF
--- a/plugins/kube-ps1/kube-ps1.plugin.zsh
+++ b/plugins/kube-ps1/kube-ps1.plugin.zsh
@@ -121,7 +121,7 @@ _kube_ps1_get_context_ns() {
   KUBE_PS1_LAST_TIME=$EPOCHSECONDS
 
   if [[ "${KUBE_PS1_EKS}" == true ]]; then
-    KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context | awk -F':' '{print $6}' | s    ed 's/cluster\///g' 2>/dev/null)"
+    KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context | awk -F':' '{print $6}' | sed 's/cluster\///g' 2>/dev/null)"
   else
     KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
   fi

--- a/plugins/kube-ps1/kube-ps1.plugin.zsh
+++ b/plugins/kube-ps1/kube-ps1.plugin.zsh
@@ -120,7 +120,12 @@ _kube_ps1_get_context_ns() {
   # Set the command time
   KUBE_PS1_LAST_TIME=$EPOCHSECONDS
 
-  KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
+  if [[ "${KUBE_PS1_EKS}" == true ]]; then
+    KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context | awk -F':' '{print $6}' | s    ed 's/cluster\///g' 2>/dev/null)"
+  else
+    KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
+  fi
+
   if [[ -z "${KUBE_PS1_CONTEXT}" ]]; then
     KUBE_PS1_CONTEXT="N/A"
     KUBE_PS1_NAMESPACE="N/A"


### PR DESCRIPTION
Hey,
When working against Kubernetes on AWS the output looks like that: `arn:aws:eks:us-west-2:123456789012:cluster/unicorn:default`, which is obviously very long.

This PR introduces new variable `KUBE_PS1_EKS`, which whenever set to *true* will format the output to: `unicorn:default`.