### PR TITLE
Feat: add `git clone` aliases for main providers

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -42,12 +42,15 @@ plugins=(... git)
 | gcam                 | git commit -a -m                                                                                                              |
 | gcsm                 | git commit -s -m                                                                                                              |
 | gcb                  | git checkout -b                                                                                                               |
+| gcbb user team/project | git clone https://user@bitbucket.org/team/project.git                                                                       |
 | gcf                  | git config --list                                                                                                             |
 | gcl                  | git clone --recurse-submodules                                                                                                |
 | gclean               | git clean -id                                                                                                                 |
 | gpristine            | git reset --hard && git clean -dfx                                                                                            |
 | gcm                  | git checkout master                                                                                                           |
 | gcd                  | git checkout develop                                                                                                          |
+| gcgh user/project    | git clone https://github.com/username/project.git                                                                             |
+| gcgl user/project    | git clone https://gitlab.com/username/project.git                                                                             |
 | gcmsg                | git commit -m                                                                                                                 |
 | gco                  | git checkout                                                                                                                  |
 | gcount               | git shortlog -sn                                                                                                              |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -257,5 +257,5 @@ alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"'
 
 function gcgh() { git clone "https://github.com/$1.git" }
-function ghgl() { git clone "https://gitlab.com/$1.git" }
+function gcgl() { git clone "https://gitlab.com/$1.git" }
 function gcbb() { git clone "https://$1@bitbucket.org/$2.git" }

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -255,3 +255,7 @@ alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"'
+
+function gcgh() { git clone "https://github.com/$1.git" }
+function ghgl() { git clone "https://gitlab.com/$1.git" }
+function gcbb() { git clone "https://$1@bitbucket.org/$2.git" }


### PR DESCRIPTION
# Motivation
Sometimes is need to clone the same repository many times.

> I know the repository name :bulb: 
> I know the owner :bulb: 

However we go to `github.com`, copy & paste URL repository because type it is so tedious.

# Description
This PR includes aliases as functions for easily clone repositories from GitHub, GitLab & BitBucket.
### `git clone` aliases for providers:
* GitHub: `gcgh` (Git Clone GitHub)
* GitLab: `gcgl` (Git Clone GitLab)
* BitBucket: `gcbb` (Git Clone BitBucket)

# Usage

`Input`:
```bash
gcgh robbyrussell/oh-my-zsh
```
`Output`:
```bash
Cloning into 'oh-my-zsh'...
remote: Enumerating objects: 126, done.
remote: Counting objects: 100% (126/126), done.
remote: Compressing objects: 100% (48/48), done.
remote: Total 743 (delta 109), reused 81 (delta 77), pack-reused 617
Receiving objects: 100% (743/743), 418.52 KiB | 1.53 MiB/s, done.
Resolving deltas: 100% (439/439), done.
```