### PR TITLE
Wd: point to the correct directory even if installed with antibody

### DIFF
--- a/plugins/wd/wd.plugin.zsh
+++ b/plugins/wd/wd.plugin.zsh
@@ -1,12 +1,7 @@
-#!/bin/zsh
-
 # WARP DIRECTORY
 # ==============
 # oh-my-zsh plugin
 #
 # @github.com/mfaerevaag/wd
-PATH_TO_WD=${0:A:h}
 
-wd() {
-    source ${PATH_TO_WD}/wd.sh
-}
+eval "wd() { source '${0:A:h}/wd.sh' }"

--- a/plugins/wd/wd.plugin.zsh
+++ b/plugins/wd/wd.plugin.zsh
@@ -5,7 +5,8 @@
 # oh-my-zsh plugin
 #
 # @github.com/mfaerevaag/wd
+PATH_TO_WD=${0:A:h}
 
 wd() {
-    . $ZSH/plugins/wd/wd.sh
+    source ${PATH_TO_WD}/wd.sh
 }


### PR DESCRIPTION
https://github.com/robbyrussell/oh-my-zsh/issues/8117

Save you a click to the failing integration:

```
+main:97> echo 'Adding labels to PR #8116 on robbyrussell/oh-my-zsh:' \''Area: plugin'\''...'
564
Adding labels to PR #8116 on robbyrussell/oh-my-zsh: 'Area: plugin'...
565
+main:98> HTTP_STATUS=+main:98> cat
566
+main:98> HTTP_STATUS=+main:98> curl -w '%{http_code}' -o /proc/self/fd/13 -XPUT -sSL -H 'Authorization: token ***' -H 'Accept: application/vnd.github.v3+json' --data '{"labels":["Area: plugin"]}' https://api.github.com/repos/robbyrussell/oh-my-zsh/issues/8116/labels
567
{
568
  "message": "Resource not accessible by integration",
569
  "documentation_url": "https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue"
570
}
571
+main:98> HTTP_STATUS=403 
572
+main:106> case 403 (4*)
573
+main:107> echo HTTP Response: 403
574
HTTP Response: 403
575
+main:107> exit 78
576
##[error]Docker run failed with exit code 78
```