### PR TITLE
autojump: fix autojump loading

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,8 +1,3 @@
-(( $+commands[autojump] )) || {
-  echo '[oh-my-zsh] Please install autojump first (https://github.com/wting/autojump)'
-  return
-}
-
 declare -a autojump_paths
 autojump_paths=(
   $HOME/.autojump/etc/profile.d/autojump.zsh         # manual installation


### PR DESCRIPTION
`commands[autojump]` block errs out when autojump is not found, and the rest, which is intended to be used for loading `autojump`, does not get executed.