### PR TITLE
Restore prompt spacing in robbyrussell theme

### DIFF
--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT="%(?:%{$fg_bold[green]%}➜:%{$fg_bold[red]%}➜)"
+PROMPT="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
 PROMPT+=' %{$fg[cyan]%}%c%{$reset_color%} $(git_prompt_info)'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"


### PR DESCRIPTION
This restores the original spacing of the prompt changed by https://github.com/robbyrussell/oh-my-zsh/pull/8131:

<img width="906" alt="Screen Shot 2019-09-13 at 11 28 55 AM" src="https://user-images.githubusercontent.com/37336037/64878694-b9213b00-d619-11e9-977d-d599ade193bd.png">
