### PR TITLE
react-native: add aliases for newer iPhones

### DIFF
--- a/plugins/react-native/README.md
+++ b/plugins/react-native/README.md
@@ -40,8 +40,8 @@ plugins=(... react-native)
 | **rniosxsm**   | `react-native run-ios --simulator "iPhone Xs Max"`                           |
 | **rniosxr**    | `react-native run-ios --simulator "iPhone Xʀ"`                               |
 | **rnios11**    | `react-native run-ios --simulator "iPhone 11"`                               |
-| **rnios11p**    | `react-native run-ios --simulator "iPhone 11 Pro"`                          |
-| **rnios11pm**    | `react-native run-ios --simulator "iPhone 11 Pro Max"`                     |
+| **rnios11p**   | `react-native run-ios --simulator "iPhone 11 Pro"`                           |
+| **rnios11pm**  | `react-native run-ios --simulator "iPhone 11 Pro Max"`                       |
 | _iPad_         |                                                                              |
 | **rnipad2**    | `react-native run-ios --simulator "iPad 2"`                                  |
 | **rnipad5**    | `react-native run-ios --simulator "iPad (5th generation)"`                   |

--- a/plugins/react-native/README.md
+++ b/plugins/react-native/README.md
@@ -39,6 +39,9 @@ plugins=(... react-native)
 | **rniosxs**    | `react-native run-ios --simulator "iPhone Xs"`                               |
 | **rniosxsm**   | `react-native run-ios --simulator "iPhone Xs Max"`                           |
 | **rniosxr**    | `react-native run-ios --simulator "iPhone Xʀ"`                               |
+| **rnios11**    | `react-native run-ios --simulator "iPhone 11"`                               |
+| **rnios11p**    | `react-native run-ios --simulator "iPhone 11 Pro"`                          |
+| **rnios11pm**    | `react-native run-ios --simulator "iPhone 11 Pro Max"`                     |
 | _iPad_         |                                                                              |
 | **rnipad2**    | `react-native run-ios --simulator "iPad 2"`                                  |
 | **rnipad5**    | `react-native run-ios --simulator "iPad (5th generation)"`                   |

--- a/plugins/react-native/react-native.plugin.zsh
+++ b/plugins/react-native/react-native.plugin.zsh
@@ -24,6 +24,10 @@ alias rniosx='react-native run-ios --simulator "iPhone X"'
 alias rniosxs='react-native run-ios --simulator "iPhone Xs"'
 alias rniosxsm='react-native run-ios --simulator "iPhone Xs Max"'
 alias rniosxr='react-native run-ios --simulator "iPhone Xʀ"'
+alias rnios11='react-native run-ios --simulator "iPhone 11"'
+alias rnios11p='react-native run-ios --simulator "iPhone 11 Pro"'
+alias rnios11pm='react-native run-ios --simulator "iPhone 11 Pro Max"'
+
 
 # iPad
 alias rnipad2='react-native run-ios --simulator "iPad 2"'


### PR DESCRIPTION
Added aliases for `iPhone 11`, `11 Pro`, `11 Pro Max`