### PR TITLE
Add a note where to put the `PROMPT=...` line

### DIFF
--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -56,7 +56,9 @@ plugins=(
 PROMPT=$PROMPT'$(kube_ps1) '
 ```
 
-Note: the `PROMPT` example above was tested with the theme `robbyrussell`
+Note: The `PROMPT` example above was tested with the theme `robbyrussell`.
+
+Note 2: Insert the `PROMPT=...` line *below* `source $ZSH/oh-my-zsh.sh`, otherwise it will have no effect.
 
 ## Enabling / Disabling on the current shell
 

--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -53,12 +53,11 @@ plugins=(
   kube-ps1
 )
 
+# After the "source Oh My Zsh" line
 PROMPT=$PROMPT'$(kube_ps1) '
 ```
 
 Note: The `PROMPT` example above was tested with the theme `robbyrussell`.
-
-Note 2: Insert the `PROMPT=...` line *below* `source $ZSH/oh-my-zsh.sh`, otherwise it will have no effect.
 
 ## Enabling / Disabling on the current shell
 


### PR DESCRIPTION
Found this while investigating why the prompt wouldn't show up in my Terminal.

The change in the contributor section wasn't intended; guess this is a Github issue.