### PR TITLE
Stops git-auto-fetch plugin from asking for ssh-key passphrase

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -1,16 +1,17 @@
 GIT_AUTO_FETCH_INTERVAL=${GIT_AUTO_FETCH_INTERVAL:=60}
 
 function git-fetch-all {
-  (`git rev-parse --is-inside-work-tree 2>/dev/null` &&
-  dir=`git rev-parse --git-dir` &&
+  (`command git rev-parse --is-inside-work-tree 2>/dev/null` &&
+  dir=`command git rev-parse --git-dir` &&
   [[ ! -f $dir/NO_AUTO_FETCH ]] &&
   (( `date +%s` - `date -r $dir/FETCH_LOG +%s 2>/dev/null || echo 0` > $GIT_AUTO_FETCH_INTERVAL )) &&
-  git fetch --all 2>/dev/null &>! $dir/FETCH_LOG &)
+  GIT_SSH_COMMAND="command ssh -o BatchMode=yes" \
+    command git fetch --all 2>/dev/null &>! $dir/FETCH_LOG &)
 }
 
 function git-auto-fetch {
-  `git rev-parse --is-inside-work-tree 2>/dev/null` || return
-  guard="`git rev-parse --git-dir`/NO_AUTO_FETCH"
+  `command git rev-parse --is-inside-work-tree 2>/dev/null` || return
+  guard="`command git rev-parse --git-dir`/NO_AUTO_FETCH"
 
   (rm $guard 2>/dev/null &&
     echo "${fg_bold[green]}enabled${reset_color}") ||


### PR DESCRIPTION
This takes care of not prompting for the ssh-key passphrase that can then not be entered.
This fixes #8381

PS: I also prefixed the git commands with `command` to not run into any issues with aliases or functions.

PPS: @slavaGanzin, it looks like you wrote most of this code, maybe you can take a look at it :smile: 