### PR TITLE
Fix / Export ZSH_TMUX_CONFIG again to provide to tmux

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -46,6 +46,7 @@ fi
 
 # Set the correct local config file to use.
 if [[ "$ZSH_TMUX_ITERM2" == "false" && -e "$ZSH_TMUX_CONFIG" ]]; then
+  export ZSH_TMUX_CONFIG="$ZSH_TMUX_CONFIG"
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.extra.conf"
 else
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.only.conf"

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -46,7 +46,7 @@ fi
 
 # Set the correct local config file to use.
 if [[ "$ZSH_TMUX_ITERM2" == "false" && -e "$ZSH_TMUX_CONFIG" ]]; then
-  export ZSH_TMUX_CONFIG="$ZSH_TMUX_CONFIG"
+  export ZSH_TMUX_CONFIG
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.extra.conf"
 else
   export _ZSH_TMUX_FIXED_CONFIG="${0:h:a}/tmux.only.conf"


### PR DESCRIPTION
#8374 introduced a bug in tmux autostart.
After those changes, `~/.tmux.conf` was not being loaded anymore when setting `ZSH_TMUX_FIXTERM="true"`.

This is due to tmux removing variables that are not present (exported) in the source environment.

> Tmux' man page states that update-environment will remove variables "that do not exist in the source environment [...] as if -r was given to the set-environment command".
>
> -- https://unix.stackexchange.com/a/76256/27284

This can be checked in the terminal with:

```bash
$ echo $ZSH_TMUX_CONFIG                          
/home/diovani/.tmux.conf
$ grep ZSH_TMUX_CONFIG
# nothing                     
$ tmux show-environment -g | grep ZSH_TMUX_CONFIG
# nothing
``` 

This pull request fixed that by exporting again `ZSH_TMUX_CONFIG` before sourcing `tmux.extra.conf` (which will source `$ZSH_TMUX_CONFIG`).