### PR TITLE
Add hg to af-magic, and tweak the virtualenv support a bit

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -8,7 +8,7 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 # primary prompt
 PROMPT='$FG[237]${(l.COLUMNS..-.)}%{$reset_color%}
 $FG[032]%~\
-$(git_prompt_info) \
+$(git_prompt_info)$(hg_prompt_info) \
 $FG[105]%(!.#.»)%{$reset_color%} '
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 RPS1='${return_code}'
@@ -21,7 +21,7 @@ eval my_orange='$FG[214]'
 # right prompt
 if type "virtualenv_prompt_info" > /dev/null
 then
-	RPROMPT='$(virtualenv_prompt_info)$my_gray%n@%m%{$reset_color%}%'
+	RPROMPT='$FG[078]$(virtualenv_prompt_info)%{$reset_color%} $my_gray%n@%m%{$reset_color%}%'
 else
 	RPROMPT='$my_gray%n@%m%{$reset_color%}%'
 fi
@@ -31,3 +31,9 @@ ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075]($FG[078]"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"
+
+# hg settings
+ZSH_THEME_HG_PROMPT_PREFIX="$FG[075]($FG[078]"
+ZSH_THEME_HG_PROMPT_CLEAN=""
+ZSH_THEME_HG_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
+ZSH_THEME_HG_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"


### PR DESCRIPTION
I've been using the `af-magic` theme for a while now and I love it, just had a couple tweaks inspired by my workflow that I thought would be widely useful.

- Added mercurial support to af-magic, so now the vcs prompt will show in either a git or hg repository
- The virtualenv prompt was white and bumped up against the user@hostname output. Fixed that so its green (which I thought highlighted it more thematically) and has a space before user@hostname

Before virtualenv fix:
![image](https://user-images.githubusercontent.com/4631191/62413540-2b940980-b5de-11e9-9d25-67a68068775a.png)

After virtualenv fix:
![image](https://user-images.githubusercontent.com/4631191/62413569-5a11e480-b5de-11e9-97d2-dd80cff02285.png)

cc @mcornella as last one to touch this theme and @andyfleming as original theme-writer