### PR TITLE
Fix 'sudo: [cmd]: command not found' when using `_` alias

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -22,7 +22,7 @@ env_default 'PAGER' 'less'
 env_default 'LESS' '-R'
 
 ## super user alias
-alias _='sudo'
+alias _='sudo '
 
 ## more intelligent acking for ubuntu users
 if which ack-grep &> /dev/null; then


### PR DESCRIPTION
fix 'sudo: [cmd]: command not found' error when executing commands like `_ ff somefile -print`
(see http://superuser.com/questions/605417/ddg#605460)