### PR TITLE
YARN | Improve suggestions for `yarn run` command

### DIFF
--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -76,7 +76,7 @@ _global_commands=(
 
 _yarn_commands_scripts() {
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
+  scripts=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
   _describe 'command or script' _commands -- _global_commands -- scripts
 }
 

--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -85,22 +85,24 @@ _yarn_scripts() {
   local -a binaries
   local -a scripts
   local -a scriptsUnescaped
+  
   binaries=($(yarn run --json 2>/dev/null | sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
   scriptsUnescaped=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n'))
   scripts=($(echo "${scriptsUnescaped[@]}" | sed -e 's/:/\\:/g'))
   scriptsObject=$(yarn run --json 2>/dev/null | sed -n '/.type.\s\?:\s\?.possibleCommands./p' | head -1)
 
-  if ! [ "$(command -v jq)" ]; then
-    commands=("${scripts[@]}")
-  else
+  if [ "$(command -v jq)" ]; then
     for script in "${scriptsUnescaped[@]}"; do
       scriptCommand=$(echo -E $scriptsObject | jq ".data.hints.\"$script\"")
       commands+=("$(echo "${script//:/\\:}"):$scriptCommand")
     done
-
-    commands=("${commands[@]}" "${binaries[@]}")
+  else
+    for script in "${scripts[@]}"; do
+      commands+=("$script:package\.json")
+    done
   fi
 
+  commands=("${commands[@]}" "${binaries[@]}")
   _describe 'scripts' commands
 }
 

--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -94,7 +94,7 @@ _yarn_scripts() {
     commands=("${scripts[@]}")
   else
     for script in "${scriptsUnescaped[@]}"; do
-      scriptCommand=$(echo $scriptsObject | jq --raw-output ".data.hints.\"$script\"")
+      scriptCommand=$(echo -E $scriptsObject | jq ".data.hints.\"$script\"")
       commands+=("$(echo "${script//:/\\:}"):$scriptCommand")
     done
 

--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -81,9 +81,27 @@ _yarn_commands_scripts() {
 }
 
 _yarn_scripts() {
+  local -a commands
+  local -a binaries
   local -a scripts
-  scripts=($(yarn run --json 2>/dev/null | sed -E '/Commands available|possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
-  _describe 'script' scripts
+  local -a scriptsUnescaped
+  binaries=($(yarn run --json 2>/dev/null | sed -E '/Commands available/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n' | sed -e 's/:/\\:/g'))
+  scriptsUnescaped=($(yarn run --json 2>/dev/null | sed -E '/possibleCommands/!d;s/.*Commands available from binary scripts: ([^"]+)".*/\1/;s/.*"items":\[([^]]+).*/\1/;s/[" ]//g' | tr , '\n'))
+  scripts=($(echo "${scriptsUnescaped[@]}" | sed -e 's/:/\\:/g'))
+  scriptsObject=$(yarn run --json 2>/dev/null | sed -n '/.type.\s\?:\s\?.possibleCommands./p' | head -1)
+
+  if ! [ "$(command -v jq)" ]; then
+    commands=("${scripts[@]}")
+  else
+    for script in "${scriptsUnescaped[@]}"; do
+      scriptCommand=$(echo $scriptsObject | jq --raw-output ".data.hints.\"$script\"")
+      commands+=("$(echo "${script//:/\\:}"):$scriptCommand")
+    done
+
+    commands=("${commands[@]}" "${binaries[@]}")
+  fi
+
+  _describe 'scripts' commands
 }
 
 _yarn_global_commands() {


### PR DESCRIPTION
Improves `yarn run` suggestions by prioritizing/separating the packages scripts from the binaries.
See for details and fixes #8115

#### New Behavior

> Separates package scripts from binaries

![oh-my-zsh-yarn-behavior](https://user-images.githubusercontent.com/10104630/63997506-94728280-cab3-11e9-9a56-8faf29adc6a1.png)

#### New Behavior without `jq`

> Binaries are separated from package scripts

![oh-my-zsh new behavior without jq](https://user-images.githubusercontent.com/10104630/66031344-0c1f3d00-e4b8-11e9-8cff-6af12e84811d.png)


#### Old Behavior

> Package scripts and binaries mixed together

![oh-my-zsh-yarn-old-behavior](https://user-images.githubusercontent.com/10104630/63997486-81f84900-cab3-11e9-8d2d-193d4655b32b.png)
