### PR TITLE
Make bundler plugin play nice with functions that call wrapped commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -95,7 +95,7 @@ _binstubbed() {
 _run-with-bundler() {
   if _bundler-installed && _within-bundled-project; then
     if _binstubbed $1; then
-      ./bin/$@
+      ./bin/${^^@}
     else
       bundle exec $@
     fi


### PR DESCRIPTION
When another function calls one of the bundler plugin's wrapper functions, the
command to run gets passed as an array instead of a space-separated string. That
works fine when the arguments are expanded alone, like `bundle exec $@`, but
something like `./bin/$@` will expand to something like `./bin/rake
./bin/--silent ./bin/--tasks`, which of course will explode. This was causing a
nasty interaction with the rake-fast plugin, and I'd be shocked if it wasn't
causing other problems.

The fix is to explicitly turn off the `RC_EXPAND_PARAM` option for that
expansion. See
http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion
for more details.