### PR TITLE
Use safer append to hook function arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ custom/
 # temp files directories
 cache/
 log/
+*.swp

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -75,8 +75,9 @@ function omz_termsupport_preexec {
   title '$CMD' '%100>...>$LINE%<<'
 }
 
-precmd_functions+=(omz_termsupport_precmd)
-preexec_functions+=(omz_termsupport_preexec)
+autoload -U add-zsh-hook
+add-zsh-hook precmd omz_termsupport_precmd
+add-zsh-hook preexec omz_termsupport_preexec
 
 
 # Keep Apple Terminal.app's current working directory updated
@@ -99,7 +100,7 @@ if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
   }
 
   # Use a precmd hook instead of a chpwd hook to avoid contaminating output
-  precmd_functions+=(update_terminalapp_cwd)
+  add-zsh-hook precmd update_terminalapp_cwd
   # Run once to get initial cwd set
   update_terminalapp_cwd
 fi

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -43,6 +43,5 @@ preexec_alias-finder() {
   fi
 }
 
-if [[ ${preexec_functions[(ie)preexec_alias-finder]} -gt ${#preexec_functions} ]]; then
-  preexec_functions+=(preexec_alias-finder)
-fi
+autoload -U add-zsh-hook
+add-zsh-hook preexec preexec_alias-finder

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -4,7 +4,7 @@ alias-finder() {
     case $i in
       -e|--exact) exact=true;;
       -l|--longer) longer=true;;
-      *) 
+      *)
         if [[ -z $cmd ]]; then
           cmd=$i
         else
@@ -43,4 +43,6 @@ preexec_alias-finder() {
   fi
 }
 
-preexec_functions+=(preexec_alias-finder)
+if [[ ${preexec_functions[(ie)preexec_alias-finder]} -gt ${#preexec_functions} ]]; then
+  preexec_functions+=(preexec_alias-finder)
+fi

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -53,7 +53,8 @@ function push_future() {
 }
 
 # Called by zsh when directory changes
-chpwd_functions+=(chpwd_dirhistory)
+autoload -U add-zsh-hook
+add-zsh-hook chpwd chpwd_dirhistory
 function chpwd_dirhistory() {
   push_past $PWD
   # If DIRHISTORY_CD is not set...

--- a/plugins/dirpersist/dirpersist.plugin.zsh
+++ b/plugins/dirpersist/dirpersist.plugin.zsh
@@ -11,7 +11,8 @@ if [[ -f ${dirstack_file} ]] && [[ ${#dirstack[*]} -eq 0 ]] ; then
   [[ -d $dirstack[1] ]] && cd $dirstack[1] && cd $OLDPWD
 fi
 
-chpwd_functions+=(chpwd_dirpersist)
+autoload -U add-zsh-hook
+add-zsh-hook chpwd chpwd_dirpersist
 chpwd_dirpersist() {
   if (( $DIRSTACKSIZE <= 0 )) || [[ -z $dirstack_file ]]; then return; fi
   local -ax my_stack

--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -20,9 +20,10 @@ function precmd_update_git_vars() {
     fi
 }
 
-chpwd_functions+=(chpwd_update_git_vars)
-precmd_functions+=(precmd_update_git_vars)
-preexec_functions+=(preexec_update_git_vars)
+autoload -U add-zsh-hook
+add-zsh-hook chpwd chpwd_update_git_vars
+add-zsh-hook precmd precmd_update_git_vars
+add-zsh-hook preexec preexec_update_git_vars
 
 
 ## Function definitions

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -2,7 +2,8 @@
 typeset -g ZSH_LAST_WORKING_DIRECTORY
 
 # Updates the last directory once directory is changed
-chpwd_functions+=(chpwd_last_working_dir)
+autoload -U add-zsh-hook
+add-zsh-hook chpwd chpwd_last_working_dir
 chpwd_last_working_dir() {
 	if [ "$ZSH_SUBSHELL" = 0 ]; then
 		local cache_file="$ZSH_CACHE_DIR/last-working-dir"

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -23,7 +23,8 @@ _togglePipenvShell() {
     fi
   fi
 }
-chpwd_functions+=(_togglePipenvShell)
+autoload -U add-zsh-hook
+add-zsh-hook chpwd _togglePipenvShell
 
 # Aliases
 alias pch="pipenv check"

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -25,5 +25,6 @@ __timer_display_timer_precmd() {
   fi
 }
 
-preexec_functions+=(__timer_save_time_preexec)
-precmd_functions+=(__timer_display_timer_precmd)
+autoload -U add-zsh-hook
+add-zsh-hook preexec __timer_save_time_preexec
+add-zsh-hook precmd __timer_display_timer_precmd

--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -96,7 +96,6 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
 
   # Append workon_cwd to the chpwd_functions array, so it will be called on cd
   # http://zsh.sourceforge.net/Doc/Release/Functions.html
-  if ! (( $chpwd_functions[(I)workon_cwd] )); then
-    chpwd_functions+=(workon_cwd)
-  fi
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd workon_cwd
 fi

--- a/themes/pygmalion-virtualenv.zsh-theme
+++ b/themes/pygmalion-virtualenv.zsh-theme
@@ -28,7 +28,8 @@ prompt_setup_pygmalion(){
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
-  precmd_functions+=(prompt_pygmalion_precmd)
+  autoload -U add-zsh-hook
+  add-zsh-hook precmd prompt_pygmalion_precmd
 }
 
 prompt_pygmalion_precmd(){
@@ -46,5 +47,3 @@ prompt_pygmalion_precmd(){
 }
 
 prompt_setup_pygmalion
-
-

--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -12,7 +12,8 @@ prompt_setup_pygmalion(){
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
-  precmd_functions+=(prompt_pygmalion_precmd)
+  autoload -U add-zsh-hook
+  add-zsh-hook precmd prompt_pygmalion_precmd
 }
 
 prompt_pygmalion_precmd(){
@@ -30,5 +31,3 @@ prompt_pygmalion_precmd(){
 }
 
 prompt_setup_pygmalion
-
-


### PR DESCRIPTION
When zsh config and thus omz is reloaded `preexec_functions` can start to have duplicates. I noticed this first with alias-finder. There are three other places in the codebase where this is done. If this solution is acceptable I would like to encapsulate it in a function that could be used in any plugin and then update the existing places to use this function. 