### PR TITLE
Add documentation for pyenv plugin

### DIFF
--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -1,8 +1,8 @@
 # pyenv 
 
 This plugin looks for [pyenv](https://github.com/pyenv/pyenv), a Simple Python version
-management system, and loads it if it's found. It also defines a prompt function to
-display the Python version in use.
+management system, and loads it if it's found. It also loads pyenv-virtualenv, a pyenv
+plugin to manage virtualenv, if it's found.
 
 To use it, add `pyenv` to the plugins array in your zshrc file:
 

--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -1,0 +1,15 @@
+# pyenv 
+
+This plugin adds completion for [pyenv](https://github.com/pyenv/pyenv), a Simple Python version management system.
+
+To use it, add `pyenv` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... pyenv)
+```
+
+## Aliases
+
+| Alias        | Command              | Description                                                                                                              |
+| -------------| -------------------- | -------------------------------------------------------------------------------------------------------------------------|
+| pyenv_prompt_info | `system: $(python -V 2>&1 | cut -f 2 -d ' ')` | Displays the global Python version, which is defined via pyenv  |                                         |

--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -12,4 +12,4 @@ plugins=(... pyenv)
 
 | Alias        | Command              | Description                                                                                                              |
 | -------------| -------------------- | -------------------------------------------------------------------------------------------------------------------------|
-| pyenv_prompt_info | `system: $(python -V 2>&1 | cut -f 2 -d ' ')` | Displays the global Python version, which is defined via pyenv  |                                         |
+| pyenv_prompt_info | `system: $(python -V 2>&1 \| cut -f 2 -d ' ')` | Displays the global Python version, which is defined via pyenv  |                                         |

--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -1,6 +1,8 @@
 # pyenv 
 
-This plugin adds completion for [pyenv](https://github.com/pyenv/pyenv), a Simple Python version management system.
+This plugin looks for [pyenv](https://github.com/pyenv/pyenv), a Simple Python version
+management system, and loads it if it's found. It also defines a prompt function to
+display the Python version in use.
 
 To use it, add `pyenv` to the plugins array in your zshrc file:
 
@@ -8,8 +10,7 @@ To use it, add `pyenv` to the plugins array in your zshrc file:
 plugins=(... pyenv)
 ```
 
-## Aliases
+## Functions
 
-| Alias        | Command              | Description                                                                                                              |
-| -------------| -------------------- | -------------------------------------------------------------------------------------------------------------------------|
-| pyenv_prompt_info | `system: $(python -V 2>&1 \| cut -f 2 -d ' ')` | Displays the global Python version, which is defined via pyenv  |                                         |
+- `pyenv_prompt_info`: displays the Python version in use by pyenv; or the global Python
+  version, if pyenv wasn't found.


### PR DESCRIPTION
Partially addresses #7175 

Adds a README for the `pyenv` plugin. Plugin already has documentation on the wiki: https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins#pyenv