### PR TITLE
Add gcloud plugin

### DIFF
--- a/plugins/gcloud/README.md
+++ b/plugins/gcloud/README.md
@@ -1,0 +1,24 @@
+# gcloud
+
+This plugin provides completion support for the
+[Google Cloud SDK CLI](https://cloud.google.com/sdk/gcloud/).
+
+To use it, add `gcloud` to the plugins array in your zshrc file.
+
+```zsh
+plugins=(... gcloud)
+```
+
+It relies on you having installed the SDK using one of the supported options
+listed [here](https://cloud.google.com/sdk/install).
+
+## Plugin Options
+
+* Set `CLOUDSDK_HOME` in your `zshrc` file before you load oh-my-zsh if you have
+your GCloud SDK installed in a non-standard location. The plugin will use this
+as the base for your SDK if it finds it set already.
+
+* If you do not have a `python2` in your `PATH` you'll also need to set the
+`CLOUDSDK_PYTHON` environment variable at the end of your `.zshrc`. This is
+used by the SDK to call a compatible interpreter when you run one of the
+SDK commands.

--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -21,9 +21,11 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
 fi
 
 if (( ${+CLOUDSDK_HOME} )); then
-  if ! type "${CLOUDSDK_HOME}/bin/gcloud" > /dev/null; then
+  if (( ! $+commands[gcloud] )); then
     # Only source this if GCloud isn't already on the path
-    source "${CLOUDSDK_HOME}/path.zsh.inc"
+    if [[ -f "${CLOUDSDK_HOME}/path.zsh.inc" ]]; then
+      source "${CLOUDSDK_HOME}/path.zsh.inc"
+    fi
   fi
   source "${CLOUDSDK_HOME}/completion.zsh.inc"
   export CLOUDSDK_HOME

--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -1,0 +1,30 @@
+#####################################################
+# gcloud plugin for oh-my-zsh                       #
+# Author: Ian Chesal (github.com/ianchesal)         #
+#####################################################
+
+if [[ -z "${CLOUDSDK_HOME}" ]]; then
+  search_locations=(
+    "$HOME/google-cloud-sdk"
+    "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
+    "/usr/share/google-cloud-sdk"
+    "/snap/google-cloud-sdk/current"
+    "/usr/lib64/google-cloud-sdk/"
+  )
+
+  for gcloud_sdk_location in $search_locations; do
+    if [[ -d "${gcloud_sdk_location}" ]]; then
+      CLOUDSDK_HOME="${gcloud_sdk_location}"
+      break
+    fi
+  done
+fi
+
+if (( ${+CLOUDSDK_HOME} )); then
+  if ! type "${CLOUDSDK_HOME}/bin/gcloud" > /dev/null; then
+    # Only source this if GCloud isn't already on the path
+    source "${CLOUDSDK_HOME}/path.zsh.inc"
+  fi
+  source "${CLOUDSDK_HOME}/completion.zsh.inc"
+  export CLOUDSDK_HOME
+fi


### PR DESCRIPTION
This PR addresses issue #6205

This adds support for loading completion for the Google Cloud SDK
command line tools. It searches the known paths for an SDK and loads the
provided completion if it is found. Users can supply a custom location
for the SDK by setting `CLOUDSDK_HOME` in their `zshrc` before loading
oh-my-zsh plugins.

Fixes #6205 