### PR TITLE
Update aws.plugin.zsh

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -11,7 +11,7 @@ function asp() {
   fi
 
   local available_profiles=($(aws_profiles))
-  if [[ -z "${available_profiles[(r)$1]}" ]]; then
+  if [[ -z $(egrep -x "$1" <<< "$available_profiles") ]]; then
     echo "${fg[red]}Profile '$1' not found in '${AWS_CONFIG_FILE:-$HOME/.aws/config}'" >&2
     echo "Available profiles: ${(j:, :)available_profiles:-no profiles found}${reset_color}" >&2
     return 1


### PR DESCRIPTION
The plugin wasn't working, because it couldn't find profiles that were actually available.

This fix finds an exact matching line, which achieves the same intended behaviour.