### PR TITLE
Only add jenv to PATH if it is not already on it

### DIFF
--- a/plugins/jenv/jenv.plugin.zsh
+++ b/plugins/jenv/jenv.plugin.zsh
@@ -15,7 +15,7 @@ if [[ $FOUND_JENV -eq 0 ]]; then
 fi
 
 if [[ $FOUND_JENV -eq 1 ]]; then
-    export PATH="${jenvdir}/bin:$PATH"
+    (( $+commands[jenv] )) || export PATH="${jenvdir}/bin:$PATH"
     eval "$(jenv init - zsh)"
 
     function jenv_prompt_info() { jenv version-name 2>/dev/null }


### PR DESCRIPTION
This prevents the jenv plugin from messing up the PATH and putting `user/local/bin` back at the front of the PATH, undoing any careful setup done before enabling this plugin.

Fixes #8413