### PR TITLE
Adding README for rvm

### DIFF
--- a/plugins/rvm/README.md
+++ b/plugins/rvm/README.md
@@ -1,0 +1,19 @@
+# Ruby Version Manager plugin
+
+This plugin adds some utility functions and completions for [Ruby Version Manager](https://rvm.io/).
+
+To use it, add `rvm` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... rvm)
+```
+
+## Functions
+| Alias          | Command              |
+|----------------|----------------------|
+| `rb18`         | `rvm use ruby-1.8.7` |
+| `rb19`         | `rvm use ruby-1.9.3` |
+| `rb20`         | `rvm use ruby-2.0.0` |
+| `rb21`         | `rvm use ruby-2.1.2` |
+| `rvm-update`   | `rvm get head`       |
+| `gems`         | `gem list`           |


### PR DESCRIPTION
This adds the README file for `rvm`, Ruby Version Manager, as part of #7175 