### PR TITLE
New Gcloud plugin search path for ArchLinux

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -10,6 +10,7 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
     "/usr/share/google-cloud-sdk"
     "/snap/google-cloud-sdk/current"
     "/usr/lib64/google-cloud-sdk/"
+    "/opt/google-cloud-sdk"
   )
 
   for gcloud_sdk_location in $search_locations; do


### PR DESCRIPTION
Hi @ianchesal, I have added the path for ArchLinux, the SDK is located on `/opt/google-cloud-sdk`.

Cheers.

