### PR TITLE
git: Add missing `grev` alias to docs

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -123,6 +123,7 @@ plugins=(... git)
 | grbi                 | git rebase -i                                                                                                                 |
 | grbm                 | git rebase master                                                                                                             |
 | grbs                 | git rebase --skip                                                                                                             |
+| grev                 | git revert                                                                                                                   |
 | grh                  | git reset                                                                                                                     |
 | grhh                 | git reset --hard                                                                                                              |
 | groh                 | git reset origin/$(git_current_branch) --hard                                                                                 |


### PR DESCRIPTION
#7841 adds support for the `grev` alias for `git revert`, however this is not reflected in the documentation.