### PR TITLE
used kubectl alias everywhere

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -14,122 +14,122 @@ fi
 alias k=kubectl
 
 # Execute a kubectl command against all namespaces
-alias kca='f(){ kubectl "$@" --all-namespaces;  unset -f f; }; f'
+alias kca='f(){ k "$@" --all-namespaces;  unset -f f; }; f'
 
 # Apply a YML file
-alias kaf='kubectl apply -f'
+alias kaf='k apply -f'
 
 # Drop into an interactive terminal on a container
-alias keti='kubectl exec -ti'
+alias keti='k exec -ti'
 
 # Manage configuration quickly to switch contexts between local, dev ad staging.
-alias kcuc='kubectl config use-context'
-alias kcsc='kubectl config set-context'
-alias kcdc='kubectl config delete-context'
-alias kccc='kubectl config current-context'
+alias kcuc='k config use-context'
+alias kcsc='k config set-context'
+alias kcdc='k config delete-context'
+alias kccc='k config current-context'
 
 # List all contexts
-alias kcgc='kubectl config get-contexts'
+alias kcgc='k config get-contexts'
 
 # General aliases
-alias kdel='kubectl delete'
-alias kdelf='kubectl delete -f'
+alias kdel='k delete'
+alias kdelf='k delete -f'
 
 # Pod management.
-alias kgp='kubectl get pods'
+alias kgp='k get pods'
 alias kgpw='kgp --watch'
 alias kgpwide='kgp -o wide'
-alias kep='kubectl edit pods'
-alias kdp='kubectl describe pods'
-alias kdelp='kubectl delete pods'
+alias kep='k edit pods'
+alias kdp='k describe pods'
+alias kdelp='k delete pods'
 
 # get pod by label: kgpl "app=myapp" -n myns
 alias kgpl='kgp -l'
 
 # Service management.
-alias kgs='kubectl get svc'
+alias kgs='k get svc'
 alias kgsw='kgs --watch'
 alias kgswide='kgs -o wide'
-alias kes='kubectl edit svc'
-alias kds='kubectl describe svc'
-alias kdels='kubectl delete svc'
+alias kes='k edit svc'
+alias kds='k describe svc'
+alias kdels='k delete svc'
 
 # Ingress management
-alias kgi='kubectl get ingress'
-alias kei='kubectl edit ingress'
-alias kdi='kubectl describe ingress'
-alias kdeli='kubectl delete ingress'
+alias kgi='k get ingress'
+alias kei='k edit ingress'
+alias kdi='k describe ingress'
+alias kdeli='k delete ingress'
 
 # Namespace management
-alias kgns='kubectl get namespaces'
-alias kens='kubectl edit namespace'
-alias kdns='kubectl describe namespace'
-alias kdelns='kubectl delete namespace'
-alias kcn='kubectl config set-context $(kubectl config current-context) --namespace'
+alias kgns='k get namespaces'
+alias kens='k edit namespace'
+alias kdns='k describe namespace'
+alias kdelns='k delete namespace'
+alias kcn='k config set-context $(k config current-context) --namespace'
 
 # ConfigMap management
-alias kgcm='kubectl get configmaps'
-alias kecm='kubectl edit configmap'
-alias kdcm='kubectl describe configmap'
-alias kdelcm='kubectl delete configmap'
+alias kgcm='k get configmaps'
+alias kecm='k edit configmap'
+alias kdcm='k describe configmap'
+alias kdelcm='k delete configmap'
 
 # Secret management
-alias kgsec='kubectl get secret'
-alias kdsec='kubectl describe secret'
-alias kdelsec='kubectl delete secret'
+alias kgsec='k get secret'
+alias kdsec='k describe secret'
+alias kdelsec='k delete secret'
 
 # Deployment management.
-alias kgd='kubectl get deployment'
+alias kgd='k get deployment'
 alias kgdw='kgd --watch'
 alias kgdwide='kgd -o wide'
-alias ked='kubectl edit deployment'
-alias kdd='kubectl describe deployment'
-alias kdeld='kubectl delete deployment'
-alias ksd='kubectl scale deployment'
-alias krsd='kubectl rollout status deployment'
+alias ked='k edit deployment'
+alias kdd='k describe deployment'
+alias kdeld='k delete deployment'
+alias ksd='k scale deployment'
+alias krsd='k rollout status deployment'
 kres(){
-    kubectl set env $@ REFRESHED_AT=$(date +%Y%m%d%H%M%S)
+    k set env $@ REFRESHED_AT=$(date +%Y%m%d%H%M%S)
 }
 
 # Rollout management.
-alias kgrs='kubectl get rs'
-alias krh='kubectl rollout history'
-alias kru='kubectl rollout undo'
+alias kgrs='k get rs'
+alias krh='k rollout history'
+alias kru='k rollout undo'
 
 # Statefulset management.
-alias kgss='kubectl get statefulset'
+alias kgss='k get statefulset'
 alias kgssw='kgss --watch'
 alias kgsswide='kgss -o wide'
-alias kess='kubectl edit statefulset'
-alias kdss='kubectl describe statefulset'
-alias kdelss='kubectl delete statefulset'
-alias ksss='kubectl scale statefulset'
-alias krsss='kubectl rollout status statefulset'
+alias kess='k edit statefulset'
+alias kdss='k describe statefulset'
+alias kdelss='k delete statefulset'
+alias ksss='k scale statefulset'
+alias krsss='k rollout status statefulset'
 
 # Port forwarding
-alias kpf="kubectl port-forward"
+alias kpf="k port-forward"
 
 # Tools for accessing all information
-alias kga='kubectl get all'
-alias kgaa='kubectl get all --all-namespaces'
+alias kga='k get all'
+alias kgaa='k get all --all-namespaces'
 
 # Logs
-alias kl='kubectl logs'
-alias klf='kubectl logs -f'
+alias kl='k logs'
+alias klf='k logs -f'
 
 # File copy
-alias kcp='kubectl cp'
+alias kcp='k cp'
 
 # Node Management
-alias kgno='kubectl get nodes'
-alias keno='kubectl edit node'
-alias kdno='kubectl describe node'
-alias kdelno='kubectl delete node'
+alias kgno='k get nodes'
+alias keno='k edit node'
+alias kdno='k describe node'
+alias kdelno='k delete node'
 
 # PVC management.
-alias kgpvc='kubectl get pvc'
+alias kgpvc='k get pvc'
 alias kgpvcw='kgpvc --watch'
-alias kepvc='kubectl edit pvc'
-alias kdpvc='kubectl describe pvc'
-alias kdelpvc='kubectl delete pvc'
+alias kepvc='k edit pvc'
+alias kdpvc='k describe pvc'
+alias kdelpvc='k delete pvc'
 


### PR DESCRIPTION
I've changed the aliases to use the root-alias 'k'. In this way I can easily switch between standard kubectl and microk8s.kubectl just by redefining the 'k' alias. I see you've reused the 'kgp' alias as well, so I think this would be all right too.
See https://microk8s.io/docs/ for more info