### PR TITLE
Make unattended installation command a one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ flag `--unattended` to the `install.sh` script. This will have the effect of not
 the default shell, and also won't run `zsh` when the installation has finished.
 
 ```shell
-curl -Lo install.sh https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh
-sh install.sh --unattended
+curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh | bash -s -- --unattended
 ```
 
 #### Installing from a forked repository

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ flag `--unattended` to the `install.sh` script. This will have the effect of not
 the default shell, and also won't run `zsh` when the installation has finished.
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh | bash -s -- --unattended
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" "" --unattended
 ```
 
 #### Installing from a forked repository


### PR DESCRIPTION
The original suggestion for an unattended install downloads the installation script to a file, then runs that file with the --unattended argument. The install.sh file would be left behind after the suggested command was run.
This change pipes the file from curl into bash while passing the --unattended argument into bash. So, it's a nice one-liner like the default installation script, and it doesn't leave a dangling install.sh script.