### PR TITLE
Detect gems.rb in _rake_command

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -17,7 +17,7 @@ function _rake_command () {
     bin/stubs/rake $@
   elif [ -e "bin/rake" ]; then
     bin/rake $@
-  elif type bundle &> /dev/null && [ -e "Gemfile" ]; then
+  elif type bundle &> /dev/null && ([ -e "Gemfile" ] || [ -e "gems.rb" ]); then
     bundle exec rake $@
   else
     command rake $@


### PR DESCRIPTION
Apart from `Gemfile`/`Gemfile.lock`, Bundler supports `gems.rb`/`gems.locked` since [version 1.8.0.pre](https://github.com/bundler/bundler/blob/1-8-stable/CHANGELOG.md#180pre-2015-01-26)

This commit tweaks the `_rake_command` to pick up `gems.rb` as well.