### PR TITLE
Fix rendering issue in README of the rails plugin

### DIFF
--- a/plugins/rails/README.md
+++ b/plugins/rails/README.md
@@ -44,7 +44,7 @@ plugins=(... rails)
 | `rlc`   | `rake log:clear`                | Clear Rails logs                                       |
 | `rn`    | `rake notes`                    | Search for notes (`FIXME`, `TODO`) in code comments    |
 | `rr`    | `rake routes`                   | List all defined routes                                |
-| `rrg`   | `rake routes | grep`            | List and filter the defined routes                     |
+| `rrg`   | `rake routes \| grep`            | List and filter the defined routes                     |
 | `rt`    | `rake test`                     | Run Rails tests                                        |
 | `rmd`   | `rake middleware`               | Interact with Rails middlewares                        |
 | `rsts`  | `rake stats`                    | Print code statistics                                  |

--- a/plugins/rails/README.md
+++ b/plugins/rails/README.md
@@ -18,7 +18,7 @@ plugins=(... rails)
 | `rcs` | `rails console --sandbox`  | Test code in a sandbox, without changing any data  |
 | `rd`  | `rails destroy`            | Undo a generate operation                          |
 | `rdb` | `rails dbconsole`          | Interact with your db from the console             |
-| `rgen`  | `rails generate`           | Generate boilerplate code                          |
+| `rgen`| `rails generate`           | Generate boilerplate code                          |
 | `rgm` | `rails generate migration` | Generate a db migration                            |
 | `rp`  | `rails plugin`             | Run a Rails plugin command                         |
 | `ru`  | `rails runner`             | Run Ruby code in the context of Rails              |
@@ -44,7 +44,7 @@ plugins=(... rails)
 | `rlc`   | `rake log:clear`                | Clear Rails logs                                       |
 | `rn`    | `rake notes`                    | Search for notes (`FIXME`, `TODO`) in code comments    |
 | `rr`    | `rake routes`                   | List all defined routes                                |
-| `rrg`   | `rake routes \| grep`            | List and filter the defined routes                     |
+| `rrg`   | `rake routes \| grep`           | List and filter the defined routes                     |
 | `rt`    | `rake test`                     | Run Rails tests                                        |
 | `rmd`   | `rake middleware`               | Interact with Rails middlewares                        |
 | `rsts`  | `rake stats`                    | Print code statistics                                  |


### PR DESCRIPTION
The pipe character in the md file was being interpreted by Github, breaking the rendering of the readme. I changed it to be escaped instead.

@mcornella 