### PR TITLE
Support BSD mktemp in emacsclient.sh

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -20,7 +20,8 @@ _emacsfun()
 # tempfile. (first argument will be `--no-wait` passed in by the plugin.zsh)
 if [ "$#" -ge "2" -a "$2" = "-" ]
 then
-    tempfile="$(mktemp emacs-stdin-$USER.XXXXXXX --tmpdir)"
+    tempfile="$(mktemp --tmpdir emacs-stdin-$USER.XXXXXXX 2>/dev/null \
+                || mktemp -t emacs-stdin-$USER)" # support BSD mktemp
     cat - > "$tempfile"
     _emacsfun --no-wait $tempfile
 else


### PR DESCRIPTION
Piping stdin to emacs alias on MacOS was breaking (--tmpdir is not
supported in BSD flavored mktemp).

Tested in MacOS 10.14 and debian:buster to confirm it still works in
linux.

```
ls -al | e -
ls $TMPDIR/emacs-stdin*
```

@mcornella, I've read these guidelines which ask contributors to copy anyone relevant & found you as the most recent contributor to this script:
https://github.com/robbyrussell/oh-my-zsh/blob/master/CONTRIBUTING.md#you-have-a-solution