### PR TITLE
Fix bad tmux config syntax and logical expression error in 86b39cf

### DIFF
--- a/plugins/tmux/tmux.extra.conf
+++ b/plugins/tmux/tmux.extra.conf
@@ -1,2 +1,2 @@
 set -g default-terminal $ZSH_TMUX_TERM
-source $ZSH_TMUX_CONFIG
+source-file $ZSH_TMUX_CONFIG

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -67,9 +67,8 @@ function _zsh_tmux_plugin_run() {
 
   # If failed, just run tmux, fixing the TERM variable if requested.
   if [[ $? -ne 0 ]]; then
-    [[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG") || \
-    [[ -e "$ZSH_TMUX_CONFIG" ]] && tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")
-    $tmux_cmd new-session  
+    [[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
+    $tmux_cmd new-session
   fi
 
   if [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]]; then

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -67,7 +67,11 @@ function _zsh_tmux_plugin_run() {
 
   # If failed, just run tmux, fixing the TERM variable if requested.
   if [[ $? -ne 0 ]]; then
-    [[ "$ZSH_TMUX_FIXTERM" == "true" ]] && tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
+    if [[ "$ZSH_TMUX_FIXTERM" == "true" ]]; then
+      tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
+    elif [[ -e "$ZSH_TMUX_CONFIG" ]]; then
+      tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")
+    fi
     $tmux_cmd new-session
   fi
 


### PR DESCRIPTION
1. The tmux command that allows you to include config file should be `source-file` not `source`.
2. since `$_ZSH_TMUX_FIXED_CONFIG` already includes the custom config with `source-file`, it is unnecessary to include the config manually with `tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")`.