### PR TITLE
Added README describing mysql-macports plugin in oh-my-zsh

### DIFF
--- a/plugins/mysql-macports/README.md
+++ b/plugins/mysql-macports/README.md
@@ -1,0 +1,18 @@
+# MySQL-Macports plugin
+
+This plugin adds aliases for some of the commonly used [MySQL](https://www.mysql.com/) commands when installed using [MacPorts](https://www.macports.org/) on the MacOS. This facilitates easy use of MySQL-Server on MacOS machines using oh-my-zsh and eliminates the need to remember the complicated commands or paths for the same. For instructions to install MySQL using MacPorts, read the [MacPorts wiki](https://trac.macports.org/wiki/howto/MySQL/).
+
+To use it, add `mysql-macports` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... mysql-macports)
+```
+
+## Aliases
+
+| Alias        | Command                                                   | Description                                                         |
+| ------------ | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| mysqlstart   | `sudo /opt/local/share/mysql5/mysql/mysql.server start`   | Start the MySQL server.                                             |
+| mysqlstop    | `sudo /opt/local/share/mysql5/mysql/mysql.server stop`    | Stop the MySQL server.                                              |
+| mysqlrestart | `sudo /opt/local/share/mysql5/mysql/mysql.server restart` | Stop the MySQL server.                                              |
+| mysqlstatus  | `mysqladmin5 -u root -p ping`                             | Ping the MySQLAdmin to know the current status of the MySQL server. |

--- a/plugins/mysql-macports/README.md
+++ b/plugins/mysql-macports/README.md
@@ -1,6 +1,6 @@
 # MySQL-Macports plugin
 
-This plugin adds aliases for some of the commonly used [MySQL](https://www.mysql.com/) commands when installed using [MacPorts](https://www.macports.org/) on the MacOS. This facilitates easy use of MySQL-Server on MacOS machines using oh-my-zsh and eliminates the need to remember the complicated commands or paths for the same. For instructions to install MySQL using MacPorts, read the [MacPorts wiki](https://trac.macports.org/wiki/howto/MySQL/).
+This plugin adds aliases for some of the commonly used [MySQL](https://www.mysql.com/) commands when installed using [MacPorts](https://www.macports.org/) on macOS.
 
 To use it, add `mysql-macports` to the plugins array in your zshrc file:
 
@@ -8,11 +8,13 @@ To use it, add `mysql-macports` to the plugins array in your zshrc file:
 plugins=(... mysql-macports)
 ```
 
+For instructions on how to install MySQL using MacPorts, read the [MacPorts wiki](https://trac.macports.org/wiki/howto/MySQL/).
+
 ## Aliases
 
-| Alias        | Command                                                   | Description                                                         |
-| ------------ | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| mysqlstart   | `sudo /opt/local/share/mysql5/mysql/mysql.server start`   | Start the MySQL server.                                             |
-| mysqlstop    | `sudo /opt/local/share/mysql5/mysql/mysql.server stop`    | Stop the MySQL server.                                              |
-| mysqlrestart | `sudo /opt/local/share/mysql5/mysql/mysql.server restart` | Stop the MySQL server.                                              |
-| mysqlstatus  | `mysqladmin5 -u root -p ping`                             | Ping the MySQLAdmin to know the current status of the MySQL server. |
+| Alias        | Command                                                   | Description                                |
+| ------------ | --------------------------------------------------------- | ------------------------------------------ |
+| mysqlstart   | `sudo /opt/local/share/mysql5/mysql/mysql.server start`   | Start the MySQL server.                    |
+| mysqlstop    | `sudo /opt/local/share/mysql5/mysql/mysql.server stop`    | Stop the MySQL server.                     |
+| mysqlrestart | `sudo /opt/local/share/mysql5/mysql/mysql.server restart` | Restart the MySQL server.                  |
+| mysqlstatus  | `mysqladmin5 -u root -p ping`                             | Check whether the MySQL server is running. |


### PR DESCRIPTION
### Adds a README for the [mysql-macports](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/mysql-macports) plugin 
Describes the aliases provided by the script for easy use of mysql on MacOS when installed using MacPorts

References issue #7175