### PR TITLE
fabric: support fabric 2+ completion targets

### DIFF
--- a/plugins/fabric/_fab
+++ b/plugins/fabric/_fab
@@ -5,7 +5,7 @@ local curcontext=$curcontext state line
 declare -A opt_args
 
 declare target_list
-target_list=(`fab --shortlist 2>/dev/null`)
+target_list=(`fab --shortlist 2>/dev/null || fab --complete 2>/dev/null`)
 
 _targets() {
     _describe -t commands "fabric targets" target_list


### PR DESCRIPTION
Hi @robbyrussell / @mcornella ! 
New major fabric version is using another option to list targets. This commit adds the fallback to the newer version listing in case of errors.