### PR TITLE
fix geteip fails when using proxy

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -131,7 +131,7 @@ d0() {
 
 # gather external ip address
 geteip() {
-    curl -s -S https://icanhazip.com
+    curl -s -S http://icanhazip.com
 }
 
 # determine local IP address(es)


### PR DESCRIPTION
Using `curl` to access https sites when on proxy returns an error:
```
$ geteip
curl: (35) error:1408F10B:SSL routines:ssl3_get_record:wrong version number
```
For more info see [this stackoverflow qestion.](https://stackoverflow.com/questions/50840101/curl-35-error1408f10bssl-routinesssl3-get-recordwrong-version-number/50842202)
Changing from https://icanhazip.com to http://icanhazip.com resolves it for me.