### PR TITLE
fix(spotify): fix exit on unknown command

### DIFF
--- a/plugins/osx/spotify
+++ b/plugins/osx/spotify
@@ -470,7 +470,7 @@ while [ $# -gt 0 ]; do
             break ;;
         * )
             showHelp;
-            exit 1;
+            break;
 
     esac
 done


### PR DESCRIPTION
When you run `spotify` with an unknown command, then the default case runs in the function, which exits with return code 1 (`exit 1`).
I think this is a not very nice behaviour as it closes my shell session when I mistype a command.
The trivial fix is to just `break`.