### PR TITLE
Add autocompletion for openliberty

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -267,6 +267,8 @@ function listMavenCompletions {
 		stage:copy
 		# toolchain
 		toolchain:toolchain
+                #liberty
+                liberty:clean-server liberty:compile-jsp liberty:configure-arquillian liberty:create-server liberty:debug liberty:debug-server liberty:deploy liberty:dev liberty:display-url liberty:dump-server liberty:install-apps liberty:install-feature liberty:install-server liberty:java-dump-server liberty:package-server liberty:run liberty:run-server liberty:server-status liberty:start liberty:start-server liberty:status liberty:stop liberty:stop-server liberty:test-start-server liberty:test-stop-server liberty:undeploy liberty:uninstall-feature
 
 		# options
 		"-Dmaven.test.skip=true" -DskipTests -DskipITs -Dmaven.surefire.debug -DenableCiProfile "-Dpmd.skip=true" "-Dcheckstyle.skip=true" "-Dtycho.mode=maven" "-Dmaven.test.failure.ignore=true" "-DgroupId=" "-DartifactId=" "-Dversion=" "-Dpackaging=jar" "-Dfile="


### PR DESCRIPTION
Add maven autocompletion for [openliberty](http://openliberty.io) web server. It has a maven [plugin](https://mvnrepository.com/artifact/io.openliberty.tools/liberty-maven-plugin). It would be good to have autocompletion for it. 

plugin goals are extracted by
``` 
mvn help:describe -Dplugin=liberty | grep "liberty:" | paste -sd " " - 
``` 
which provides the following result:
```                                                                                                                                                                                                                                          
liberty:clean-server liberty:compile-jsp liberty:configure-arquillian liberty:create-server liberty:debug liberty:debug-server liberty:deploy liberty:dev liberty:display-url liberty:dump-server liberty:install-apps liberty:install-feature liberty:install-server liberty:java-dump-server liberty:package-server liberty:run liberty:run-server liberty:server-status liberty:start liberty:start-server liberty:status liberty:stop liberty:stop-server liberty:test-start-server liberty:test-stop-server liberty:undeploy liberty:uninstall-feature
```